### PR TITLE
fix(windows): hide console window flash when starting recording

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -104,10 +104,14 @@ fn play_recording_start_sound() {
 /// Play a system sound to confirm recording start (Windows)
 #[cfg(target_os = "windows")]
 fn play_recording_start_sound() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
     std::thread::spawn(|| {
-        // Use PowerShell to play a system sound on Windows
+        // Use PowerShell to play a system sound on Windows (hidden console)
         let _ = std::process::Command::new("powershell")
             .args(["-c", "[console]::beep(800, 100)"])
+            .creation_flags(CREATE_NO_WINDOW)
             .spawn();
     });
 }


### PR DESCRIPTION
## Summary
- Add `CREATE_NO_WINDOW` flag to PowerShell process that plays the recording start beep on Windows
- Prevents a brief black console window from flashing each time recording begins

## Problem
On Windows, when starting a recording, a black console window would briefly flash on screen. This was caused by the PowerShell process spawning without the `CREATE_NO_WINDOW` flag.

## Solution
Added `std::os::windows::process::CommandExt` and applied `.creation_flags(CREATE_NO_WINDOW)` to hide the console window.

## Test plan
- [x] Tested on Windows - console window no longer flashes when starting recording
- [x] Recording start sound still plays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)