### PR TITLE
fix: address support-reported recording and navigation issues

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -2,9 +2,9 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::audio::recorder::AudioRecorder;
-use crate::commands::license::check_license_status_internal;
+use crate::commands::license::{check_license_status_internal, CachedLicense};
 use crate::commands::settings::{get_settings, resolve_pill_indicator_mode, Settings};
-use crate::license::{LicenseState, LicenseStatus};
+use crate::license::LicenseState;
 use crate::media::MediaPauseController;
 use crate::parakeet::messages::ParakeetResponse;
 use crate::parakeet::ParakeetManager;
@@ -552,8 +552,18 @@ fn select_best_fallback_model(
     })
 }
 
-fn license_allows_recording(status: &LicenseStatus) -> bool {
-    matches!(status.status, LicenseState::Licensed | LicenseState::Trial)
+fn cached_license_allows_recording(cached: &CachedLicense) -> bool {
+    match cached.status.status {
+        LicenseState::Licensed => true,
+        LicenseState::Trial => cached
+            .status
+            .trial_days_left
+            .and_then(|days| u64::try_from(days).ok())
+            .filter(|days| *days > 0)
+            .map(|days| cached.age() < std::time::Duration::from_secs(days * 24 * 60 * 60))
+            .unwrap_or(false),
+        LicenseState::Expired | LicenseState::None => false,
+    }
 }
 
 /// Pre-recording validation using the readiness state
@@ -601,7 +611,7 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
                     cached.age()
                 );
                 let fallback =
-                    license_allows_recording(&cached.status).then(|| cached.status.clone());
+                    cached_license_allows_recording(cached).then(|| cached.status.clone());
                 (None, fallback)
             }
         } else {
@@ -1110,7 +1120,7 @@ pub async fn start_recording(
             }
 
             update_recording_state(&app, RecordingState::Idle, None);
-            return Err("PTT key released during audio initialization".to_string());
+            return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());
         }
     }
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -553,7 +553,7 @@ fn select_best_fallback_model(
 }
 
 fn cached_license_allows_recording(cached: &CachedLicense) -> bool {
-    match cached.status.status {
+    match &cached.status.status {
         LicenseState::Licensed => true,
         LicenseState::Trial => cached
             .status

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1103,12 +1103,27 @@ pub async fn start_recording(
                 .load(std::sync::atomic::Ordering::SeqCst)
         {
             log::info!("PTT: Key was released during audio init; stopping recorder immediately");
-            // Stop the audio recorder synchronously before transitioning state
+            // Stop the audio recorder synchronously before transitioning state.
+            // If this fails, do not pretend the app is idle: propagate the
+            // failure so the hotkey handler moves to Error and the recorder
+            // remains visible for recovery instead of orphaning capture.
             let recorder_state_handle = app.state::<RecorderState>();
-            if let Ok(mut recorder) = recorder_state_handle.inner().0.lock() {
-                if recorder.is_recording() {
-                    let _ = recorder.stop_recording();
-                }
+            let stop_result = recorder_state_handle
+                .inner()
+                .0
+                .lock()
+                .map_err(|e| format!("Failed to acquire recorder lock: {}", e))
+                .and_then(|mut recorder| {
+                    if recorder.is_recording() {
+                        recorder.stop_recording()
+                    } else {
+                        Ok(String::new())
+                    }
+                });
+
+            if let Err(e) = stop_result {
+                MEDIA_CONTROLLER.resume_if_we_paused();
+                return Err(e);
             }
             MEDIA_CONTROLLER.resume_if_we_paused();
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -604,9 +604,18 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
     let status = if let Some(cached_status) = license_status {
         cached_status
     } else {
-        // Cache miss or stale - perform fresh license check
-        match check_license_status_internal(app).await {
-            Ok(fresh_status) => {
+        // Cache miss or stale - perform license check with a bounded timeout.
+        // This prevents the recording start path from blocking indefinitely on
+        // slow/offline network license validation, which causes PTT key-up to be
+        // missed and recording to start after the user released the key.
+        let check_result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            check_license_status_internal(app),
+        )
+        .await;
+
+        match check_result {
+            Ok(Ok(fresh_status)) => {
                 // Update cache
                 let app_state = app.state::<AppState>();
                 let mut cache = app_state.license_cache.write().await;
@@ -616,9 +625,17 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
                 log::debug!("License status cached for 6 hours");
                 fresh_status
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 log::error!("Failed to check license status: {}", e);
                 // Allow recording if license check fails (graceful degradation)
+                return Ok(());
+            }
+            Err(_) => {
+                // Timeout - license check took too long.
+                // Allow recording to proceed; enforcement happens on next successful check.
+                log::warn!(
+                    "License check timed out after 3s; allowing recording to proceed (enforcement deferred to next successful validation)"
+                );
                 return Ok(());
             }
         }
@@ -701,6 +718,18 @@ pub async fn start_recording(
                 ],
             );
             return Err(e);
+        }
+    }
+
+    // PTT guard: if recording mode is PushToTalk and the key was already released
+    // while validation was running, abort now. This prevents recording from starting
+    // after the user has already released the PTT key (e.g., during slow license checks).
+    {
+        let app_state = app.state::<AppState>();
+        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(RecordingMode::Toggle);
+        if mode == RecordingMode::PushToTalk && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst) {
+            log::info!("PTT: Key was released during validation; aborting recording start");
+            return Err("PTT key released before recording could start".to_string());
         }
     }
 
@@ -1022,10 +1051,41 @@ pub async fn start_recording(
     // Clear cancellation flag for new recording
     app_state.clear_cancellation();
 
+    // Second PTT guard: check again right before committing to Recording state.
+    // Audio capture has already started; if PTT key was released between the first
+    // guard (before Starting) and now (e.g., during audio device init), stop immediately.
+    {
+        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(RecordingMode::Toggle);
+        if mode == RecordingMode::PushToTalk && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst) {
+            log::info!("PTT: Key was released during audio init; stopping recorder immediately");
+            // Stop the audio recorder synchronously before transitioning state
+            let recorder_state_handle = app.state::<RecorderState>();
+            if let Ok(mut recorder) = recorder_state_handle.inner().0.lock() {
+                if recorder.is_recording() {
+                    let _ = recorder.stop_recording();
+                }
+            }
+            MEDIA_CONTROLLER.resume_if_we_paused();
+
+            // Clean up the audio file
+            if let Ok(mut path_guard) = app_state.current_recording_path.lock() {
+                if let Some(path) = path_guard.take() {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+
+            update_recording_state(&app, RecordingState::Idle, None);
+            return Err("PTT key released during audio initialization".to_string());
+        }
+    }
+
     // Update state to recording
     update_recording_state(&app, RecordingState::Recording, None);
 
-    // If a toggle-stop was requested while starting, honor it immediately after entering Recording
+    // If a stop was requested while starting (toggle or PTT), honor it immediately
+    // after entering Recording state. For PTT, key-up in Starting state sets this flag.
+    // The second PTT guard above handles key-up during audio init; this handles the
+    // narrow window between Starting transition and this point.
     if app_state
         .pending_stop_after_start
         .swap(false, std::sync::atomic::Ordering::SeqCst)

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -28,6 +28,8 @@ use tauri_plugin_store::StoreExt;
 
 pub(crate) const PTT_START_ABORTED_AFTER_RELEASE: &str =
     "PTT key released before recording could start";
+const LICENSE_CHECK_TIMEOUT_SECS: u64 = 3;
+const STALE_TRIAL_LICENSE_FALLBACK_MAX_AGE_SECS: u64 = 24 * 60 * 60;
 
 /// Atomic counter for toast IDs to prevent race conditions
 static TOAST_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -555,13 +557,21 @@ fn select_best_fallback_model(
 fn cached_license_allows_recording(cached: &CachedLicense) -> bool {
     match &cached.status.status {
         LicenseState::Licensed => true,
-        LicenseState::Trial => cached
-            .status
-            .trial_days_left
-            .and_then(|days| u64::try_from(days).ok())
-            .filter(|days| *days > 0)
-            .map(|days| cached.age() < std::time::Duration::from_secs(days * 24 * 60 * 60))
-            .unwrap_or(false),
+        LicenseState::Trial => {
+            // Trial fallback is intentionally short-lived: it only covers
+            // transient offline/timeout failures for a session that recently
+            // proved it still had trial time remaining. Do not extend stale
+            // trial evidence by the number of days remaining in the trial.
+            let has_trial_time_remaining = cached
+                .status
+                .trial_days_left
+                .and_then(|days| u64::try_from(days).ok())
+                .is_some_and(|days| days > 0);
+
+            has_trial_time_remaining
+                && cached.age()
+                    < std::time::Duration::from_secs(STALE_TRIAL_LICENSE_FALLBACK_MAX_AGE_SECS)
+        }
         LicenseState::Expired | LicenseState::None => false,
     }
 }
@@ -628,7 +638,7 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
         // local license evidence. Without that, fail closed instead of allowing
         // indefinite recording when the license service is slow or blocked.
         let check_result = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(LICENSE_CHECK_TIMEOUT_SECS),
             check_license_status_internal(app),
         )
         .await;
@@ -658,12 +668,16 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
             Err(_) => {
                 if let Some(fallback_status) = timeout_fallback_status {
                     log::warn!(
-                        "License check timed out after 3s; using stale in-memory license status for this recording"
+                        "License check timed out after {}s; using stale in-memory license status for this recording",
+                        LICENSE_CHECK_TIMEOUT_SECS
                     );
                     fallback_status
                 } else {
+                    // Deliberate fail-closed path: without local license evidence,
+                    // an offline or slow validation cannot start a new recording.
                     return Err(
-                        "License validation timed out. Please try again when online.".to_string(),
+                        "License validation timed out. Please check your connection and try again."
+                            .to_string(),
                     );
                 }
             }
@@ -1121,11 +1135,8 @@ pub async fn start_recording(
                     }
                 });
 
-            if let Err(e) = stop_result {
-                MEDIA_CONTROLLER.resume_if_we_paused();
-                return Err(e);
-            }
             MEDIA_CONTROLLER.resume_if_we_paused();
+            stop_result?;
 
             // Clean up the audio file
             if let Ok(mut path_guard) = app_state.current_recording_path.lock() {

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -716,6 +716,21 @@ pub(crate) fn clear_pending_stop_after_start(app_state: &AppState) {
         .store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
+pub(crate) fn ptt_key_released(app_state: &AppState) -> bool {
+    let mode = match app_state.recording_mode.lock() {
+        Ok(guard) => *guard,
+        Err(poisoned) => {
+            log::warn!("recording_mode mutex poisoned; recovering value for PTT guard");
+            *poisoned.into_inner()
+        }
+    };
+
+    mode == RecordingMode::PushToTalk
+        && !app_state
+            .ptt_key_held
+            .load(std::sync::atomic::Ordering::SeqCst)
+}
+
 #[tauri::command]
 pub async fn start_recording(
     app: AppHandle,
@@ -775,16 +790,7 @@ pub async fn start_recording(
     // after the user has already released the PTT key (e.g., during slow license checks).
     {
         let app_state = app.state::<AppState>();
-        let mode = app_state
-            .recording_mode
-            .lock()
-            .map(|g| *g)
-            .unwrap_or(RecordingMode::Toggle);
-        if mode == RecordingMode::PushToTalk
-            && !app_state
-                .ptt_key_held
-                .load(std::sync::atomic::Ordering::SeqCst)
-        {
+        if ptt_key_released(&app_state) {
             log::info!("PTT: Key was released during validation; aborting recording start");
             return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());
         }
@@ -1109,50 +1115,39 @@ pub async fn start_recording(
     // Second PTT guard: check again right before committing to Recording state.
     // Audio capture has already started; if PTT key was released between the first
     // guard (before Starting) and now (e.g., during audio device init), stop immediately.
-    {
-        let mode = app_state
-            .recording_mode
+    if ptt_key_released(&app_state) {
+        log::info!("PTT: Key was released during audio init; stopping recorder immediately");
+        // Stop the audio recorder synchronously before transitioning state.
+        // If this fails, do not pretend the app is idle: propagate the
+        // failure so the hotkey handler moves to Error and the recorder
+        // remains visible for recovery instead of orphaning capture.
+        let recorder_state_handle = app.state::<RecorderState>();
+        let stop_result = recorder_state_handle
+            .inner()
+            .0
             .lock()
-            .map(|g| *g)
-            .unwrap_or(RecordingMode::Toggle);
-        if mode == RecordingMode::PushToTalk
-            && !app_state
-                .ptt_key_held
-                .load(std::sync::atomic::Ordering::SeqCst)
-        {
-            log::info!("PTT: Key was released during audio init; stopping recorder immediately");
-            // Stop the audio recorder synchronously before transitioning state.
-            // If this fails, do not pretend the app is idle: propagate the
-            // failure so the hotkey handler moves to Error and the recorder
-            // remains visible for recovery instead of orphaning capture.
-            let recorder_state_handle = app.state::<RecorderState>();
-            let stop_result = recorder_state_handle
-                .inner()
-                .0
-                .lock()
-                .map_err(|e| format!("Failed to acquire recorder lock: {}", e))
-                .and_then(|mut recorder| {
-                    if recorder.is_recording() {
-                        recorder.stop_recording()
-                    } else {
-                        Ok(String::new())
-                    }
-                });
-
-            clear_pending_stop_after_start(&app_state);
-            MEDIA_CONTROLLER.resume_if_we_paused();
-            stop_result?;
-
-            // Clean up the audio file
-            if let Ok(mut path_guard) = app_state.current_recording_path.lock() {
-                if let Some(path) = path_guard.take() {
-                    let _ = std::fs::remove_file(&path);
+            .map_err(|e| format!("Failed to acquire recorder lock: {}", e))
+            .and_then(|mut recorder| {
+                if recorder.is_recording() {
+                    recorder.stop_recording()
+                } else {
+                    Ok(String::new())
                 }
-            }
+            });
 
-            update_recording_state(&app, RecordingState::Idle, None);
-            return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());
+        clear_pending_stop_after_start(&app_state);
+        MEDIA_CONTROLLER.resume_if_we_paused();
+        stop_result?;
+
+        // Clean up the audio file
+        if let Ok(mut path_guard) = app_state.current_recording_path.lock() {
+            if let Some(path) = path_guard.take() {
+                let _ = std::fs::remove_file(&path);
+            }
         }
+
+        update_recording_state(&app, RecordingState::Idle, None);
+        return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());
     }
 
     // Update state to recording

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -4,7 +4,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use crate::audio::recorder::AudioRecorder;
 use crate::commands::license::check_license_status_internal;
 use crate::commands::settings::{get_settings, resolve_pill_indicator_mode, Settings};
-use crate::license::LicenseState;
+use crate::license::{LicenseState, LicenseStatus};
 use crate::media::MediaPauseController;
 use crate::parakeet::messages::ParakeetResponse;
 use crate::parakeet::ParakeetManager;
@@ -25,6 +25,9 @@ use std::time::Instant;
 use tauri::async_runtime::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 use tauri_plugin_store::StoreExt;
+
+pub(crate) const PTT_START_ABORTED_AFTER_RELEASE: &str =
+    "PTT key released before recording could start";
 
 /// Atomic counter for toast IDs to prevent race conditions
 static TOAST_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -549,6 +552,10 @@ fn select_best_fallback_model(
     })
 }
 
+fn license_allows_recording(status: &LicenseStatus) -> bool {
+    matches!(status.status, LicenseState::Licensed | LicenseState::Trial)
+}
+
 /// Pre-recording validation using the readiness state
 async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> {
     let availability = crate::recognition_availability_snapshot(app).await;
@@ -580,24 +587,26 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
     }
 
     // Check license status (with caching to improve performance)
-    let license_status = {
+    let (license_status, timeout_fallback_status) = {
         let app_state = app.state::<AppState>();
         let cache = app_state.license_cache.read().await;
 
         if let Some(cached) = cache.as_ref() {
             if cached.is_valid() {
                 log::debug!("Using cached license status (age: {:?})", cached.age());
-                Some(cached.status.clone())
+                (Some(cached.status.clone()), None)
             } else {
                 log::debug!(
                     "License cache is stale (age: {:?}), will refresh",
                     cached.age()
                 );
-                None
+                let fallback =
+                    license_allows_recording(&cached.status).then(|| cached.status.clone());
+                (None, fallback)
             }
         } else {
             log::debug!("No license cache found, will perform fresh check");
-            None
+            (None, None)
         }
     };
 
@@ -605,9 +614,9 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
         cached_status
     } else {
         // Cache miss or stale - perform license check with a bounded timeout.
-        // This prevents the recording start path from blocking indefinitely on
-        // slow/offline network license validation, which causes PTT key-up to be
-        // missed and recording to start after the user released the key.
+        // Timeout fallback is only allowed when this session already has valid
+        // local license evidence. Without that, fail closed instead of allowing
+        // indefinite recording when the license service is slow or blocked.
         let check_result = tokio::time::timeout(
             std::time::Duration::from_secs(3),
             check_license_status_internal(app),
@@ -627,16 +636,26 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
             }
             Ok(Err(e)) => {
                 log::error!("Failed to check license status: {}", e);
-                // Allow recording if license check fails (graceful degradation)
-                return Ok(());
+                if let Some(fallback_status) = timeout_fallback_status {
+                    log::warn!(
+                        "License check failed; using stale in-memory license status for this recording"
+                    );
+                    fallback_status
+                } else {
+                    return Err(e);
+                }
             }
             Err(_) => {
-                // Timeout - license check took too long.
-                // Allow recording to proceed; enforcement happens on next successful check.
-                log::warn!(
-                    "License check timed out after 3s; allowing recording to proceed (enforcement deferred to next successful validation)"
-                );
-                return Ok(());
+                if let Some(fallback_status) = timeout_fallback_status {
+                    log::warn!(
+                        "License check timed out after 3s; using stale in-memory license status for this recording"
+                    );
+                    fallback_status
+                } else {
+                    return Err(
+                        "License validation timed out. Please try again when online.".to_string(),
+                    );
+                }
             }
         }
     };
@@ -726,10 +745,18 @@ pub async fn start_recording(
     // after the user has already released the PTT key (e.g., during slow license checks).
     {
         let app_state = app.state::<AppState>();
-        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(RecordingMode::Toggle);
-        if mode == RecordingMode::PushToTalk && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst) {
+        let mode = app_state
+            .recording_mode
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(RecordingMode::Toggle);
+        if mode == RecordingMode::PushToTalk
+            && !app_state
+                .ptt_key_held
+                .load(std::sync::atomic::Ordering::SeqCst)
+        {
             log::info!("PTT: Key was released during validation; aborting recording start");
-            return Err("PTT key released before recording could start".to_string());
+            return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());
         }
     }
 
@@ -1055,8 +1082,16 @@ pub async fn start_recording(
     // Audio capture has already started; if PTT key was released between the first
     // guard (before Starting) and now (e.g., during audio device init), stop immediately.
     {
-        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(RecordingMode::Toggle);
-        if mode == RecordingMode::PushToTalk && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst) {
+        let mode = app_state
+            .recording_mode
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(RecordingMode::Toggle);
+        if mode == RecordingMode::PushToTalk
+            && !app_state
+                .ptt_key_held
+                .load(std::sync::atomic::Ordering::SeqCst)
+        {
             log::info!("PTT: Key was released during audio init; stopping recorder immediately");
             // Stop the audio recorder synchronously before transitioning state
             let recorder_state_handle = app.state::<RecorderState>();

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -710,6 +710,12 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
     Ok(())
 }
 
+pub(crate) fn clear_pending_stop_after_start(app_state: &AppState) {
+    app_state
+        .pending_stop_after_start
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+}
+
 #[tauri::command]
 pub async fn start_recording(
     app: AppHandle,
@@ -874,9 +880,7 @@ pub async fn start_recording(
 
     // Store path for later use and reset any leftover pending-toggle flag
     let app_state = app.state::<AppState>();
-    app_state
-        .pending_stop_after_start
-        .store(false, std::sync::atomic::Ordering::SeqCst);
+    clear_pending_stop_after_start(&app_state);
 
     // Save current recording path
     match app_state.current_recording_path.lock() {
@@ -1135,6 +1139,7 @@ pub async fn start_recording(
                     }
                 });
 
+            clear_pending_stop_after_start(&app_state);
             MEDIA_CONTROLLER.resume_if_we_paused();
             stop_result?;
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1137,14 +1137,28 @@ pub async fn start_recording(
 
         clear_pending_stop_after_start(&app_state);
         MEDIA_CONTROLLER.resume_if_we_paused();
-        stop_result?;
+
+        let cleanup_recording_path = || {
+            if let Ok(mut path_guard) = app_state.current_recording_path.lock() {
+                if let Some(path) = path_guard.take() {
+                    if let Err(error) = std::fs::remove_file(&path) {
+                        log::warn!(
+                            "Failed to remove aborted recording file {}: {}",
+                            path.display(),
+                            error
+                        );
+                    }
+                }
+            }
+        };
+
+        if let Err(error) = stop_result {
+            cleanup_recording_path();
+            return Err(error);
+        }
 
         // Clean up the audio file
-        if let Ok(mut path_guard) = app_state.current_recording_path.lock() {
-            if let Some(path) = path_guard.take() {
-                let _ = std::fs::remove_file(&path);
-            }
-        }
+        cleanup_recording_path();
 
         update_recording_state(&app, RecordingState::Idle, None);
         return Err(PTT_START_ABORTED_AFTER_RELEASE.to_string());

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -37,7 +37,9 @@ fn ensure_trailing_sentence_space(text: &str) -> String {
     // Preserve explicit structural whitespace. The helper is for ergonomic
     // sentence spacing, not for rewriting multiline text or caller-provided
     // newlines/tabs at the insertion boundary.
-    if without_trailing_spaces.ends_with(['\n', '\r', '\t'])
+    if without_trailing_spaces.ends_with('\n')
+        || without_trailing_spaces.ends_with('\r')
+        || without_trailing_spaces.ends_with('\t')
         || without_trailing_spaces.contains('\n')
         || without_trailing_spaces.contains('\r')
     {
@@ -57,7 +59,8 @@ fn ensure_trailing_sentence_space(text: &str) -> String {
     }
 
     // Detect contexts where a trailing space would be harmful.
-    let semantic_end = without_trailing_spaces.trim_end_matches(closing_punctuation);
+    let semantic_end =
+        without_trailing_spaces.trim_end_matches(|c| closing_punctuation.contains(&c));
     let before_period = semantic_end.strip_suffix('.').unwrap_or(semantic_end);
     let looks_like_url = semantic_end.contains("://")
         || before_period.ends_with(".com")

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -29,22 +29,37 @@ static IS_INSERTING: AtomicBool = AtomicBool::new(false);
 /// - `foo@bar.com.` → `foo@bar.com.` (email-like, skip)
 /// - `x = y.` → `x = y.` (code-like, skip)
 fn ensure_trailing_sentence_space(text: &str) -> String {
-    let trimmed = text.trim_end();
-    if trimmed.is_empty() {
+    let without_trailing_spaces = text.trim_end_matches(' ');
+    if without_trailing_spaces.is_empty() {
         return text.to_string();
     }
 
-    let last_char = trimmed.chars().last().unwrap();
-
-    // Only add space after sentence-ending punctuation
-    if !matches!(last_char, '.' | '!' | '?') {
+    // Preserve explicit structural whitespace. The helper is for ergonomic
+    // sentence spacing, not for rewriting multiline text or caller-provided
+    // newlines/tabs at the insertion boundary.
+    if without_trailing_spaces.ends_with(['\n', '\r', '\t'])
+        || without_trailing_spaces.contains('\n')
+        || without_trailing_spaces.contains('\r')
+    {
         return text.to_string();
     }
 
-    // Detect contexts where a trailing space would be harmful
-    // Strip the trailing period to check what precedes it for TLD patterns
-    let before_period = trimmed.strip_suffix('.').unwrap_or(trimmed);
-    let looks_like_url = trimmed.contains("://")
+    let closing_punctuation = ['"', '\'', '”', '’', ')', ']', '}'];
+    let sentence_end = without_trailing_spaces
+        .chars()
+        .rev()
+        .find(|c| !closing_punctuation.contains(c));
+
+    // Only add space after sentence-ending punctuation, allowing closing
+    // quotes/brackets after the punctuation.
+    if !matches!(sentence_end, Some('.' | '!' | '?')) {
+        return text.to_string();
+    }
+
+    // Detect contexts where a trailing space would be harmful.
+    let semantic_end = without_trailing_spaces.trim_end_matches(closing_punctuation);
+    let before_period = semantic_end.strip_suffix('.').unwrap_or(semantic_end);
+    let looks_like_url = semantic_end.contains("://")
         || before_period.ends_with(".com")
         || before_period.ends_with(".org")
         || before_period.ends_with(".net")
@@ -53,17 +68,20 @@ fn ensure_trailing_sentence_space(text: &str) -> String {
         || before_period.ends_with(".app");
     // Email-like: contains @ with no spaces (even if followed by period)
     let looks_like_email = before_period.contains('@') && !before_period.contains(' ');
-    let looks_like_code = trimmed.contains("=") || trimmed.contains("->") || trimmed.contains("::") || trimmed.contains("{") || trimmed.contains("}") || trimmed.contains(";");
-    let has_newlines = trimmed.contains('\n');
+    let looks_like_code = semantic_end.contains('=')
+        || semantic_end.contains("->")
+        || semantic_end.contains("::")
+        || semantic_end.contains('{')
+        || semantic_end.contains('}')
+        || semantic_end.contains(';');
 
-    if looks_like_url || looks_like_email || looks_like_code || has_newlines {
+    if looks_like_url || looks_like_email || looks_like_code {
         return text.to_string();
     }
 
-    // Preserve exactly one trailing space
-    format!("{} ", trimmed)
+    // Preserve exactly one trailing space after the original closing punctuation.
+    format!("{} ", without_trailing_spaces)
 }
-
 
 #[tauri::command]
 pub async fn insert_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
@@ -516,7 +534,6 @@ fn paste_linux() -> Result<(), SimulateError> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,10 +572,7 @@ mod tests {
 
     #[test]
     fn no_sentence_end_no_space() {
-        assert_eq!(
-            ensure_trailing_sentence_space("Hello world"),
-            "Hello world"
-        );
+        assert_eq!(ensure_trailing_sentence_space("Hello world"), "Hello world");
     }
 
     #[test]
@@ -587,10 +601,7 @@ mod tests {
 
     #[test]
     fn code_like_no_space() {
-        assert_eq!(
-            ensure_trailing_sentence_space("x = y."),
-            "x = y."
-        );
+        assert_eq!(ensure_trailing_sentence_space("x = y."), "x = y.");
     }
 
     #[test]
@@ -602,19 +613,34 @@ mod tests {
     }
 
     #[test]
-    fn empty_string_unchanged() {
+    fn trailing_newline_is_preserved() {
+        assert_eq!(ensure_trailing_sentence_space("Hello.\n"), "Hello.\n");
+    }
+
+    #[test]
+    fn closing_quote_gets_trailing_space() {
         assert_eq!(
-            ensure_trailing_sentence_space(""),
-            ""
+            ensure_trailing_sentence_space("He said \"yes.\""),
+            "He said \"yes.\" "
         );
     }
 
     #[test]
-    fn only_whitespace_unchanged() {
+    fn closing_paren_gets_trailing_space() {
         assert_eq!(
-            ensure_trailing_sentence_space("   "),
-            "   "
+            ensure_trailing_sentence_space("That works (really!)"),
+            "That works (really!) "
         );
+    }
+
+    #[test]
+    fn empty_string_unchanged() {
+        assert_eq!(ensure_trailing_sentence_space(""), "");
+    }
+
+    #[test]
+    fn only_whitespace_unchanged() {
+        assert_eq!(ensure_trailing_sentence_space("   "), "   ");
     }
 
     #[test]
@@ -637,9 +663,6 @@ mod tests {
 
     #[test]
     fn semicolon_code_like_no_space() {
-        assert_eq!(
-            ensure_trailing_sentence_space("let x = 5;"),
-            "let x = 5;"
-        );
+        assert_eq!(ensure_trailing_sentence_space("let x = 5;"), "let x = 5;");
     }
 }

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -46,7 +46,7 @@ fn ensure_trailing_sentence_space(text: &str) -> String {
         return text.to_string();
     }
 
-    let closing_punctuation = ['"', '\'', '”', '’', ')', ']', '}'];
+    let closing_punctuation = ['"', '\'', '“', '”', '’', ')', ']', '}'];
     let sentence_end = without_trailing_spaces
         .chars()
         .rev()
@@ -625,6 +625,14 @@ mod tests {
         assert_eq!(
             ensure_trailing_sentence_space("He said \"yes.\""),
             "He said \"yes.\" "
+        );
+    }
+
+    #[test]
+    fn curly_closing_quote_gets_trailing_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("He said “yes.”"),
+            "He said “yes.” "
         );
     }
 

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -18,6 +18,53 @@ use enigo::{
 // Global flag to prevent concurrent text insertions
 static IS_INSERTING: AtomicBool = AtomicBool::new(false);
 
+/// Ensure prose ending in sentence punctuation has exactly one trailing space.
+///
+/// This is applied at the insertion boundary only, so stored transcription
+/// history remains clean. Rules:
+/// - `Hello world.` → `Hello world. `
+/// - `Hello world. ` → `Hello world. ` (normalize to one)
+/// - `Hello world` → `Hello world` (no sentence end, no space)
+/// - `https://example.com.` → `https://example.com.` (URL-like, skip)
+/// - `foo@bar.com.` → `foo@bar.com.` (email-like, skip)
+/// - `x = y.` → `x = y.` (code-like, skip)
+fn ensure_trailing_sentence_space(text: &str) -> String {
+    let trimmed = text.trim_end();
+    if trimmed.is_empty() {
+        return text.to_string();
+    }
+
+    let last_char = trimmed.chars().last().unwrap();
+
+    // Only add space after sentence-ending punctuation
+    if !matches!(last_char, '.' | '!' | '?') {
+        return text.to_string();
+    }
+
+    // Detect contexts where a trailing space would be harmful
+    // Strip the trailing period to check what precedes it for TLD patterns
+    let before_period = trimmed.strip_suffix('.').unwrap_or(trimmed);
+    let looks_like_url = trimmed.contains("://")
+        || before_period.ends_with(".com")
+        || before_period.ends_with(".org")
+        || before_period.ends_with(".net")
+        || before_period.ends_with(".io")
+        || before_period.ends_with(".dev")
+        || before_period.ends_with(".app");
+    // Email-like: contains @ with no spaces (even if followed by period)
+    let looks_like_email = before_period.contains('@') && !before_period.contains(' ');
+    let looks_like_code = trimmed.contains("=") || trimmed.contains("->") || trimmed.contains("::") || trimmed.contains("{") || trimmed.contains("}") || trimmed.contains(";");
+    let has_newlines = trimmed.contains('\n');
+
+    if looks_like_url || looks_like_email || looks_like_code || has_newlines {
+        return text.to_string();
+    }
+
+    // Preserve exactly one trailing space
+    format!("{} ", trimmed)
+}
+
+
 #[tauri::command]
 pub async fn insert_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
     // Check if already inserting text
@@ -54,10 +101,13 @@ pub async fn insert_text(app: tauri::AppHandle, text: String) -> Result<(), Stri
     };
 
     tokio::task::spawn_blocking(move || {
+        // Apply trailing sentence space only at the insertion boundary,
+        // so stored transcription history remains clean.
+        let insertable_text = ensure_trailing_sentence_space(&text);
         // Always use clipboard method for reliability and to prevent duplicate insertion
         // This function handles both copying to clipboard and pasting at cursor
         insert_via_clipboard(
-            text,
+            insertable_text,
             has_accessibility_permission,
             Some(app),
             keep_transcription_in_clipboard,
@@ -464,4 +514,132 @@ fn paste_linux() -> Result<(), SimulateError> {
     send_key_event(&EventType::KeyRelease(RdevKey::ControlLeft))?;
     log::debug!("Linux paste simulation completed");
     Ok(())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sentence_end_gets_trailing_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello world."),
+            "Hello world. "
+        );
+    }
+
+    #[test]
+    fn exclamation_gets_trailing_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("That's great!"),
+            "That's great! "
+        );
+    }
+
+    #[test]
+    fn question_mark_gets_trailing_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("How are you?"),
+            "How are you? "
+        );
+    }
+
+    #[test]
+    fn existing_trailing_spaces_normalize_to_one() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello world.   "),
+            "Hello world. "
+        );
+    }
+
+    #[test]
+    fn no_sentence_end_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello world"),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn comma_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello world,"),
+            "Hello world,"
+        );
+    }
+
+    #[test]
+    fn url_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Visit https://example.com."),
+            "Visit https://example.com."
+        );
+    }
+
+    #[test]
+    fn email_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("user@example.com."),
+            "user@example.com."
+        );
+    }
+
+    #[test]
+    fn code_like_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("x = y."),
+            "x = y."
+        );
+    }
+
+    #[test]
+    fn multiline_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello.\nWorld."),
+            "Hello.\nWorld."
+        );
+    }
+
+    #[test]
+    fn empty_string_unchanged() {
+        assert_eq!(
+            ensure_trailing_sentence_space(""),
+            ""
+        );
+    }
+
+    #[test]
+    fn only_whitespace_unchanged() {
+        assert_eq!(
+            ensure_trailing_sentence_space("   "),
+            "   "
+        );
+    }
+
+    #[test]
+    fn tld_like_ending_no_space() {
+        // .com ending should not get a space (ambiguous with domain)
+        assert_eq!(
+            ensure_trailing_sentence_space("example.com."),
+            "example.com."
+        );
+    }
+
+    #[test]
+    fn normal_prose_with_period() {
+        // Normal dictation: sentence with a period
+        assert_eq!(
+            ensure_trailing_sentence_space("The quick brown fox jumps over the lazy dog."),
+            "The quick brown fox jumps over the lazy dog. "
+        );
+    }
+
+    #[test]
+    fn semicolon_code_like_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("let x = 5;"),
+            "let x = 5;"
+        );
+    }
 }

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -665,6 +665,21 @@ mod tests {
     }
 
     #[test]
+    fn repeated_sentence_insertions_keep_boundaries() {
+        let combined = format!(
+            "{}{}{}",
+            ensure_trailing_sentence_space("This is the testing bro one two three."),
+            ensure_trailing_sentence_space("This is a testing blow one to three."),
+            ensure_trailing_sentence_space("This is a testing row on to three."),
+        );
+
+        assert_eq!(
+            combined,
+            "This is the testing bro one two three. This is a testing blow one to three. This is a testing row on to three. "
+        );
+    }
+
+    #[test]
     fn code_assignment_sentence_like_no_space() {
         assert_eq!(
             ensure_trailing_sentence_space("result = ok."),

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -665,7 +665,10 @@ mod tests {
     }
 
     #[test]
-    fn semicolon_code_like_no_space() {
-        assert_eq!(ensure_trailing_sentence_space("let x = 5;"), "let x = 5;");
+    fn code_assignment_sentence_like_no_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("result = ok."),
+            "result = ok."
+        );
     }
 }

--- a/src-tauri/src/recording/hotkeys.rs
+++ b/src-tauri/src/recording/hotkeys.rs
@@ -1,4 +1,6 @@
-use crate::commands::audio::{start_recording, stop_recording, RecorderState};
+use crate::commands::audio::{
+    start_recording, stop_recording, RecorderState, PTT_START_ABORTED_AFTER_RELEASE,
+};
 use crate::recording::escape_handler::handle_escape_key_press;
 use crate::{get_recording_state, update_recording_state, AppState, RecordingMode, RecordingState};
 use std::sync::atomic::Ordering;
@@ -183,6 +185,10 @@ fn handle_ptt_mode(
                     let recorder_state = app_handle.state::<RecorderState>();
                     match start_recording(app_handle.clone(), recorder_state).await {
                         Ok(_) => log::info!("PTT: Recording started successfully"),
+                        Err(e) if e == PTT_START_ABORTED_AFTER_RELEASE => {
+                            log::info!("PTT: Recording start cancelled after key release");
+                            update_recording_state(&app_handle, RecordingState::Idle, None);
+                        }
                         Err(e) => {
                             log::error!("PTT: Error starting recording: {}", e);
                             update_recording_state(&app_handle, RecordingState::Error, Some(e));
@@ -218,7 +224,9 @@ fn handle_ptt_mode(
                     // Set the pending flag so start_recording() can honor the stop
                     // as soon as it reaches the Recording state. This prevents
                     // recording from continuing after the user released PTT.
-                    log::info!("PTT: Key released while Starting; setting pending_stop_after_start");
+                    log::info!(
+                        "PTT: Key released while Starting; setting pending_stop_after_start"
+                    );
                     app_state
                         .pending_stop_after_start
                         .store(true, Ordering::SeqCst);

--- a/src-tauri/src/recording/hotkeys.rs
+++ b/src-tauri/src/recording/hotkeys.rs
@@ -201,19 +201,31 @@ fn handle_ptt_mode(
                 return;
             }
 
-            if matches!(
-                current_state,
-                RecordingState::Recording | RecordingState::Starting
-            ) {
-                log::info!("PTT: Stopping recording");
-                let app_handle = app.clone();
-                tauri::async_runtime::spawn(async move {
-                    let recorder_state = app_handle.state::<RecorderState>();
-                    match stop_recording(app_handle.clone(), recorder_state).await {
-                        Ok(_) => log::info!("PTT: Recording stopped successfully"),
-                        Err(e) => log::error!("PTT: Error stopping recording: {}", e),
-                    }
-                });
+            match current_state {
+                RecordingState::Recording => {
+                    log::info!("PTT: Stopping recording");
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let recorder_state = app_handle.state::<RecorderState>();
+                        match stop_recording(app_handle.clone(), recorder_state).await {
+                            Ok(_) => log::info!("PTT: Recording stopped successfully"),
+                            Err(e) => log::error!("PTT: Error stopping recording: {}", e),
+                        }
+                    });
+                }
+                RecordingState::Starting => {
+                    // Key released while recording is still starting up.
+                    // Set the pending flag so start_recording() can honor the stop
+                    // as soon as it reaches the Recording state. This prevents
+                    // recording from continuing after the user released PTT.
+                    log::info!("PTT: Key released while Starting; setting pending_stop_after_start");
+                    app_state
+                        .pending_stop_after_start
+                        .store(true, Ordering::SeqCst);
+                }
+                _ => {
+                    log::debug!("PTT: Key released in state {:?}; no action", current_state);
+                }
             }
         }
     }

--- a/src-tauri/src/tests/audio_commands.rs
+++ b/src-tauri/src/tests/audio_commands.rs
@@ -289,23 +289,25 @@ mod tests {
     // arrives while recording start is blocked by slow license validation.
 
     #[test]
-    fn test_ptt_key_held_flag_default_false() {
-        let app_state = AppState::new();
-        assert!(!app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
-    }
-
-    #[test]
     fn test_ptt_key_held_set_and_cleared() {
         let app_state = AppState::new();
 
         // Simulate key-down
-        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
-        assert!(app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
+        app_state
+            .ptt_key_held
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(app_state
+            .ptt_key_held
+            .load(std::sync::atomic::Ordering::SeqCst));
 
         // Simulate key-up (swap returns previous value)
-        let was_held = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        let was_held = app_state
+            .ptt_key_held
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
         assert!(was_held);
-        assert!(!app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!app_state
+            .ptt_key_held
+            .load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]
@@ -319,25 +321,40 @@ mod tests {
         }
 
         // Simulate: key-down starts the process
-        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
+        app_state
+            .ptt_key_held
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // State transitions to Starting
-        app_state.recording_state.force_set(RecordingState::Starting).unwrap();
+        app_state
+            .recording_state
+            .force_set(RecordingState::Starting)
+            .unwrap();
         assert_eq!(app_state.get_current_state(), RecordingState::Starting);
 
         // Simulate: key-up arrives while Starting
-        let was_held = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        let was_held = app_state
+            .ptt_key_held
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
         assert!(was_held); // Key was held before release
 
         // PTT handler should set pending_stop_after_start
-        app_state.pending_stop_after_start.store(true, std::sync::atomic::Ordering::SeqCst);
+        app_state
+            .pending_stop_after_start
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
         // Simulate: start_recording reaches Recording state and checks the flag
-        app_state.recording_state.force_set(RecordingState::Recording).unwrap();
+        app_state
+            .recording_state
+            .force_set(RecordingState::Recording)
+            .unwrap();
         let pending = app_state
             .pending_stop_after_start
             .swap(false, std::sync::atomic::Ordering::SeqCst);
-        assert!(pending, "pending_stop_after_start should be true when key-up happened during Starting");
+        assert!(
+            pending,
+            "pending_stop_after_start should be true when key-up happened during Starting"
+        );
     }
 
     #[test]
@@ -351,12 +368,20 @@ mod tests {
         }
 
         // Key was never pressed (or already released)
-        app_state.ptt_key_held.store(false, std::sync::atomic::Ordering::SeqCst);
+        app_state
+            .ptt_key_held
+            .store(false, std::sync::atomic::Ordering::SeqCst);
 
         // Guard check: mode is PTT and key is not held
-        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        let mode = app_state
+            .recording_mode
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(crate::RecordingMode::Toggle);
         let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
+            && !app_state
+                .ptt_key_held
+                .load(std::sync::atomic::Ordering::SeqCst);
         assert!(should_abort, "PTT guard should abort when key is not held");
     }
 
@@ -371,12 +396,23 @@ mod tests {
         }
 
         // Key is still held
-        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::SeqCst);
+        app_state
+            .ptt_key_held
+            .store(true, std::sync::atomic::Ordering::SeqCst);
 
-        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        let mode = app_state
+            .recording_mode
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(crate::RecordingMode::Toggle);
         let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
-        assert!(!should_abort, "PTT guard should NOT abort when key is still held");
+            && !app_state
+                .ptt_key_held
+                .load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            !should_abort,
+            "PTT guard should NOT abort when key is still held"
+        );
     }
 
     #[test]
@@ -384,34 +420,31 @@ mod tests {
         let app_state = AppState::new();
 
         // Toggle mode (default)
-        app_state.ptt_key_held.store(false, std::sync::atomic::Ordering::SeqCst);
+        app_state
+            .ptt_key_held
+            .store(false, std::sync::atomic::Ordering::SeqCst);
 
-        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        let mode = app_state
+            .recording_mode
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(crate::RecordingMode::Toggle);
         assert_eq!(mode, crate::RecordingMode::Toggle);
 
         // In toggle mode, the PTT guard should not trigger even if key is not held
         let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
+            && !app_state
+                .ptt_key_held
+                .load(std::sync::atomic::Ordering::SeqCst);
         assert!(!should_abort, "PTT guard should not affect toggle mode");
     }
 
     #[test]
     fn test_pending_stop_after_start_default_false() {
         let app_state = AppState::new();
-        assert!(!app_state.pending_stop_after_start.load(std::sync::atomic::Ordering::SeqCst));
-    }
-
-    #[test]
-    fn test_pending_stop_after_start_reset_on_new_recording() {
-        let app_state = AppState::new();
-
-        // Set the flag (simulating previous key-up during start)
-        app_state.pending_stop_after_start.store(true, std::sync::atomic::Ordering::SeqCst);
-
-        // start_recording resets it at the beginning (line ~825 in audio.rs)
-        app_state.pending_stop_after_start.store(false, std::sync::atomic::Ordering::SeqCst);
-
-        assert!(!app_state.pending_stop_after_start.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!app_state
+            .pending_stop_after_start
+            .load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]
@@ -419,14 +452,23 @@ mod tests {
         let app_state = AppState::new();
 
         // First key-down
-        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
+        app_state
+            .ptt_key_held
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // First key-up: swap returns true (was held), now false
-        let first_swap = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        let first_swap = app_state
+            .ptt_key_held
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
         assert!(first_swap);
 
         // Second key-up (duplicate event): swap returns false (already released)
-        let second_swap = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
-        assert!(!second_swap, "Duplicate key release should return false from swap");
+        let second_swap = app_state
+            .ptt_key_held
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            !second_swap,
+            "Duplicate key release should return false from swap"
+        );
     }
 }

--- a/src-tauri/src/tests/audio_commands.rs
+++ b/src-tauri/src/tests/audio_commands.rs
@@ -283,4 +283,150 @@ mod tests {
             assert!(task_guard.is_none());
         }
     }
+
+    // --- PTT race condition tests ---
+    // These tests verify the fix for the PTT/license-lag issue where key-up
+    // arrives while recording start is blocked by slow license validation.
+
+    #[test]
+    fn test_ptt_key_held_flag_default_false() {
+        let app_state = AppState::new();
+        assert!(!app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_ptt_key_held_set_and_cleared() {
+        let app_state = AppState::new();
+
+        // Simulate key-down
+        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
+
+        // Simulate key-up (swap returns previous value)
+        let was_held = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(was_held);
+        assert!(!app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_ptt_key_release_while_starting_sets_pending_stop() {
+        let app_state = AppState::new();
+
+        // Simulate: recording mode is PTT
+        {
+            let mut mode = app_state.recording_mode.lock().unwrap();
+            *mode = crate::RecordingMode::PushToTalk;
+        }
+
+        // Simulate: key-down starts the process
+        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // State transitions to Starting
+        app_state.recording_state.force_set(RecordingState::Starting).unwrap();
+        assert_eq!(app_state.get_current_state(), RecordingState::Starting);
+
+        // Simulate: key-up arrives while Starting
+        let was_held = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(was_held); // Key was held before release
+
+        // PTT handler should set pending_stop_after_start
+        app_state.pending_stop_after_start.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        // Simulate: start_recording reaches Recording state and checks the flag
+        app_state.recording_state.force_set(RecordingState::Recording).unwrap();
+        let pending = app_state
+            .pending_stop_after_start
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(pending, "pending_stop_after_start should be true when key-up happened during Starting");
+    }
+
+    #[test]
+    fn test_ptt_guard_detects_released_key() {
+        let app_state = AppState::new();
+
+        // Set to PTT mode
+        {
+            let mut mode = app_state.recording_mode.lock().unwrap();
+            *mode = crate::RecordingMode::PushToTalk;
+        }
+
+        // Key was never pressed (or already released)
+        app_state.ptt_key_held.store(false, std::sync::atomic::Ordering::SeqCst);
+
+        // Guard check: mode is PTT and key is not held
+        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        let should_abort = mode == crate::RecordingMode::PushToTalk
+            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(should_abort, "PTT guard should abort when key is not held");
+    }
+
+    #[test]
+    fn test_ptt_guard_allows_when_key_still_held() {
+        let app_state = AppState::new();
+
+        // Set to PTT mode
+        {
+            let mut mode = app_state.recording_mode.lock().unwrap();
+            *mode = crate::RecordingMode::PushToTalk;
+        }
+
+        // Key is still held
+        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        let should_abort = mode == crate::RecordingMode::PushToTalk
+            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(!should_abort, "PTT guard should NOT abort when key is still held");
+    }
+
+    #[test]
+    fn test_toggle_mode_not_affected_by_ptt_guard() {
+        let app_state = AppState::new();
+
+        // Toggle mode (default)
+        app_state.ptt_key_held.store(false, std::sync::atomic::Ordering::SeqCst);
+
+        let mode = app_state.recording_mode.lock().map(|g| *g).unwrap_or(crate::RecordingMode::Toggle);
+        assert_eq!(mode, crate::RecordingMode::Toggle);
+
+        // In toggle mode, the PTT guard should not trigger even if key is not held
+        let should_abort = mode == crate::RecordingMode::PushToTalk
+            && !app_state.ptt_key_held.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(!should_abort, "PTT guard should not affect toggle mode");
+    }
+
+    #[test]
+    fn test_pending_stop_after_start_default_false() {
+        let app_state = AppState::new();
+        assert!(!app_state.pending_stop_after_start.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_pending_stop_after_start_reset_on_new_recording() {
+        let app_state = AppState::new();
+
+        // Set the flag (simulating previous key-up during start)
+        app_state.pending_stop_after_start.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        // start_recording resets it at the beginning (line ~825 in audio.rs)
+        app_state.pending_stop_after_start.store(false, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(!app_state.pending_stop_after_start.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_duplicate_ptt_key_release_ignored() {
+        let app_state = AppState::new();
+
+        // First key-down
+        app_state.ptt_key_held.store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // First key-up: swap returns true (was held), now false
+        let first_swap = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(first_swap);
+
+        // Second key-up (duplicate event): swap returns false (already released)
+        let second_swap = app_state.ptt_key_held.swap(false, std::sync::atomic::Ordering::SeqCst);
+        assert!(!second_swap, "Duplicate key release should return false from swap");
+    }
 }

--- a/src-tauri/src/tests/audio_commands.rs
+++ b/src-tauri/src/tests/audio_commands.rs
@@ -448,6 +448,23 @@ mod tests {
     }
 
     #[test]
+    fn test_ptt_abort_clears_pending_stop_after_start() {
+        let app_state = AppState::new();
+        app_state
+            .pending_stop_after_start
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        crate::commands::audio::clear_pending_stop_after_start(&app_state);
+
+        assert!(
+            !app_state
+                .pending_stop_after_start
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "PTT abort cleanup must not leave a stale pending stop for the next recording"
+        );
+    }
+
+    #[test]
     fn test_duplicate_ptt_key_release_ignored() {
         let app_state = AppState::new();
 

--- a/src-tauri/src/tests/audio_commands.rs
+++ b/src-tauri/src/tests/audio_commands.rs
@@ -372,17 +372,10 @@ mod tests {
             .ptt_key_held
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
-        // Guard check: mode is PTT and key is not held
-        let mode = app_state
-            .recording_mode
-            .lock()
-            .map(|g| *g)
-            .unwrap_or(crate::RecordingMode::Toggle);
-        let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state
-                .ptt_key_held
-                .load(std::sync::atomic::Ordering::SeqCst);
-        assert!(should_abort, "PTT guard should abort when key is not held");
+        assert!(
+            crate::commands::audio::ptt_key_released(&app_state),
+            "PTT guard should abort when key is not held"
+        );
     }
 
     #[test]
@@ -424,17 +417,8 @@ mod tests {
             .ptt_key_held
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
-        let mode = app_state
-            .recording_mode
-            .lock()
-            .map(|g| *g)
-            .unwrap_or(crate::RecordingMode::Toggle);
-        let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state
-                .ptt_key_held
-                .load(std::sync::atomic::Ordering::SeqCst);
         assert!(
-            !should_abort,
+            !crate::commands::audio::ptt_key_released(&app_state),
             "PTT guard should NOT abort when key is still held"
         );
     }
@@ -455,12 +439,10 @@ mod tests {
             .unwrap_or(crate::RecordingMode::Toggle);
         assert_eq!(mode, crate::RecordingMode::Toggle);
 
-        // In toggle mode, the PTT guard should not trigger even if key is not held
-        let should_abort = mode == crate::RecordingMode::PushToTalk
-            && !app_state
-                .ptt_key_held
-                .load(std::sync::atomic::Ordering::SeqCst);
-        assert!(!should_abort, "PTT guard should not affect toggle mode");
+        assert!(
+            !crate::commands::audio::ptt_key_released(&app_state),
+            "PTT guard should not affect toggle mode"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tests/audio_commands.rs
+++ b/src-tauri/src/tests/audio_commands.rs
@@ -386,6 +386,30 @@ mod tests {
     }
 
     #[test]
+    fn test_ptt_key_released_recovers_poisoned_mode_lock() {
+        let app_state = AppState::new();
+        {
+            let mut mode = app_state.recording_mode.lock().unwrap();
+            *mode = crate::RecordingMode::PushToTalk;
+        }
+        app_state
+            .ptt_key_held
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+
+        let mode_for_thread = app_state.recording_mode.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = mode_for_thread.lock().unwrap();
+            panic!("intentional poison for PTT guard recovery test");
+        })
+        .join();
+
+        assert!(
+            crate::commands::audio::ptt_key_released(&app_state),
+            "PTT guard should recover poisoned mode lock and still detect released key"
+        );
+    }
+
+    #[test]
     fn test_ptt_guard_allows_when_key_still_held() {
         let app_state = AppState::new();
 

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AppContainer } from './AppContainer';
 
@@ -56,7 +56,9 @@ vi.mock('@/services/updateService', () => ({
   updateService: {
     initialize: vi.fn().mockResolvedValue(true),
     dispose: vi.fn(),
-    getJustUpdatedVersion: () => mockGetJustUpdatedVersion()
+    getJustUpdatedVersion: () => mockGetJustUpdatedVersion(),
+    checkForUpdatesManually: vi.fn().mockResolvedValue(undefined),
+    requestNotificationPermission: vi.fn()
   }
 }));
 
@@ -67,9 +69,8 @@ vi.mock('@/components/onboarding/OnboardingDesktop', () => ({
 }));
 
 vi.mock('@/components/ui/sidebar', () => ({
-  Sidebar: ({ children, onSectionChange }: any) => (
-    <div data-testid="sidebar">
-      <button onClick={() => onSectionChange('models')}>Models</button>
+  Sidebar: ({ children, collapsible }: any) => (
+    <div data-testid="sidebar" data-collapsible={collapsible}>
       {children}
     </div>
   ),
@@ -94,10 +95,12 @@ vi.mock('./tabs/TabContainer', () => ({
     </div>
   )
 }));
-// Mock event coordinator
+
+// Captured mock for registerEvent so we can verify calls
+const mockRegisterEvent = vi.fn();
 vi.mock('@/hooks/useEventCoordinator', () => ({
   useEventCoordinator: () => ({
-    registerEvent: vi.fn()
+    registerEvent: mockRegisterEvent
   })
 }));
 
@@ -125,16 +128,72 @@ describe('AppContainer', () => {
     expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
   });
 
-  it('allows navigation between sections', () => {
-    // This test verifies the AppContainer renders and is interactive
-    // The actual navigation is tested through the Sidebar mock
+  it('renders sidebar as non-collapsible', () => {
     render(<AppContainer />);
-    
-    // Verify the app structure is in place
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveAttribute('data-collapsible', 'none');
+  });
+
+  it('keeps sidebar visible after Cmd+B keyboard shortcut', () => {
+    render(<AppContainer />);
+    // Simulate Cmd+B being pressed
+    fireEvent.keyDown(window, { key: 'b', metaKey: true });
+    // Sidebar must still be in the document
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+  });
+
+  it('navigate-to-settings event navigates to general tab', () => {
+    render(<AppContainer />);
+
+    // Find the registerEvent call for navigate-to-settings
+    const settingsCall = mockRegisterEvent.mock.calls.find(
+      (call: any[]) => call[0] === 'navigate-to-settings'
+    );
+    expect(settingsCall).toBeDefined();
+
+    // Invoke the handler
+    const handler = settingsCall![1];
+    act(() => handler());
+
+    // TabContainer should show 'general' tab
+    expect(screen.getByTestId('tab-container')).toHaveTextContent('Current Tab: general');
+  });
+
+  it('navigate-to-settings does not navigate to overview', () => {
+    render(<AppContainer />);
+
+    const settingsCall = mockRegisterEvent.mock.calls.find(
+      (call: any[]) => call[0] === 'navigate-to-settings'
+    );
+    expect(settingsCall).toBeDefined();
+
+    const handler = settingsCall![1];
+    act(() => handler());
+
+    expect(screen.getByTestId('tab-container')).not.toHaveTextContent('Current Tab: overview');
+  });
+
+  it('registerEvent is called once per event type on mount', () => {
+    render(<AppContainer />);
+
+    // Collect all event names registered
+    const eventNames = mockRegisterEvent.mock.calls.map((call: any[]) => call[0]);
+    const counts: Record<string, number> = {};
+    for (const name of eventNames) {
+      counts[name] = (counts[name] || 0) + 1;
+    }
+
+    // Each event should be registered exactly once
+    for (const [name, count] of Object.entries(counts)) {
+      expect(count, `Event '${name}' should be registered once`).toBe(1);
+    }
+  });
+
+  it('allows navigation between sections', () => {
+    render(<AppContainer />);
     expect(screen.getByTestId('sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('tab-container')).toBeInTheDocument();
   });
-
   describe('post-update modal', () => {
     it('shows update dialog when app was just updated', async () => {
       mockGetJustUpdatedVersion.mockReturnValue('1.13.0');
@@ -150,7 +209,6 @@ describe('AppContainer', () => {
       mockGetJustUpdatedVersion.mockReturnValue(null);
       render(<AppContainer />);
 
-      // Wait for initial render to settle
       await waitFor(() => {
         expect(screen.getByTestId('sidebar')).toBeInTheDocument();
       });
@@ -165,7 +223,6 @@ describe('AppContainer', () => {
         expect(screen.getByText('VoiceTypr Updated')).toBeInTheDocument();
       });
 
-      // Click the dismiss button inside the dialog
       const dismissBtn = screen.getByRole('button', { name: /^dismiss$/i });
       fireEvent.click(dismissBtn);
 

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -96,8 +96,9 @@ vi.mock('./tabs/TabContainer', () => ({
   )
 }));
 
-// Captured mock for registerEvent so we can verify calls
+// Captured mock for registerEvent so we can verify calls and cleanup
 const mockRegisterEvent = vi.fn();
+const mockUnlisteners: Array<ReturnType<typeof vi.fn>> = [];
 vi.mock('@/hooks/useEventCoordinator', () => ({
   useEventCoordinator: () => ({
     registerEvent: mockRegisterEvent
@@ -113,6 +114,12 @@ describe('AppContainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSettings.onboarding_completed = true;
+    mockUnlisteners.length = 0;
+    mockRegisterEvent.mockImplementation(() => {
+      const unlisten = vi.fn();
+      mockUnlisteners.push(unlisten);
+      return Promise.resolve(unlisten);
+    });
   });
 
   it('shows main app when onboarding is completed', () => {
@@ -186,6 +193,20 @@ describe('AppContainer', () => {
     // Each event should be registered exactly once
     for (const [name, count] of Object.entries(counts)) {
       expect(count, `Event '${name}' should be registered once`).toBe(1);
+    }
+  });
+
+  it('cleans up registered Tauri event listeners on unmount', async () => {
+    const { unmount } = render(<AppContainer />);
+
+    await waitFor(() => {
+      expect(mockUnlisteners).toHaveLength(6);
+    });
+
+    unmount();
+
+    for (const unlisten of mockUnlisteners) {
+      expect(unlisten).toHaveBeenCalledTimes(1);
     }
   });
 

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -200,7 +200,7 @@ describe('AppContainer', () => {
     const { unmount } = render(<AppContainer />);
 
     await waitFor(() => {
-      expect(mockUnlisteners).toHaveLength(6);
+      expect(mockUnlisteners).toHaveLength(mockRegisterEvent.mock.calls.length);
     });
 
     unmount();

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -47,7 +47,78 @@ export function AppContainer() {
   // Use a ref to track if we've just completed onboarding
   const hasJustCompletedOnboarding = useRef(false);
 
-  // Initialize app
+  // Register event listeners once — settings changes must not re-register
+  useEffect(() => {
+    // Listen for no-models event to redirect to onboarding
+    const handleNoModels = () => {
+      console.log("No models available - redirecting to onboarding");
+      setShowOnboarding(true);
+    };
+    window.addEventListener("no-models-available", handleNoModels);
+
+    // Listen for navigate-to-settings event from tray menu
+    registerEvent("navigate-to-settings", () => {
+      console.log("Navigate to settings requested from tray menu");
+      setActiveSection("general");
+    });
+
+    // Listen for manual update checks triggered from tray
+    registerEvent("tray-check-updates", async () => {
+      try {
+        await updateService.checkForUpdatesManually();
+      } catch (e) {
+        console.error("Manual update check failed:", e);
+        toast.error("Failed to check for updates");
+      }
+    });
+
+    // Listen for tray action errors
+    registerEvent("tray-action-error", (event) => {
+      console.error("Tray action error:", event.payload);
+      toast.error(event.payload as string);
+    });
+
+    registerEvent<string>("parakeet-unavailable", (message) => {
+      const description = typeof message === "string" && message.trim().length > 0
+        ? message
+        : "Parakeet is unavailable on this Mac. Please reinstall VoiceTypr or remove the quarantine flag.";
+      console.error("Parakeet unavailable:", description);
+      toast.error("Parakeet Unavailable", {
+        description,
+        duration: 8000
+      });
+    });
+
+    // Listen for license-required event and navigate to License section
+    registerEvent<{ title: string; message: string; action?: string }>(
+      "license-required", 
+      (data) => {
+        console.log("License required event received in AppContainer:", data);
+        setActiveSection("license");
+        toast.error(data.title || "License Required", {
+          description: data.message || "Please purchase or restore a license to continue",
+          duration: 5000
+        });
+      }
+    );
+
+    // Listen for no models error (when trying to record without any models)
+    registerEvent<ErrorEventPayload>("no-models-error", (data) => {
+      console.error("No models available:", data);
+      toast.error(data.title || 'No Models Available', {
+        description:
+          data.message ||
+          'Connect a cloud provider or download a local model in Models before recording.',
+        duration: 8000
+      });
+    });
+
+    return () => {
+      window.removeEventListener("no-models-available", handleNoModels);
+    };
+  }, [registerEvent]);
+
+  // Settings-dependent initialization (onboarding check, cleanup, update service)
   useEffect(() => {
     const init = async () => {
       try {
@@ -78,83 +149,17 @@ export function AppContainer() {
             // Window focus is best-effort; dialog still renders
           }
         }
-        // Listen for no-models event to redirect to onboarding
-        const handleNoModels = () => {
-          console.log("No models available - redirecting to onboarding");
-          setShowOnboarding(true);
-        };
-        window.addEventListener("no-models-available", handleNoModels);
-
-        // Listen for navigate-to-settings event from tray menu
-        registerEvent("navigate-to-settings", () => {
-          console.log("Navigate to settings requested from tray menu");
-          setActiveSection("overview");
-        });
-
-        // Listen for manual update checks triggered from tray
-        registerEvent("tray-check-updates", async () => {
-          try {
-            await updateService.checkForUpdatesManually();
-          } catch (e) {
-            console.error("Manual update check failed:", e);
-            toast.error("Failed to check for updates");
-          }
-        });
-
-        // Listen for tray action errors
-        registerEvent("tray-action-error", (event) => {
-          console.error("Tray action error:", event.payload);
-          toast.error(event.payload as string);
-        });
-
-        registerEvent<string>("parakeet-unavailable", (message) => {
-          const description = typeof message === "string" && message.trim().length > 0
-            ? message
-            : "Parakeet is unavailable on this Mac. Please reinstall VoiceTypr or remove the quarantine flag.";
-          console.error("Parakeet unavailable:", description);
-          toast.error("Parakeet Unavailable", {
-            description,
-            duration: 8000
-          });
-        });
-
-        // Listen for license-required event and navigate to License section
-        registerEvent<{ title: string; message: string; action?: string }>(
-          "license-required", 
-          (data) => {
-            console.log("License required event received in AppContainer:", data);
-            // Navigate to License section to show license management
-            setActiveSection("license");
-            // Show a toast to inform the user
-            toast.error(data.title || "License Required", {
-              description: data.message || "Please purchase or restore a license to continue",
-              duration: 5000
-            });
-          }
-        );
-
-        // Listen for no models error (when trying to record without any models)
-        registerEvent<ErrorEventPayload>("no-models-error", (data) => {
-          console.error("No models available:", data);
-          toast.error(data.title || 'No Models Available', {
-            description:
-              data.message ||
-              'Connect a cloud provider or download a local model in Models before recording.',
-            duration: 8000
-          });
-        });
-
-        return () => {
-          window.removeEventListener("no-models-available", handleNoModels);
-          updateService.dispose();
-        };
       } catch (error) {
         console.error("Failed to initialize:", error);
       }
     };
 
     init();
-  }, [registerEvent, settings]);
+
+    return () => {
+      updateService.dispose();
+    };
+  }, [settings]);
 
   // Mark when onboarding is being shown
   useEffect(() => {

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Sparkles } from "lucide-react";
@@ -49,6 +50,23 @@ export function AppContainer() {
 
   // Register event listeners once — settings changes must not re-register
   useEffect(() => {
+    const unlisteners: UnlistenFn[] = [];
+    let disposed = false;
+
+    const trackEvent = (unlistenPromise: Promise<UnlistenFn>) => {
+      void unlistenPromise
+        .then((unlisten) => {
+          if (disposed) {
+            unlisten();
+          } else {
+            unlisteners.push(unlisten);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to register app event listener:", error);
+        });
+    };
+
     // Listen for no-models event to redirect to onboarding
     const handleNoModels = () => {
       console.log("No models available - redirecting to onboarding");
@@ -57,28 +75,28 @@ export function AppContainer() {
     window.addEventListener("no-models-available", handleNoModels);
 
     // Listen for navigate-to-settings event from tray menu
-    registerEvent("navigate-to-settings", () => {
+    trackEvent(registerEvent("navigate-to-settings", () => {
       console.log("Navigate to settings requested from tray menu");
       setActiveSection("general");
-    });
+    }));
 
     // Listen for manual update checks triggered from tray
-    registerEvent("tray-check-updates", async () => {
+    trackEvent(registerEvent("tray-check-updates", async () => {
       try {
         await updateService.checkForUpdatesManually();
       } catch (e) {
         console.error("Manual update check failed:", e);
         toast.error("Failed to check for updates");
       }
-    });
+    }));
 
     // Listen for tray action errors
-    registerEvent("tray-action-error", (event) => {
+    trackEvent(registerEvent("tray-action-error", (event) => {
       console.error("Tray action error:", event.payload);
       toast.error(event.payload as string);
-    });
+    }));
 
-    registerEvent<string>("parakeet-unavailable", (message) => {
+    trackEvent(registerEvent<string>("parakeet-unavailable", (message) => {
       const description = typeof message === "string" && message.trim().length > 0
         ? message
         : "Parakeet is unavailable on this Mac. Please reinstall VoiceTypr or remove the quarantine flag.";
@@ -87,10 +105,10 @@ export function AppContainer() {
         description,
         duration: 8000
       });
-    });
+    }));
 
     // Listen for license-required event and navigate to License section
-    registerEvent<{ title: string; message: string; action?: string }>(
+    trackEvent(registerEvent<{ title: string; message: string; action?: string }>(
       "license-required", 
       (data) => {
         console.log("License required event received in AppContainer:", data);
@@ -100,10 +118,10 @@ export function AppContainer() {
           duration: 5000
         });
       }
-    );
+    ));
 
     // Listen for no models error (when trying to record without any models)
-    registerEvent<ErrorEventPayload>("no-models-error", (data) => {
+    trackEvent(registerEvent<ErrorEventPayload>("no-models-error", (data) => {
       console.error("No models available:", data);
       toast.error(data.title || 'No Models Available', {
         description:
@@ -111,10 +129,14 @@ export function AppContainer() {
           'Connect a cloud provider or download a local model in Models before recording.',
         duration: 8000
       });
-    });
+    }));
 
     return () => {
+      disposed = true;
       window.removeEventListener("no-models-available", handleNoModels);
+      for (const unlisten of unlisteners) {
+        unlisten();
+      }
     };
   }, [registerEvent]);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export function Sidebar({ activeSection, onSectionChange }: SidebarProps) {
   const daysLeft = status?.trial_days_left || -1;
 
   return (
-    <SidebarPrimitive >
+    <SidebarPrimitive collapsible="none">
       <SidebarContent className="px-2">
         <SidebarGroup className="flex-1">
           <SidebarMenu>

--- a/src/components/ui/sidebar.test.tsx
+++ b/src/components/ui/sidebar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarInset,
+  SidebarProvider,
+} from './sidebar';
+
+describe('sidebar layout', () => {
+  it('pins the fixed desktop layout to the viewport instead of page-scrolling', () => {
+    render(
+      <SidebarProvider>
+        <Sidebar collapsible="none">
+          <SidebarContent>
+            <div>Sidebar content</div>
+          </SidebarContent>
+          <SidebarFooter>Footer stays pinned</SidebarFooter>
+        </Sidebar>
+        <SidebarInset>
+          <div style={{ height: 4000 }}>Overflowing main content</div>
+        </SidebarInset>
+      </SidebarProvider>
+    );
+
+    const sidebar = screen.getByText('Sidebar content').closest('[data-slot="sidebar"]');
+    const sidebarContent = screen.getByText('Sidebar content').closest('[data-slot="sidebar-content"]');
+    const sidebarFooter = screen.getByText('Footer stays pinned').closest('[data-slot="sidebar-footer"]');
+    const inset = screen.getByText('Overflowing main content').closest('[data-slot="sidebar-inset"]');
+
+    expect(sidebar).toHaveClass('h-svh', 'shrink-0');
+    expect(sidebarContent).toHaveClass('flex-1', 'overflow-auto');
+    expect(sidebarFooter).not.toBeNull();
+    expect(sidebarFooter?.parentElement).toBe(sidebar);
+    expect(sidebarContent?.parentElement).toBe(sidebar);
+    expect(inset).toHaveClass('h-svh', 'overflow-hidden');
+  });
+});

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -132,7 +132,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex h-svh w-full overflow-hidden",
             className
           )}
           {...props}
@@ -163,7 +163,7 @@ function Sidebar({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          "bg-sidebar text-sidebar-foreground flex h-svh shrink-0 w-(--sidebar-width) flex-col",
           className
         )}
         {...props}
@@ -278,7 +278,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        "bg-background relative flex h-svh min-w-0 flex-1 flex-col overflow-hidden",
         "peer-data-[variant=inset]:m-2 peer-data-[variant=inset]:ml-0 peer-data-[variant=inset]:rounded-xl peer-data-[variant=inset]:shadow-sm peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
## Summary

Fixes three support-reported reliability and UX issues in one PR, with separate commits per fix cluster:

- hardens push-to-talk recording startup when license validation is slow or fails
- keeps Settings/sidebar navigation accessible instead of allowing the fixed desktop nav to disappear or scroll its footer away
- preserves expected sentence spacing when inserting transcribed text at the cursor

## What changed

### Recording / PTT startup
- Adds bounded license validation around recording startup instead of letting slow validation create confusing PTT behavior.
- Uses valid cached license evidence as bounded fallback only when appropriate.
- Handles PTT release-before-start as a clean abort instead of leaving the hotkey state in an error path.
- Propagates recorder stop failures when aborting after audio init has begun.
- Clears stale pending PTT stop state on start/abort paths so the next recording cannot be immediately stopped by a latched flag.

### Navigation
- Makes the fixed desktop sidebar non-collapsible so the main navigation cannot disappear without a visible restore path.
- Pins the app shell/sidebar to the viewport so the sidebar footer stays in place while content scrolls internally.
- Routes settings navigation events to the actual Settings tab instead of Overview.
- Reduces listener churn in `AppContainer` by splitting stable event registration from settings-dependent effects.

### Text insertion spacing
- Adds a trailing sentence space at insertion time for terminal punctuation.
- Keeps stored transcript/history content clean.
- Preserves explicit newlines/tabs and avoids adding spaces to URL/email/code-like endings.

## Review follow-up

- Oracle review found a stale `pending_stop_after_start` PTT latch blocker; fixed in the latest commit.
- Oracle re-check confirmed the blocker is fixed and found no new blockers.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` → 216 passed, 0 failed, 1 ignored
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings` → passed
- `pnpm vitest run src/components/ui/sidebar.test.tsx src/components/AppContainer.test.tsx src/components/tabs/TabContainer.test.tsx src/components/tabs/SettingsTab.test.tsx` → 17 tests passed
- `pnpm typecheck` → passed
- `pnpm lint` → passed

Note: the Vitest run still prints existing React `act(...)` warnings from `TabContainer.test.tsx`; tests pass.