### PR TITLE
fix: require confirmation for updater installs

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -83,7 +83,7 @@
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE2Q0M5NTZENjAwM0YyNDkKUldSSjhnTmdiWlhNRm0wdHQ1YmxNSzBWS2tiZlcyZ3FJZG5FajZ3MFBzTUZmRDgvZys5R1J6c2cK",
       "windows": {
-        "installMode": "passive"
+        "installMode": "basicUi"
       }
     }
   }

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -82,7 +82,7 @@
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE2Q0M5NTZENjAwM0YyNDkKUldSSjhnTmdiWlhNRm0wdHQ1YmxNSzBWS2tiZlcyZ3FJZG5FajZ3MFBzTUZmRDgvZys5R1J6c2cK",
       "windows": {
-        "installMode": "passive"
+        "installMode": "basicUi"
       }
     }
   }

--- a/src/services/updateService.test.ts
+++ b/src/services/updateService.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { ask } from '@tauri-apps/plugin-dialog';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { check, type Update } from '@tauri-apps/plugin-updater';
 
 // Mock Tauri plugins before importing the module under test
 vi.mock('@tauri-apps/plugin-updater', () => ({
@@ -36,6 +40,21 @@ import { UpdateService } from './updateService';
 
 const JUST_UPDATED_KEY = 'just_updated_version';
 
+
+type TestUpdate = Update & {
+  downloadAndInstall: ReturnType<typeof vi.fn>;
+};
+
+function createAvailableUpdate(): TestUpdate {
+  return {
+    available: true,
+    currentVersion: '1.0.0',
+    version: '1.2.3',
+    body: 'Security and reliability fixes',
+    rawJson: {},
+    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TestUpdate;
+}
 describe('UpdateService version marker', () => {
   let service: UpdateService;
 
@@ -95,5 +114,38 @@ describe('UpdateService version marker', () => {
 
     const result = freshService.getJustUpdatedVersion();
     expect(result).toBe('1.12.1');
+  });
+
+  it('asks before installing an update found during a background check', async () => {
+    const update = createAvailableUpdate();
+    vi.mocked(check).mockResolvedValue(update);
+    vi.mocked(ask).mockResolvedValue(false);
+
+    await service.checkForUpdatesInBackground();
+
+    expect(ask).toHaveBeenCalledWith(
+      expect.stringContaining('Update 1.2.3 is available'),
+      expect.objectContaining({
+        title: 'Update Available',
+        okLabel: 'Update',
+        cancelLabel: 'Later',
+      }),
+    );
+    expect(update.downloadAndInstall).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it('installs a background update only after explicit confirmation', async () => {
+    const update = createAvailableUpdate();
+    vi.mocked(check).mockResolvedValue(update);
+    vi.mocked(ask).mockResolvedValue(true);
+    vi.mocked(invoke).mockResolvedValue({ state: 'idle' });
+    vi.mocked(relaunch).mockResolvedValue(undefined);
+
+    await service.checkForUpdatesInBackground();
+
+    expect(update.downloadAndInstall).toHaveBeenCalledOnce();
+    expect(relaunch).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(JUST_UPDATED_KEY)).toBe('1.2.3');
   });
 });

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -92,7 +92,7 @@ export class UpdateService {
   /**
    * Initialize the update service
    * - Checks for updates on startup if enabled
-   * - Sets up daily update checks
+   * - Never downloads or installs an update until the user confirms
    */
   async initialize(settings: AppSettings): Promise<void> {
     // Check if automatic updates are enabled (default to true if not set)
@@ -153,9 +153,9 @@ export class UpdateService {
   }
 
   /**
-   * Check for updates in the background and auto-install if available.
-   * Shows progress toasts during download/install, then relaunches the app.
-   * Runs on startup and daily when automatic updates are enabled.
+   * Check for updates in the background.
+   * If an update is available, ask the user before downloading or installing.
+   * Runs on startup and daily when automatic update checks are enabled.
    */
   async checkForUpdatesInBackground(): Promise<void> {
     if (this.checkInProgress) {
@@ -184,7 +184,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update, true);
+        await this.handleUpdateAvailable(update);
       }
     } catch (error) {
       console.error('Background update check failed:', error);
@@ -213,7 +213,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update, false);
+        await this.handleUpdateAvailable(update);
       } else {
         toast.success("You're on the latest version!");
       }
@@ -228,71 +228,8 @@ export class UpdateService {
   /**
    * Handle when an update is available
    */
-  private async handleUpdateAvailable(update: Update, isBackgroundCheck: boolean): Promise<void> {
-    if (isBackgroundCheck) {
-      // For background checks, auto-install silently
-      await this.autoInstallUpdate(update);
-    } else {
-      // For manual checks, show dialog to let user decide
-      await this.showUpdateDialog(update);
-    }
-  }
-
-  /**
-   * Auto-install update silently with progress feedback
-   */
-  private async autoInstallUpdate(update: Update, retryCount = 0): Promise<void> {
-    const MAX_RETRIES = 3;
-    const RETRY_DELAY = 30000; // 30 seconds
-
-    // Defer auto-update if user is in active session (recording/transcribing)
-    if (this.isSessionActive) {
-      if (retryCount < MAX_RETRIES) {
-        console.log(`Deferring auto-update - session active (retry ${retryCount + 1}/${MAX_RETRIES} in 30s)`);
-        setTimeout(() => this.autoInstallUpdate(update, retryCount + 1), RETRY_DELAY);
-        return;
-      }
-      console.log('Skipping auto-update - session still active after max retries');
-      return;
-    }
-
-    const toastId = 'update-progress';
-    
-    try {
-      await update.downloadAndInstall((event) => {
-        if (event.event === 'Started') {
-          toast.info(`Downloading update ${update.version}...`, { 
-            id: toastId,
-            duration: Infinity 
-          });
-        } else if (event.event === 'Finished') {
-          toast.success('Update ready, restarting...', { 
-            id: toastId,
-            duration: Infinity 
-          });
-        }
-      });
-    } catch (error) {
-      console.error('Auto-update failed:', error);
-      toast.error('Update failed. You can try again from Settings > About.', { 
-        id: toastId,
-        duration: 5000 
-      });
-      return;
-    }
-
-    // Re-check session state before relaunch (user may have started recording during download)
-    if (this.isSessionActive) {
-      console.log('Update downloaded but session active - will relaunch when session ends');
-      this.pendingRelaunch = true;
-      this.pendingUpdateVersion = update.version;
-      toast.dismiss(toastId);
-      await this.sendSystemNotification('Update Ready', 'VoiceTypr will restart when recording ends');
-      return;
-    }
-
-    this.pendingUpdateVersion = update.version;
-    await this.performRelaunch();
+  private async handleUpdateAvailable(update: Update): Promise<void> {
+    await this.showUpdateDialog(update);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes #80 by changing background update checks to ask before downloading/installing.
- Fixes #81 by switching Windows updater installs from passive to basic UI so the installer can request elevation when needed.
- Adds UpdateService regression tests covering background update consent.

## Verification
- `pnpm test -- src/services/updateService.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- JSON parse for `src-tauri/tauri.conf.json` and `src-tauri/tauri.dev.conf.json`
- `git diff --check`