### PR TITLE
feat: add auto-paste toggle

### DIFF
--- a/docs/plans/2026-04-27-001-feat-auto-paste-toggle-plan.md
+++ b/docs/plans/2026-04-27-001-feat-auto-paste-toggle-plan.md
@@ -1,0 +1,182 @@
+---
+title: feat: Add auto-paste toggle
+type: feat
+status: active
+date: 2026-04-27
+origin: https://github.com/moinulmoin/voicetypr/issues/74
+---
+
+# feat: Add auto-paste toggle
+
+## Overview
+
+Add a user-facing setting that controls whether VoiceTypr automatically inserts completed transcriptions into the focused app. The default remains enabled so existing users keep current behavior. When disabled, VoiceTypr should still complete transcription, run formatting, save history, and leave the transcript available in the clipboard for manual paste without sending paste keystrokes to the current focused window.
+
+## Problem Frame
+
+Issue #74 reports that long transcriptions can finish after the user has switched context, causing auto-paste to insert text into the wrong window. The first QoL improvement is a simple opt-out. Capturing the original app/control and retargeting insertion is intentionally out of scope because it requires cross-platform focus/accessibility design.
+
+## Requirements Trace
+
+- R1. Provide an app setting to activate/deactivate auto-paste.
+- R2. Preserve current default behavior: auto-paste remains enabled unless the user disables it.
+- R3. When auto-paste is disabled, do not paste into the active app after transcription finishes.
+- R4. When auto-paste is disabled, preserve the completed transcript for manual use and continue saving transcription history.
+- R5. Cover defaults, persistence, and insertion gating with targeted tests.
+
+## Scope Boundaries
+
+- Do not implement original-window/control retargeting in this change.
+- Do not change transcription, AI formatting, or history semantics except for the final auto-paste gate.
+- Do not change permission requirements beyond avoiding paste when auto-paste is disabled.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src-tauri/src/commands/settings.rs` owns persisted settings, defaults, `get_settings`, and `save_settings`.
+- `src/types.ts` mirrors `AppSettings` for frontend settings updates.
+- `src/components/sections/GeneralSettings.tsx` already has switch rows for recording preferences including `keep_transcription_in_clipboard`.
+- `src-tauri/src/commands/audio.rs` calls `crate::commands::text::insert_text` after transcription/formatting and before saving history.
+- `src-tauri/src/commands/text.rs` already has `copy_text_to_clipboard`, which copies without attempting paste.
+- `src-tauri/src/tests/settings_commands.rs` covers settings defaults and serialization.
+- `src/components/sections/__tests__/GeneralSettings.autostart.test.tsx` and `GeneralSettings.recording-indicator.test.tsx` show the General Settings testing pattern.
+
+### Institutional Learnings
+
+- `docs/solutions/` is not present in the tracked/current checkout, so no project learning doc was available for this feature.
+
+## Key Technical Decisions
+
+- Add a distinct `auto_paste_transcription` setting instead of reusing `keep_transcription_in_clipboard`; one controls paste side effects, the other controls clipboard restoration after paste.
+- Default `auto_paste_transcription` to `true` for backward compatibility.
+- Gate in the backend `audio.rs` completion path so all recording entry points share the same behavior.
+- When disabled, call `copy_text_to_clipboard(final_text)` instead of `insert_text(final_text)` so the transcript remains manually available without paste keystrokes.
+- Keep history saving after the gate unchanged.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should disabled auto-paste still copy to clipboard? Yes. The existing UI already frames clipboard retention/manual paste as a user workflow, and copying without paste directly addresses issue #74.
+
+### Deferred to Implementation
+
+- Exact toast wording when auto-paste is disabled: choose concise existing pill-toast style while editing `audio.rs`.
+
+## Implementation Units
+
+- [x] **Unit 1: Persist auto-paste preference**
+
+**Goal:** Add `auto_paste_transcription` to backend settings and frontend types.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src-tauri/src/commands/settings.rs`
+- Modify: `src/types.ts`
+- Test: `src-tauri/src/tests/settings_commands.rs`
+
+**Approach:**
+- Add the field to `Settings`, default it to `true`, read it from store with default fallback, and write it in `save_settings`.
+- Add the optional field to frontend `AppSettings`.
+- Update settings tests that construct `Settings` explicitly.
+
+**Patterns to follow:**
+- `keep_transcription_in_clipboard` in `src-tauri/src/commands/settings.rs`
+- existing default/serialization tests in `src-tauri/src/tests/settings_commands.rs`
+
+**Test scenarios:**
+- Happy path: default settings report `auto_paste_transcription == true`.
+- Serialization: explicit settings serialize/deserialize the field.
+
+**Verification:**
+- Backend settings tests compile and pass.
+
+- [x] **Unit 2: Add General Settings toggle**
+
+**Goal:** Expose the setting in the Recording section of General Settings.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/components/sections/GeneralSettings.tsx`
+- Test: `src/components/sections/__tests__/GeneralSettings.autostart.test.tsx` or a focused General Settings test file
+
+**Approach:**
+- Add a switch row near the clipboard-retention setting.
+- Use `settings.auto_paste_transcription ?? true` for checked state.
+- Persist updates through `updateSettings({ auto_paste_transcription: checked })`.
+
+**Patterns to follow:**
+- Switch rows for clipboard retention and recording sounds in `GeneralSettings.tsx`.
+
+**Test scenarios:**
+- Happy path: switch renders enabled by default when setting is absent/true.
+- Happy path: toggling off calls `save_settings` through the existing settings context update path with `auto_paste_transcription: false`.
+
+**Verification:**
+- General Settings targeted tests pass.
+
+- [x] **Unit 3: Gate backend insertion path**
+
+**Goal:** Prevent paste keystrokes when auto-paste is disabled while preserving clipboard/manual-use and history behavior.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src-tauri/src/commands/audio.rs`
+- Test: `src-tauri/src/tests/audio_commands.rs` if a focused unit test seam exists; otherwise cover by targeted compile/test and settings tests.
+
+**Approach:**
+- In the transcription completion path after formatting and UI stabilization, read settings via `get_settings(app_for_process.clone()).await`.
+- If `auto_paste_transcription` is true, keep the existing `insert_text` behavior and error toasts.
+- If false, call `copy_text_to_clipboard(final_text.clone()).await`, show a short pill toast indicating text was copied, and continue to history save.
+- On copy failure, show a paste/copy failure toast but still continue to history save.
+
+**Patterns to follow:**
+- Existing `insert_text` error handling in `src-tauri/src/commands/audio.rs`.
+- Existing `copy_text_to_clipboard` command in `src-tauri/src/commands/text.rs`.
+
+**Test scenarios:**
+- Integration/behavior: default enabled path still attempts insertion.
+- Integration/behavior: disabled path does not call insertion and leaves transcript copied for manual paste.
+- Error path: copy failure does not prevent history save.
+
+**Verification:**
+- Targeted Rust tests pass or, if the seam is too integration-heavy for a small change, backend tests compile and pass with explicit manual reasoning documented.
+
+## System-Wide Impact
+
+- **Interaction graph:** Recording completion -> optional AI formatting -> pill hide -> auto-paste/copy gate -> history save.
+- **Error propagation:** Paste/copy errors surface as pill toasts and must not abort history persistence.
+- **State lifecycle risks:** Setting is persisted in the existing Tauri store; default fallback protects older stores.
+- **API surface parity:** Frontend `AppSettings` must match backend `Settings` for `save_settings` payloads.
+- **Integration coverage:** The backend gate is the important shared seam because hotkey recording and any recording completion path flow through `audio.rs`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Conflating clipboard retention with auto-paste | Add a separate setting with explicit naming and UI copy. |
+| Disabled auto-paste loses transcript | Copy transcript to clipboard and preserve history save. |
+| Existing users lose current workflow | Default new setting to `true`. |
+| Tests rely on stale settings fixtures | Update explicit settings objects in frontend/backend tests. |
+
+## Documentation / Operational Notes
+
+- Reference issue #74 in commit/PR summary.
+- No release workflow or migration changes required.
+
+## Sources & References
+
+- Origin issue: https://github.com/moinulmoin/voicetypr/issues/74
+- Related settings code: `src-tauri/src/commands/settings.rs`
+- Related insertion code: `src-tauri/src/commands/audio.rs`, `src-tauri/src/commands/text.rs`
+- Related UI code: `src/components/sections/GeneralSettings.tsx`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7674,7 +7674,7 @@ dependencies = [
 
 [[package]]
 name = "voicetypr"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -2061,32 +2061,59 @@ pub async fn stop_recording(
                     // Reduced delay to ensure UI is stable (was 100ms, now 50ms)
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-                    // Now handle text insertion with stable UI
-                    match crate::commands::text::insert_text(
-                        app_for_process.clone(),
-                        final_text.clone(),
-                    )
-                    .await
-                    {
-                        Ok(_) => log::debug!("Text inserted at cursor successfully"),
-                        Err(e) => {
-                            log::error!("Failed to insert text: {}", e);
+                    // Now handle text insertion or clipboard copy based on auto_paste_transcription.
+                    // Missing setting keys default inside get_settings; actual settings-read failures fail closed
+                    // to avoid surprising paste into the wrong app.
+                    let auto_paste = match get_settings(app_for_process.clone()).await {
+                        Ok(settings) => settings.auto_paste_transcription,
+                        Err(error) => {
+                            log::error!("Failed to read auto-paste setting: {}", error);
+                            false
+                        }
+                    };
 
-                            // Check if it's an accessibility permission issue
-                            if e.contains("accessibility") || e.contains("permission") {
-                                // Show pill toast for accessibility permission error
-                                pill_toast(
-                                    &app_for_process,
-                                    "Text copied - grant permission to auto-paste",
-                                    1500,
-                                );
-                            } else {
-                                // Generic paste error
-                                pill_toast(
-                                    &app_for_process,
-                                    "Paste failed - text in clipboard",
-                                    1500,
-                                );
+                    if auto_paste {
+                        // Auto-paste enabled: insert text at cursor
+                        match crate::commands::text::insert_text(
+                            app_for_process.clone(),
+                            final_text.clone(),
+                        )
+                        .await
+                        {
+                            Ok(_) => log::debug!("Text inserted at cursor successfully"),
+                            Err(e) => {
+                                log::error!("Failed to insert text: {}", e);
+
+                                // Check if it's an accessibility permission issue
+                                if e.contains("accessibility") || e.contains("permission") {
+                                    // Show pill toast for accessibility permission error
+                                    pill_toast(
+                                        &app_for_process,
+                                        "Text copied - grant permission to auto-paste",
+                                        1500,
+                                    );
+                                } else {
+                                    // Generic paste error
+                                    pill_toast(
+                                        &app_for_process,
+                                        "Paste failed - text in clipboard",
+                                        1500,
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        // Auto-paste disabled: copy to clipboard and notify
+                        match crate::commands::text::copy_text_to_clipboard(final_text.clone())
+                            .await
+                        {
+                            Ok(_) => {
+                                log::debug!("Text copied to clipboard (auto-paste disabled)");
+                                pill_toast(&app_for_process, "Transcription copied", 1500);
+                            }
+                            Err(e) => {
+                                log::error!("Failed to copy text to clipboard: {}", e);
+                                pill_toast(&app_for_process, "Copy failed", 1500);
                             }
                         }
                     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -45,6 +45,8 @@ pub struct Settings {
     pub pill_indicator_offset: u32,
     // Pause system media during recording
     pub pause_media_during_recording: bool,
+    // Automatically paste transcription text into the active window
+    pub auto_paste_transcription: bool,
 }
 
 impl Default for Settings {
@@ -72,6 +74,7 @@ impl Default for Settings {
             pill_indicator_position: "bottom-center".to_string(), // Default to bottom center of screen
             pill_indicator_offset: DEFAULT_INDICATOR_OFFSET,
             pause_media_during_recording: !cfg!(target_os = "macos"),
+            auto_paste_transcription: true, // Default to auto-pasting transcription
         }
     }
 }
@@ -243,6 +246,10 @@ pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
             .get("pause_media_during_recording")
             .and_then(|v| v.as_bool())
             .unwrap_or_else(|| Settings::default().pause_media_during_recording),
+        auto_paste_transcription: store
+            .get("auto_paste_transcription")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_else(|| Settings::default().auto_paste_transcription),
     };
 
     Ok(settings)
@@ -336,6 +343,10 @@ pub async fn save_settings(app: AppHandle, settings: Settings) -> Result<(), Str
     store.set(
         "pause_media_during_recording",
         json!(settings.pause_media_during_recording),
+    );
+    store.set(
+        "auto_paste_transcription",
+        json!(settings.auto_paste_transcription),
     );
 
     // Save pill position if provided

--- a/src-tauri/src/tests/settings_commands.rs
+++ b/src-tauri/src/tests/settings_commands.rs
@@ -15,6 +15,7 @@ mod tests {
         assert_eq!(settings.launch_at_startup, false);
         assert_eq!(settings.onboarding_completed, false);
         assert_eq!(settings.check_updates_automatically, true); // Default to true
+        assert_eq!(settings.auto_paste_transcription, true); // Default to true
     }
 
     #[test]
@@ -42,6 +43,7 @@ mod tests {
             pill_indicator_position: "bottom-center".to_string(),
             pill_indicator_offset: 10,
             pause_media_during_recording: true,
+            auto_paste_transcription: true,
         };
 
         // Test serialization
@@ -51,6 +53,7 @@ mod tests {
         assert!(json.contains("\"language\":\"es\""));
         assert!(json.contains("\"theme\":\"dark\""));
         assert!(json.contains("\"transcription_cleanup_days\":7"));
+        assert!(json.contains("\"auto_paste_transcription\":true"));
 
         // Test deserialization
         let deserialized: Settings = serde_json::from_str(&json).unwrap();
@@ -61,6 +64,10 @@ mod tests {
         assert_eq!(
             deserialized.transcription_cleanup_days,
             settings.transcription_cleanup_days
+        );
+        assert_eq!(
+            deserialized.auto_paste_transcription,
+            settings.auto_paste_transcription
         );
     }
 
@@ -105,6 +112,7 @@ mod tests {
             pill_indicator_position: "top-center".to_string(),
             pill_indicator_offset: 25,
             pause_media_during_recording: true,
+            auto_paste_transcription: true,
         };
 
         let cloned = settings.clone();

--- a/src/components/sections/GeneralSettings.tsx
+++ b/src/components/sections/GeneralSettings.tsx
@@ -328,6 +328,29 @@ export function GeneralSettings() {
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
                   <Label
+                    htmlFor="auto-paste-transcription"
+                    className="text-sm font-medium"
+                  >
+                    Auto-Paste Transcript
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Insert completed text automatically; turn off to copy for manual paste
+                  </p>
+                </div>
+                <Switch
+                  id="auto-paste-transcription"
+                  checked={settings.auto_paste_transcription ?? true}
+                  onCheckedChange={async (checked) =>
+                    await updateSettings({
+                      auto_paste_transcription: checked,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label
                     htmlFor="sound-on-recording"
                     className="text-sm font-medium"
                   >

--- a/src/components/sections/__tests__/GeneralSettings.auto-paste.test.tsx
+++ b/src/components/sections/__tests__/GeneralSettings.auto-paste.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GeneralSettings } from '../GeneralSettings';
+import type { AppSettings } from '@/types';
+
+const mockUpdateSettings = vi.fn().mockResolvedValue(undefined);
+const mockInvoke = vi.fn().mockResolvedValue(false);
+
+const baseSettings: AppSettings = {
+  recording_mode: 'toggle',
+  hotkey: 'CommandOrControl+Shift+Space',
+  current_model: '',
+  language: 'en',
+  theme: 'system',
+  keep_transcription_in_clipboard: false,
+  play_sound_on_recording: true,
+  pill_indicator_mode: 'when_recording',
+  pill_indicator_position: 'bottom-center',
+  pill_indicator_offset: 10,
+};
+
+let mockSettings: AppSettings = { ...baseSettings };
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    settings: mockSettings,
+    updateSettings: mockUpdateSettings,
+  }),
+}));
+
+vi.mock('@/contexts/ReadinessContext', () => ({
+  useCanAutoInsert: () => true,
+}));
+
+vi.mock('@/lib/platform', () => ({
+  isMacOS: false,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-autostart', () => ({
+  enable: vi.fn(),
+  disable: vi.fn(),
+  isEnabled: vi.fn(),
+}));
+
+vi.mock('@/components/HotkeyInput', () => ({
+  HotkeyInput: () => <div data-testid="hotkey-input" />,
+}));
+
+vi.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: any }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    disabled,
+    id,
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+    disabled?: boolean;
+    id?: string;
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={id}
+      data-testid={id}
+      data-disabled={disabled}
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+}));
+
+vi.mock('@/components/ui/toggle-group', () => ({
+  ToggleGroup: ({ children }: { children: any }) => <div>{children}</div>,
+  ToggleGroupItem: ({ children }: { children: any }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: any;
+    value?: string;
+    onValueChange?: (v: string) => void;
+  }) => (
+    <div
+      data-testid="select"
+      data-value={value}
+      onClick={() => onValueChange?.('top-center')}
+    >
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }: { children: any }) => (
+    <div data-testid="select-trigger">{children}</div>
+  ),
+  SelectContent: ({ children }: { children: any }) => <div>{children}</div>,
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: any;
+    value: string;
+  }) => <div data-testid={`select-item-${value}`}>{children}</div>,
+  SelectValue: () => <div data-testid="select-value" />,
+}));
+
+vi.mock('@/components/MicrophoneSelection', () => ({
+  MicrophoneSelection: () => <div data-testid="microphone-selection" />,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+describe('GeneralSettings auto-paste-transcription switch', () => {
+  beforeEach(() => {
+    mockSettings = { ...baseSettings };
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue(false);
+  });
+
+  it('defaults to enabled when setting is missing', async () => {
+    // baseSettings has no auto_paste_transcription field
+    render(<GeneralSettings />);
+
+    const sw = screen.getByRole('switch', {
+      name: 'auto-paste-transcription',
+    });
+    expect(sw).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('reflects explicit false value', async () => {
+    mockSettings = { ...baseSettings, auto_paste_transcription: false };
+
+    render(<GeneralSettings />);
+
+    const sw = screen.getByRole('switch', {
+      name: 'auto-paste-transcription',
+    });
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls updateSettings with false when toggled off', async () => {
+    // Missing field → defaults true → toggle sends false
+    render(<GeneralSettings />);
+
+    const sw = screen.getByRole('switch', {
+      name: 'auto-paste-transcription',
+    });
+    fireEvent.click(sw);
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        auto_paste_transcription: false,
+      });
+    });
+  });
+
+  it('calls updateSettings with true when toggled on from explicit false', async () => {
+    mockSettings = { ...baseSettings, auto_paste_transcription: false };
+
+    render(<GeneralSettings />);
+
+    const sw = screen.getByRole('switch', {
+      name: 'auto-paste-transcription',
+    });
+    fireEvent.click(sw);
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        auto_paste_transcription: true,
+      });
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface AppSettings {
   use_different_ptt_key?: boolean;
   ptt_hotkey?: string;
   current_model_engine?: 'whisper' | 'parakeet' | 'soniox';
+  auto_paste_transcription?: boolean;
   keep_transcription_in_clipboard?: boolean;
   // Audio feedback
   play_sound_on_recording?: boolean;


### PR DESCRIPTION
## Summary

- Adds an `auto_paste_transcription` setting that defaults to enabled for existing behavior.
- Adds an Auto-Paste Transcript switch in General Settings so users can disable automatic insertion.
- Gates the backend transcription completion path: enabled still inserts at cursor; disabled copies the transcript for manual paste and still saves history.
- Fails closed to clipboard copy if settings cannot be read, avoiding surprise paste into the wrong app.

Closes #74.

## Verification

- `pnpm vitest run src/components/sections/__tests__/GeneralSettings.auto-paste.test.tsx`
- `pnpm typecheck`
- `cargo test settings_commands`
- `cargo test audio_commands`
- `pnpm lint`
- `cargo clippy -- -D warnings`
- `pnpm quality-gate`

Note: `pnpm quality-gate` still prints existing noisy stderr from error-boundary/enhancement tests, but completed successfully.

## Review

- Backend review found one P2 fail-open fallback risk; fixed by failing closed to clipboard copy on settings-read errors.
- Second backend review: clean.
- Frontend review: clean.
