### PR TITLE
feat: add hotkey diagnostics support

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,7 +3,8 @@ use crate::commands::key_normalizer::{normalize_shortcut_keys, validate_key_comb
 use crate::parakeet::ParakeetManager;
 use crate::whisper::languages::{validate_language, SUPPORTED_LANGUAGES};
 use crate::whisper::manager::WhisperManager;
-use crate::AppState;
+use crate::{AppState, RecordingState};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::{AppHandle, Emitter, Manager};
@@ -623,11 +624,14 @@ pub async fn set_global_shortcut(app: AppHandle, shortcut: String) -> Result<(),
     // Register new shortcut immediately
     log::debug!("Registering new shortcut: {}", normalized_shortcut);
 
+    app_state.record_primary_registration_attempt();
+
     // Attempt registration - according to docs, ANY error means hotkey won't work
     let registration_result = shortcuts.register(new_shortcut);
 
     match registration_result {
         Ok(_) => {
+            app_state.record_primary_registration_success();
             log::info!("Successfully registered hotkey: {}", normalized_shortcut);
             // Hotkey registered successfully, no conflicts
         }
@@ -652,11 +656,32 @@ pub async fn set_global_shortcut(app: AppHandle, shortcut: String) -> Result<(),
                 format!("Failed to register hotkey: {}", e)
             };
 
+            if let Some(old) = old_shortcut {
+                match shortcuts.register(old) {
+                    Ok(_) => {
+                        app_state.record_primary_registration_success();
+                        log::info!("Restored previous hotkey after failed update");
+                    }
+                    Err(restore_err) => {
+                        log::error!(
+                            "Failed to restore previous hotkey after update failure: {}",
+                            restore_err
+                        );
+                        app_state.record_primary_registration_failure(format!(
+                            "Failed to register new hotkey: {}; failed to restore previous hotkey: {}",
+                            error_msg, restore_err
+                        ));
+                    }
+                }
+            } else {
+                app_state.record_primary_registration_failure(error_msg);
+            }
+
             return Err(detailed_error);
         }
     }
 
-    // Update the recording shortcut in managed state regardless of registration warnings
+    // Update the recording shortcut in managed state after successful registration.
     match app_state.recording_shortcut.lock() {
         Ok(mut shortcut_guard) => {
             *shortcut_guard = Some(new_shortcut);
@@ -685,6 +710,80 @@ pub async fn set_global_shortcut(app: AppHandle, shortcut: String) -> Result<(),
     log::info!("Successfully updated global shortcut to: {}", shortcut);
 
     Ok(())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HotkeyDiagnosticsResponse {
+    pub configured_hotkey: String,
+    pub normalized_hotkey: String,
+    pub recording_mode: String,
+    pub use_different_ptt_key: bool,
+    pub ptt_hotkey: Option<String>,
+    pub normalized_ptt_hotkey: Option<String>,
+    pub registration_status: String,
+    pub registration_error: Option<String>,
+    pub last_registration_attempt_at: Option<String>,
+    pub last_successful_registration_at: Option<String>,
+    pub last_event_at: Option<String>,
+    pub last_event_kind: Option<String>,
+    pub last_event_state: Option<String>,
+    pub event_count: u64,
+    pub current_recording_state: String,
+    pub generated_at: String,
+    pub is_registered: Option<bool>,
+}
+
+fn recording_state_label(state: RecordingState) -> &'static str {
+    match state {
+        RecordingState::Idle => "idle",
+        RecordingState::Starting => "starting",
+        RecordingState::Recording => "recording",
+        RecordingState::Stopping => "stopping",
+        RecordingState::Transcribing => "transcribing",
+        RecordingState::Error => "error",
+    }
+}
+
+#[tauri::command]
+pub async fn get_hotkey_diagnostics(app: AppHandle) -> Result<HotkeyDiagnosticsResponse, String> {
+    let settings = get_settings(app.clone()).await?;
+    let normalized_hotkey = normalize_shortcut_keys(&settings.hotkey);
+    let normalized_ptt_hotkey = settings
+        .ptt_hotkey
+        .as_ref()
+        .map(|hotkey| normalize_shortcut_keys(hotkey));
+
+    let app_state = app.state::<AppState>();
+    let diagnostics = app_state.primary_hotkey_diagnostics_snapshot();
+    let current_recording_state = recording_state_label(app_state.get_current_state()).to_string();
+
+    let is_registered = app_state
+        .recording_shortcut
+        .lock()
+        .ok()
+        .and_then(|guard| *guard)
+        .map(|shortcut| app.global_shortcut().is_registered(shortcut));
+
+    Ok(HotkeyDiagnosticsResponse {
+        configured_hotkey: settings.hotkey,
+        normalized_hotkey,
+        recording_mode: settings.recording_mode,
+        use_different_ptt_key: settings.use_different_ptt_key,
+        ptt_hotkey: settings.ptt_hotkey,
+        normalized_ptt_hotkey,
+        registration_status: diagnostics.registration_status.as_str().to_string(),
+        registration_error: diagnostics.registration_error,
+        last_registration_attempt_at: diagnostics.last_registration_attempt_at,
+        last_successful_registration_at: diagnostics.last_successful_registration_at,
+        last_event_at: diagnostics.last_event_at,
+        last_event_kind: diagnostics.last_event_kind,
+        last_event_state: diagnostics.last_event_state,
+        event_count: diagnostics.event_count,
+        current_recording_state,
+        generated_at: Utc::now().to_rfc3339(),
+        is_registered,
+    })
 }
 
 #[derive(Serialize)]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -29,6 +29,7 @@ pub struct Settings {
     pub launch_at_startup: bool,
     pub onboarding_completed: bool,
     pub check_updates_automatically: bool,
+    pub install_updates_automatically: bool,
     pub selected_microphone: Option<String>,
     // Push-to-talk support
     pub recording_mode: String, // "toggle" or "push_to_talk"
@@ -64,6 +65,7 @@ impl Default for Settings {
             launch_at_startup: false,         // Default to not launching at startup
             onboarding_completed: false,      // Default to not completed
             check_updates_automatically: true, // Default to automatic updates enabled
+            install_updates_automatically: false, // Never install updates without explicit opt-in
             selected_microphone: None,        // Default to system default microphone
             recording_mode: "toggle".to_string(), // Default to toggle mode for backward compatibility
             use_different_ptt_key: false,         // Default to using same key
@@ -200,6 +202,10 @@ pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
             .get("check_updates_automatically")
             .and_then(|v| v.as_bool())
             .unwrap_or_else(|| Settings::default().check_updates_automatically),
+        install_updates_automatically: store
+            .get("install_updates_automatically")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_else(|| Settings::default().install_updates_automatically),
         selected_microphone: store
             .get("selected_microphone")
             .and_then(|v| v.as_str().map(|s| s.to_string())),
@@ -306,6 +312,10 @@ pub async fn save_settings(app: AppHandle, settings: Settings) -> Result<(), Str
     store.set(
         "check_updates_automatically",
         json!(settings.check_updates_automatically),
+    );
+    store.set(
+        "install_updates_automatically",
+        json!(settings.install_updates_automatically),
     );
     store.set("selected_microphone", json!(settings.selected_microphone));
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -659,7 +659,9 @@ pub async fn set_global_shortcut(app: AppHandle, shortcut: String) -> Result<(),
             if let Some(old) = old_shortcut {
                 match shortcuts.register(old) {
                     Ok(_) => {
-                        app_state.record_primary_registration_success();
+                        app_state.record_primary_registration_restored_after_failure(
+                            detailed_error.clone(),
+                        );
                         log::info!("Restored previous hotkey after failed update");
                     }
                     Err(restore_err) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -714,6 +714,12 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                         Ok(default_shortcut) => default_shortcut,
                         Err(e) => {
                             log::error!("Even default shortcut failed to parse: {}", e);
+                            let app_state = app.state::<AppState>();
+                            app_state.record_primary_registration_attempt();
+                            app_state.record_primary_registration_failure(format!(
+                                "Failed to parse default shortcut: {}",
+                                e
+                            ));
                             // Emit event to notify frontend that hotkey registration failed
                             if let Some(window) = app.get_webview_window("main") {
                                 let _ = window.emit("hotkey-registration-failed", ());
@@ -732,6 +738,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Try to register global shortcut with panic protection
+            app_state.record_primary_registration_attempt();
             let registration_start = Instant::now();
             let registration_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 app.global_shortcut().register(shortcut)
@@ -739,6 +746,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             match registration_result {
                 Ok(Ok(_)) => {
+                    app_state.record_primary_registration_success();
                     log_complete("HOTKEY_REGISTRATION", registration_start.elapsed().as_millis() as u64);
                     log_with_context(log::Level::Debug, "Hotkey registered", &[
                         ("hotkey", &hotkey_str),
@@ -747,6 +755,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                     log::info!("✅ Successfully registered global hotkey: {}", hotkey_str);
                 }
                 Ok(Err(e)) => {
+                    app_state.record_primary_registration_failure(e.to_string());
                     log_failed("HOTKEY_REGISTRATION", &e.to_string());
                     log_with_context(log::Level::Debug, "Hotkey registration failed", &[
                         ("hotkey", &hotkey_str),
@@ -775,6 +784,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                         "Unknown panic during hotkey registration".to_string()
                     };
 
+                    app_state.record_primary_registration_failure(panic_msg.clone());
                     log::error!("💥 PANIC during hotkey registration: {}", panic_msg);
                     log::warn!("⚠️  Continuing without global hotkey due to panic");
 
@@ -1056,6 +1066,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             set_audio_device,
             validate_microphone_selection,
             set_global_shortcut,
+            get_hotkey_diagnostics,
             get_supported_languages,
             set_model_from_tray,
             update_tray_menu,

--- a/src-tauri/src/recording/hotkeys.rs
+++ b/src-tauri/src/recording/hotkeys.rs
@@ -65,6 +65,17 @@ pub fn handle_global_shortcut(
     };
 
     if should_handle {
+        let event_state_label = match event_state {
+            ShortcutState::Pressed => "pressed",
+            ShortcutState::Released => "released",
+        };
+        let event_kind = if is_ptt_shortcut && !is_recording_shortcut {
+            "ptt"
+        } else {
+            "recording"
+        };
+        app_state.record_handled_hotkey_event(event_kind, event_state_label);
+
         let current_state = get_recording_state(app);
         handle_recording_shortcut(app, &app_state, recording_mode, current_state, event_state);
     } else if !is_recording_shortcut && !is_ptt_shortcut {

--- a/src-tauri/src/recording/hotkeys.rs
+++ b/src-tauri/src/recording/hotkeys.rs
@@ -3,7 +3,7 @@ use crate::commands::audio::{
 };
 use crate::recording::escape_handler::handle_escape_key_press;
 use crate::{get_recording_state, update_recording_state, AppState, RecordingMode, RecordingState};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
 use tauri_plugin_global_shortcut::{Shortcut, ShortcutState};
 
@@ -177,6 +177,10 @@ fn handle_toggle_mode(
     }
 }
 
+fn claim_ptt_press(ptt_key_held: &AtomicBool) -> bool {
+    !ptt_key_held.swap(true, Ordering::SeqCst)
+}
+
 /// Handle push-to-talk mode recording (hold to record, release to stop)
 fn handle_ptt_mode(
     app: &tauri::AppHandle,
@@ -187,7 +191,11 @@ fn handle_ptt_mode(
     match event_state {
         ShortcutState::Pressed => {
             log::info!("PTT: Key pressed");
-            app_state.ptt_key_held.store(true, Ordering::Relaxed);
+
+            if !claim_ptt_press(&app_state.ptt_key_held) {
+                log::debug!("PTT: Ignoring duplicate key press");
+                return;
+            }
 
             if matches!(current_state, RecordingState::Idle | RecordingState::Error) {
                 log::info!("PTT: Starting recording");
@@ -281,5 +289,22 @@ fn handle_non_recording_shortcut(
             let app_state = app_handle.state::<AppState>();
             handle_escape_key_press(&app_state, &app_handle, event_state).await;
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::claim_ptt_press;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn claim_ptt_press_allows_only_first_press_until_release() {
+        let held = AtomicBool::new(false);
+
+        assert!(claim_ptt_press(&held));
+        assert!(!claim_ptt_press(&held));
+
+        held.store(false, Ordering::SeqCst);
+        assert!(claim_ptt_press(&held));
     }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use chrono::Utc;
 use tauri::{Emitter, Manager};
 
 use crate::state::unified_state::UnifiedRecordingState;
@@ -25,6 +26,38 @@ pub enum RecordingState {
 pub enum RecordingMode {
     Toggle,
     PushToTalk,
+}
+
+/// Primary recording hotkey registration outcome tracked at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PrimaryHotkeyRegistrationStatus {
+    #[default]
+    Unknown,
+    Registered,
+    Failed,
+}
+
+impl PrimaryHotkeyRegistrationStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Registered => "registered",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Runtime diagnostics for the primary recording global shortcut.
+#[derive(Debug, Clone, Default)]
+pub struct PrimaryHotkeyDiagnostics {
+    pub registration_status: PrimaryHotkeyRegistrationStatus,
+    pub registration_error: Option<String>,
+    pub last_registration_attempt_at: Option<String>,
+    pub last_successful_registration_at: Option<String>,
+    pub last_event_at: Option<String>,
+    pub last_event_kind: Option<String>,
+    pub last_event_state: Option<String>,
+    pub event_count: u64,
 }
 
 /// Queued event for the pill window
@@ -53,6 +86,7 @@ pub struct AppState {
     pub license_cache: Arc<tokio::sync::RwLock<Option<crate::commands::license::CachedLicense>>>,
     pub pill_event_queue: Arc<Mutex<Vec<QueuedPillEvent>>>,
     pub last_toggle_press: Arc<Mutex<Option<Instant>>>,
+    pub primary_hotkey_diagnostics: Arc<Mutex<PrimaryHotkeyDiagnostics>>,
 }
 
 impl Default for AppState {
@@ -80,7 +114,48 @@ impl AppState {
             license_cache: Arc::new(tokio::sync::RwLock::new(None)),
             pill_event_queue: Arc::new(Mutex::new(Vec::new())),
             last_toggle_press: Arc::new(Mutex::new(None)),
+            primary_hotkey_diagnostics: Arc::new(Mutex::new(PrimaryHotkeyDiagnostics::default())),
         }
+    }
+
+    pub fn record_primary_registration_attempt(&self) {
+        let now = Utc::now().to_rfc3339();
+        if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
+            diagnostics.last_registration_attempt_at = Some(now);
+        }
+    }
+
+    pub fn record_primary_registration_success(&self) {
+        let now = Utc::now().to_rfc3339();
+        if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
+            diagnostics.registration_status = PrimaryHotkeyRegistrationStatus::Registered;
+            diagnostics.registration_error = None;
+            diagnostics.last_successful_registration_at = Some(now);
+        }
+    }
+
+    pub fn record_primary_registration_failure(&self, error: impl Into<String>) {
+        if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
+            diagnostics.registration_status = PrimaryHotkeyRegistrationStatus::Failed;
+            diagnostics.registration_error = Some(error.into());
+        }
+    }
+
+    pub fn record_handled_hotkey_event(&self, kind: &str, state: &str) {
+        let now = Utc::now().to_rfc3339();
+        if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
+            diagnostics.last_event_at = Some(now);
+            diagnostics.last_event_kind = Some(kind.to_string());
+            diagnostics.last_event_state = Some(state.to_string());
+            diagnostics.event_count = diagnostics.event_count.saturating_add(1);
+        }
+    }
+
+    pub fn primary_hotkey_diagnostics_snapshot(&self) -> PrimaryHotkeyDiagnostics {
+        self.primary_hotkey_diagnostics
+            .lock()
+            .map(|diagnostics| diagnostics.clone())
+            .unwrap_or_default()
     }
 
     pub fn set_window_manager(&self, manager: WindowManager) {
@@ -286,5 +361,42 @@ pub async fn flush_pill_event_queue(app: &tauri::AppHandle) {
                 e
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, PrimaryHotkeyRegistrationStatus};
+
+    #[test]
+    fn primary_hotkey_registration_success_clears_error() {
+        let state = AppState::new();
+
+        state.record_primary_registration_attempt();
+        state.record_primary_registration_failure("blocked by another app");
+        state.record_primary_registration_success();
+
+        let diagnostics = state.primary_hotkey_diagnostics_snapshot();
+        assert_eq!(
+            diagnostics.registration_status,
+            PrimaryHotkeyRegistrationStatus::Registered
+        );
+        assert!(diagnostics.registration_error.is_none());
+        assert!(diagnostics.last_registration_attempt_at.is_some());
+        assert!(diagnostics.last_successful_registration_at.is_some());
+    }
+
+    #[test]
+    fn handled_hotkey_events_update_latest_event_and_count() {
+        let state = AppState::new();
+
+        state.record_handled_hotkey_event("recording", "pressed");
+        state.record_handled_hotkey_event("ptt", "released");
+
+        let diagnostics = state.primary_hotkey_diagnostics_snapshot();
+        assert_eq!(diagnostics.event_count, 2);
+        assert_eq!(diagnostics.last_event_kind.as_deref(), Some("ptt"));
+        assert_eq!(diagnostics.last_event_state.as_deref(), Some("released"));
+        assert!(diagnostics.last_event_at.is_some());
     }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -34,6 +34,7 @@ pub enum PrimaryHotkeyRegistrationStatus {
     #[default]
     Unknown,
     Registered,
+    RestoredAfterFailure,
     Failed,
 }
 
@@ -42,6 +43,7 @@ impl PrimaryHotkeyRegistrationStatus {
         match self {
             Self::Unknown => "unknown",
             Self::Registered => "registered",
+            Self::RestoredAfterFailure => "restored_after_failure",
             Self::Failed => "failed",
         }
     }
@@ -130,6 +132,15 @@ impl AppState {
         if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
             diagnostics.registration_status = PrimaryHotkeyRegistrationStatus::Registered;
             diagnostics.registration_error = None;
+            diagnostics.last_successful_registration_at = Some(now);
+        }
+    }
+
+    pub fn record_primary_registration_restored_after_failure(&self, error: impl Into<String>) {
+        let now = Utc::now().to_rfc3339();
+        if let Ok(mut diagnostics) = self.primary_hotkey_diagnostics.lock() {
+            diagnostics.registration_status = PrimaryHotkeyRegistrationStatus::RestoredAfterFailure;
+            diagnostics.registration_error = Some(error.into());
             diagnostics.last_successful_registration_at = Some(now);
         }
     }
@@ -383,6 +394,27 @@ mod tests {
         );
         assert!(diagnostics.registration_error.is_none());
         assert!(diagnostics.last_registration_attempt_at.is_some());
+        assert!(diagnostics.last_successful_registration_at.is_some());
+    }
+
+    #[test]
+    fn primary_hotkey_registration_restore_preserves_error() {
+        let state = AppState::new();
+
+        state.record_primary_registration_attempt();
+        state.record_primary_registration_restored_after_failure(
+            "new hotkey blocked; previous hotkey restored",
+        );
+
+        let diagnostics = state.primary_hotkey_diagnostics_snapshot();
+        assert_eq!(
+            diagnostics.registration_status,
+            PrimaryHotkeyRegistrationStatus::RestoredAfterFailure
+        );
+        assert_eq!(
+            diagnostics.registration_error.as_deref(),
+            Some("new hotkey blocked; previous hotkey restored")
+        );
         assert!(diagnostics.last_successful_registration_at.is_some());
     }
 

--- a/src-tauri/src/tests/settings_commands.rs
+++ b/src-tauri/src/tests/settings_commands.rs
@@ -32,6 +32,7 @@ mod tests {
             onboarding_completed: true,
             translate_to_english: false,
             check_updates_automatically: true,
+            install_updates_automatically: false,
             selected_microphone: None,
             recording_mode: "toggle".to_string(),
             use_different_ptt_key: false,
@@ -54,6 +55,7 @@ mod tests {
         assert!(json.contains("\"theme\":\"dark\""));
         assert!(json.contains("\"transcription_cleanup_days\":7"));
         assert!(json.contains("\"auto_paste_transcription\":true"));
+        assert!(json.contains("\"install_updates_automatically\":false"));
 
         // Test deserialization
         let deserialized: Settings = serde_json::from_str(&json).unwrap();
@@ -68,6 +70,10 @@ mod tests {
         assert_eq!(
             deserialized.auto_paste_transcription,
             settings.auto_paste_transcription
+        );
+        assert_eq!(
+            deserialized.install_updates_automatically,
+            settings.install_updates_automatically
         );
     }
 
@@ -101,6 +107,7 @@ mod tests {
             onboarding_completed: false,
             translate_to_english: true,
             check_updates_automatically: true,
+            install_updates_automatically: true,
             selected_microphone: Some("USB Microphone".to_string()),
             recording_mode: "push_to_talk".to_string(),
             use_different_ptt_key: true,
@@ -123,6 +130,10 @@ mod tests {
         assert_eq!(
             cloned.transcription_cleanup_days,
             settings.transcription_cleanup_days
+        );
+        assert_eq!(
+            cloned.install_updates_automatically,
+            settings.install_updates_automatically
         );
     }
 

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Voicetypr",
-  "version": "1.12.1",
   "identifier": "com.ideaplexa.voicetypr.dev",
   "build": {
     "beforeDevCommand": "pnpm run sidecar:ensure-ffmpeg && pnpm dev",

--- a/src/components/ReportBugDialog.test.tsx
+++ b/src/components/ReportBugDialog.test.tsx
@@ -6,7 +6,6 @@ import { ReportBugDialog } from './ReportBugDialog';
 import { gatherManualReportData, buildReportBody, submitManualReport } from '@/utils/crashReport';
 import { toast } from 'sonner';
 
-
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
@@ -180,8 +179,6 @@ describe('ReportBugDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-
-
   it('shows an error and keeps the dialog open when submit fails', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
@@ -200,7 +197,6 @@ describe('ReportBugDialog', () => {
     expect(screen.getByText(/copy the prepared report/i)).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
   });
-
 
   it('still submits when the latest log is unavailable', async () => {
     const user = userEvent.setup();

--- a/src/components/ReportBugDialog.test.tsx
+++ b/src/components/ReportBugDialog.test.tsx
@@ -126,6 +126,16 @@ describe('ReportBugDialog', () => {
     expect(screen.getByText(/anonymous device ID/i)).toBeInTheDocument();
   });
 
+  it('keeps the report form scrollable inside the viewport', () => {
+    render(<ReportBugDialog isOpen onClose={vi.fn()} initialMessage={'Line\n'.repeat(80)} />);
+
+    expect(screen.getByRole('dialog')).toHaveClass('max-h-[90dvh]');
+    expect(screen.getByRole('dialog')).toHaveClass('overflow-y-auto');
+    expect(screen.getByLabelText(/message/i)).toHaveClass('field-sizing-fixed');
+    expect(screen.getByLabelText(/message/i)).toHaveClass('max-h-48');
+    expect(screen.getByLabelText(/message/i)).toHaveClass('overflow-y-auto');
+  });
+
   it('submits a report directly to support', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/src/components/ReportBugDialog.test.tsx
+++ b/src/components/ReportBugDialog.test.tsx
@@ -145,7 +145,8 @@ describe('ReportBugDialog', () => {
       'Moin',
       'moin@example.com',
       'The app broke',
-      'base.en'
+      'base.en',
+      undefined
     );
     expect(submitManualReport).toHaveBeenCalledWith(expect.objectContaining({
       message: 'The app broke',
@@ -231,4 +232,44 @@ describe('ReportBugDialog', () => {
       logStatusNote: 'No log file found.',
     }));
   });
+  it('prefills the message when initialMessage is provided', () => {
+    const { rerender } = render(
+      <ReportBugDialog isOpen initialMessage="Hotkey issue details" onClose={vi.fn()} />
+    );
+
+    expect(screen.getByLabelText(/message/i)).toHaveValue('Hotkey issue details');
+
+    rerender(<ReportBugDialog isOpen={false} onClose={vi.fn()} />);
+    rerender(
+      <ReportBugDialog isOpen initialMessage="Updated hotkey issue" onClose={vi.fn()} />
+    );
+
+    expect(screen.getByLabelText(/message/i)).toHaveValue('Updated hotkey issue');
+  });
+
+  it('passes diagnostic context when gathering report data', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ReportBugDialog
+        isOpen
+        diagnosticContext={'Configured Hotkey: Cmd+Shift+Space'}
+        onClose={vi.fn()}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/message/i), 'Hotkey stopped working');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(gatherManualReportData).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        'Hotkey stopped working',
+        'base.en',
+        'Configured Hotkey: Cmd+Shift+Space'
+      );
+    });
+  });
+
 });

--- a/src/components/ReportBugDialog.tsx
+++ b/src/components/ReportBugDialog.tsx
@@ -24,9 +24,16 @@ import { useSettings } from '@/contexts/SettingsContext';
 interface ReportBugDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  initialMessage?: string;
+  diagnosticContext?: string;
 }
 
-export function ReportBugDialog({ isOpen, onClose }: ReportBugDialogProps) {
+export function ReportBugDialog({
+  isOpen,
+  onClose,
+  initialMessage,
+  diagnosticContext,
+}: ReportBugDialogProps) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
@@ -39,6 +46,9 @@ export function ReportBugDialog({ isOpen, onClose }: ReportBugDialogProps) {
   const { settings } = useSettings();
   const actionIdRef = useRef(0);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const diagnosticContextRef = useRef(diagnosticContext);
+
+  diagnosticContextRef.current = diagnosticContext;
 
   useEffect(() => {
     return () => {
@@ -106,8 +116,11 @@ export function ReportBugDialog({ isOpen, onClose }: ReportBugDialogProps) {
     if (isOpen) {
       actionIdRef.current += 1;
       resetForm();
+      if (initialMessage) {
+        setMessage(initialMessage);
+      }
     }
-  }, [isOpen, resetForm]);
+  }, [isOpen, resetForm, initialMessage]);
 
   const buildAndGather = async (actionId: number): Promise<ManualReportData | null> => {
     resetSubmitFallback();
@@ -117,7 +130,8 @@ export function ReportBugDialog({ isOpen, onClose }: ReportBugDialogProps) {
         name.trim() || undefined,
         email.trim() || undefined,
         message.trim(),
-        settings?.current_model || null
+        settings?.current_model || null,
+        diagnosticContextRef.current
       );
 
       return actionId === actionIdRef.current ? data : null;
@@ -276,6 +290,7 @@ export function ReportBugDialog({ isOpen, onClose }: ReportBugDialogProps) {
             <p className="text-xs text-muted-foreground">
               <strong>What is included:</strong> Your message, optional contact info,
               system info (app version, OS, architecture, model, anonymous device ID),
+              {diagnosticContext ? ' additional diagnostics,' : ''}
               and the latest app log excerpt.
             </p>
           </div>

--- a/src/components/ReportBugDialog.tsx
+++ b/src/components/ReportBugDialog.tsx
@@ -46,9 +46,6 @@ export function ReportBugDialog({
   const { settings } = useSettings();
   const actionIdRef = useRef(0);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const diagnosticContextRef = useRef(diagnosticContext);
-
-  diagnosticContextRef.current = diagnosticContext;
 
   useEffect(() => {
     return () => {
@@ -131,7 +128,7 @@ export function ReportBugDialog({
         email.trim() || undefined,
         message.trim(),
         settings?.current_model || null,
-        diagnosticContextRef.current
+        diagnosticContext
       );
 
       return actionId === actionIdRef.current ? data : null;

--- a/src/components/ReportBugDialog.tsx
+++ b/src/components/ReportBugDialog.tsx
@@ -20,6 +20,7 @@ import {
   type ManualReportData,
 } from '@/utils/crashReport';
 import { useSettings } from '@/contexts/SettingsContext';
+import { cn } from '@/lib/utils';
 
 interface ReportBugDialogProps {
   isOpen: boolean;
@@ -198,7 +199,7 @@ export function ReportBugDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Bug className="h-5 w-5" />
@@ -274,7 +275,10 @@ export function ReportBugDialog({
               aria-required="true"
               aria-invalid={Boolean(messageError)}
               aria-describedby={messageError ? 'report-message-error' : undefined}
-              className={messageError ? 'border-destructive' : ''}
+              className={cn(
+                'field-sizing-fixed max-h-48 overflow-y-auto',
+                messageError && 'border-destructive'
+              )}
             />
             {messageError && (
               <p id="report-message-error" role="alert" className="text-xs text-destructive">

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,6 +1,8 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
 import { open } from '@tauri-apps/plugin-shell';
 import { getVersion } from '@tauri-apps/api/app';
 import { 
@@ -13,10 +15,12 @@ import XIcon from "@/components/icons/XIcon";
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { updateService } from '@/services/updateService';
+import { useSettings } from '@/contexts/SettingsContext';
 
 export function AboutSection() {
   const [appVersion, setAppVersion] = useState<string>('');
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
+  const { settings, updateSettings } = useSettings();
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -36,6 +40,20 @@ export function AboutSection() {
     setIsCheckingUpdate(true);
     await updateService.checkForUpdatesManually();
     setIsCheckingUpdate(false);
+  };
+
+  const handleAutoInstallToggle = async (checked: boolean) => {
+    try {
+      await updateSettings({ install_updates_automatically: checked });
+      toast.success(
+        checked
+          ? 'Automatic update install enabled'
+          : 'Automatic update install disabled'
+      );
+    } catch (error) {
+      console.error('Failed to update automatic install setting:', error);
+      toast.error('Failed to update update setting');
+    }
   };
 
   const openExternalLink = async (url: string) => {
@@ -88,6 +106,22 @@ export function AboutSection() {
                   <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${isCheckingUpdate ? 'animate-spin' : ''}`} />
                   {isCheckingUpdate ? 'Checking...' : 'Check for Updates'}
                 </Button>
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border border-border/40 bg-background/50 p-3">
+                <div className="space-y-0.5">
+                  <Label htmlFor="install-updates-automatically" className="text-sm font-medium">
+                    Download and install updates automatically
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    If off, VoiceTypr only shows an update prompt and waits for you to click Update.
+                  </p>
+                </div>
+                <Switch
+                  id="install-updates-automatically"
+                  checked={settings?.install_updates_automatically ?? false}
+                  onCheckedChange={handleAutoInstallToggle}
+                />
               </div>
             </div>
           </div>

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -25,7 +25,7 @@ import {
   Monitor,
 } from "lucide-react";
 import XIcon from "@/components/icons/XIcon";
-import { useState, useEffect, useCallback, type ComponentType } from "react";
+import { useState, useEffect, useCallback, useRef, type ComponentType } from "react";
 import { toast } from "sonner";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
@@ -35,26 +35,13 @@ import { useSettings } from "@/contexts/SettingsContext";
 import { useCanRecord, useCanAutoInsert } from "@/contexts/ReadinessContext";
 import { ReportBugDialog } from "@/components/ReportBugDialog";
 import { formatHotkey } from "@/lib/hotkey-utils";
-
-interface HotkeyDiagnostics {
-  configuredHotkey: string;
-  normalizedHotkey: string;
-  recordingMode: string;
-  useDifferentPttKey: boolean;
-  pttHotkey: string | null;
-  normalizedPttHotkey: string | null;
-  registrationStatus: string;
-  registrationError?: string | null;
-  lastRegistrationAttemptAt?: string | null;
-  lastSuccessfulRegistrationAt?: string | null;
-  lastEventAt?: string | null;
-  lastEventKind?: string | null;
-  lastEventState?: string | null;
-  eventCount: number;
-  currentRecordingState?: string | null;
-  generatedAt: string;
-  isRegistered: boolean | null;
-}
+import {
+  formatRegistrationStatus,
+  formatHotkeyDiagnosticContext,
+  formatHotkeyDiagnosticLines,
+  formatLastEventSummary,
+  type HotkeyDiagnostics,
+} from "@/utils/hotkeyDiagnostics";
 
 interface QuickFix {
   id: string;
@@ -67,53 +54,6 @@ interface QuickFix {
 
 const HOTKEY_TEST_POLL_MS = 500;
 const HOTKEY_TEST_TIMEOUT_MS = 10_000;
-
-function formatDiagnosticValue(value: string | number | boolean | null | undefined): string {
-  if (value === null || value === undefined || value === "") {
-    return "—";
-  }
-  return String(value);
-}
-
-function formatHotkeyDiagnosticLines(diag: HotkeyDiagnostics | null): string[] {
-  if (!diag) {
-    return ["Hotkey Diagnostics: Unavailable"];
-  }
-
-  const lines = [
-    `Configured Hotkey: ${formatDiagnosticValue(diag.configuredHotkey)}`,
-    `Normalized Hotkey: ${formatDiagnosticValue(diag.normalizedHotkey)}`,
-    `Recording Mode: ${formatDiagnosticValue(diag.recordingMode)}`,
-    `Registration Status: ${formatDiagnosticValue(diag.registrationStatus)}`,
-  ];
-
-  if (diag.registrationError) {
-    lines.push(`Registration Error: ${diag.registrationError}`);
-  }
-  if (diag.isRegistered !== undefined) {
-    lines.push(`Is Registered: ${formatDiagnosticValue(diag.isRegistered)}`);
-  }
-  if (diag.useDifferentPttKey) {
-    lines.push(`PTT Hotkey: ${formatDiagnosticValue(diag.pttHotkey)}`);
-    lines.push(`Normalized PTT Hotkey: ${formatDiagnosticValue(diag.normalizedPttHotkey)}`);
-  }
-  if (diag.lastEventAt) {
-    lines.push(
-      `Last Event: ${formatDiagnosticValue(diag.lastEventKind)} (${formatDiagnosticValue(diag.lastEventState)}) at ${diag.lastEventAt}`
-    );
-  } else {
-    lines.push("Last Event: None detected");
-  }
-  lines.push(`Event Count: ${diag.eventCount ?? 0}`);
-  lines.push(`Current Recording State: ${formatDiagnosticValue(diag.currentRecordingState)}`);
-  lines.push(`Generated At: ${formatDiagnosticValue(diag.generatedAt)}`);
-
-  return lines;
-}
-
-export function formatHotkeyDiagnosticContext(diag: HotkeyDiagnostics): string {
-  return formatHotkeyDiagnosticLines(diag).join("\n");
-}
 
 function buildSystemDiagnostics(params: {
   appVer: string;
@@ -154,15 +94,6 @@ function getHotkeyGuidance(os: string): string {
   return "If your hotkey does not work, try a different combination and check system shortcut settings.";
 }
 
-function formatLastEventSummary(diag: HotkeyDiagnostics | null): string {
-  if (!diag?.lastEventAt) {
-    return "None detected";
-  }
-  const kind = formatDiagnosticValue(diag.lastEventKind);
-  const state = formatDiagnosticValue(diag.lastEventState);
-  return `${kind} (${state})`;
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -187,6 +118,13 @@ export function HelpSection() {
   const { settings } = useSettings();
   const canRecord = useCanRecord();
   const canAutoInsert = useCanAutoInsert();
+  const hotkeyTestRunRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      hotkeyTestRunRef.current += 1;
+    };
+  }, []);
 
   const loadHotkeyDiagnostics = useCallback(async (): Promise<HotkeyDiagnostics | null> => {
     try {
@@ -357,17 +295,29 @@ Actual behavior:
   const handleTestHotkey = async () => {
     if (testingHotkey) return;
 
+    const runId = hotkeyTestRunRef.current + 1;
+    hotkeyTestRunRef.current = runId;
+    const isCancelled = () => hotkeyTestRunRef.current !== runId;
+
     setTestingHotkey(true);
     toast.info("Press your hotkey now");
 
     try {
       const baseline = await loadHotkeyDiagnostics();
+      if (isCancelled()) return;
+
       const startCount = baseline?.eventCount ?? 0;
       const deadline = Date.now() + HOTKEY_TEST_TIMEOUT_MS;
 
       while (Date.now() < deadline) {
+        if (isCancelled()) return;
+
         await sleep(HOTKEY_TEST_POLL_MS);
+        if (isCancelled()) return;
+
         const current = await invoke<HotkeyDiagnostics>("get_hotkey_diagnostics");
+        if (isCancelled()) return;
+
         setHotkeyDiagnostics(current);
 
         if (current.eventCount > startCount) {
@@ -376,12 +326,18 @@ Actual behavior:
         }
       }
 
-      toast.error("No hotkey was detected");
+      if (!isCancelled()) {
+        toast.error("No hotkey was detected");
+      }
     } catch (error) {
-      console.error("Failed to test hotkey:", error);
-      toast.error("Failed to test hotkey");
+      if (!isCancelled()) {
+        console.error("Failed to test hotkey:", error);
+        toast.error("Failed to test hotkey");
+      }
     } finally {
-      setTestingHotkey(false);
+      if (!isCancelled()) {
+        setTestingHotkey(false);
+      }
     }
   };
 
@@ -534,7 +490,7 @@ Actual behavior:
                 <div className="flex justify-between gap-4">
                   <dt className="text-muted-foreground">Registration</dt>
                   <dd className="font-medium text-right">
-                    {formatDiagnosticValue(hotkeyDiagnostics?.registrationStatus)}
+                    {formatRegistrationStatus(hotkeyDiagnostics?.registrationStatus)}
                   </dd>
                 </div>
                 <div className="flex justify-between gap-4">

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -100,6 +100,39 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
+function shouldCancelRecordingAfterHotkeyTest(
+  baseline: HotkeyDiagnostics | null,
+  current: HotkeyDiagnostics
+): boolean {
+  const baselineState = baseline?.currentRecordingState;
+  const currentState = current.currentRecordingState;
+
+  if (baselineState !== "idle" && baselineState !== "error") {
+    return false;
+  }
+
+  return Boolean(currentState && currentState !== "idle" && currentState !== "error");
+}
+
+async function cancelRecordingStartedByHotkeyTest(
+  baseline: HotkeyDiagnostics | null,
+  current: HotkeyDiagnostics,
+  isCancelled: () => boolean
+): Promise<void> {
+  if (!shouldCancelRecordingAfterHotkeyTest(baseline, current) || isCancelled()) {
+    return;
+  }
+
+  try {
+    await invoke("cancel_recording");
+  } catch (error) {
+    if (!isCancelled()) {
+      console.error("Failed to clean up recording started by hotkey test:", error);
+      toast.error("Stop recording manually");
+    }
+  }
+}
+
 export function HelpSection() {
   const [appVersion, setAppVersion] = useState<string>("");
   const [platformName, setPlatformName] = useState<string>("");
@@ -321,7 +354,10 @@ Actual behavior:
         setHotkeyDiagnostics(current);
 
         if (current.eventCount > startCount) {
-          toast.success("Hotkey detected");
+          await cancelRecordingStartedByHotkeyTest(baseline, current, isCancelled);
+          if (!isCancelled()) {
+            toast.success("Hotkey detected");
+          }
           return;
         }
       }

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -32,7 +32,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import { platform, version as osVersion } from "@tauri-apps/plugin-os";
 import { open } from "@tauri-apps/plugin-shell";
 import { useSettings } from "@/contexts/SettingsContext";
-import { useCanRecord, useCanAutoInsert } from "@/contexts/ReadinessContext";
+import { useReadiness } from "@/contexts/ReadinessContext";
 import { ReportBugDialog } from "@/components/ReportBugDialog";
 import {
   formatHotkeyDiagnosticContext,
@@ -49,8 +49,24 @@ interface QuickFix {
   checkStatus?: () => boolean;
 }
 
+type DiagnosticsStatus = "Ready" | "Needs attention" | "Not checked";
+
+interface ReadinessSnapshot {
+  has_accessibility_permission: boolean | null;
+  has_microphone_permission: boolean | null;
+  has_models: boolean | null;
+  selected_model_available: boolean | null;
+}
+
+interface DiagnosticsSummary {
+  status: DiagnosticsStatus;
+  issue: string;
+  lastChecked: "Just now" | "Not checked";
+}
+
 const HOTKEY_TEST_POLL_MS = 500;
 const HOTKEY_TEST_TIMEOUT_MS = 10_000;
+const HOTKEY_ACTION_TIMEOUT_MS = 2_000;
 
 function buildSystemDiagnostics(params: {
   appVer: string;
@@ -81,57 +97,105 @@ function buildSystemDiagnostics(params: {
   return lines.join("\n");
 }
 
-function getDiagnosticsGuidance(os: string): string {
-  if (os === "windows") {
-    return "If diagnostics find an issue, try a different shortcut combination. Security software or antivirus can block global input checks.";
-  }
-  if (os === "macos") {
-    return "If diagnostics find an issue, try a different shortcut combination and check for conflicts in macOS Keyboard Shortcuts.";
-  }
-  return "If diagnostics find an issue, try a different shortcut combination and check system shortcut settings.";
+function getDiagnosticsGuidance(): string {
+  return "Readiness checks use permissions, model availability, and shortcut registration. Test Hotkey confirms the actual shortcut press is detected.";
 }
 
-function getDiagnosticsSummary(diag: HotkeyDiagnostics | null): {
-  status: "All good" | "Needs attention" | "Not tested yet";
-  issue: string;
-  lastChecked: "Just now" | "Not checked";
-} {
-  if (!diag) {
+function getDiagnosticsSummary(params: {
+  canRecord: boolean;
+  canAutoInsert: boolean;
+  readiness: ReadinessSnapshot | null;
+  hotkeyDiag: HotkeyDiagnostics | null;
+  hotkeyTestIssue: string | null;
+  checkedAt: string | null;
+}): DiagnosticsSummary {
+  const { canRecord, canAutoInsert, readiness, hotkeyDiag, hotkeyTestIssue, checkedAt } = params;
+  const lastChecked = checkedAt ? "Just now" : "Not checked";
+
+  if (!checkedAt) {
     return {
-      status: "Not tested yet",
-      issue: "Diagnostics not loaded",
-      lastChecked: "Not checked",
+      status: "Not checked",
+      issue: "Diagnostics are still loading",
+      lastChecked,
     };
   }
 
-  if (diag.registrationStatus === "failed" || diag.isRegistered === false) {
+  if (readiness?.has_microphone_permission === false) {
+    return {
+      status: "Needs attention",
+      issue: "Microphone permission is missing",
+      lastChecked,
+    };
+  }
+
+  if (readiness?.has_models === false) {
+    return {
+      status: "Needs attention",
+      issue: "No transcription model is installed",
+      lastChecked,
+    };
+  }
+
+  if (readiness?.selected_model_available === false) {
+    return {
+      status: "Needs attention",
+      issue: "Selected transcription model is unavailable",
+      lastChecked,
+    };
+  }
+
+  if (!canRecord) {
+    return {
+      status: "Needs attention",
+      issue: "Recording pipeline is not ready",
+      lastChecked,
+    };
+  }
+
+  if (readiness?.has_accessibility_permission === false || !canAutoInsert) {
+    return {
+      status: "Needs attention",
+      issue: "Accessibility permission is missing",
+      lastChecked,
+    };
+  }
+
+  if (!hotkeyDiag) {
+    return {
+      status: "Needs attention",
+      issue: "Shortcut diagnostics could not be loaded",
+      lastChecked,
+    };
+  }
+
+  if (hotkeyDiag.registrationStatus === "failed" || hotkeyDiag.isRegistered === false) {
     return {
       status: "Needs attention",
       issue: "Global hotkey is not registered",
-      lastChecked: "Just now",
+      lastChecked,
     };
   }
 
-  if (diag.registrationStatus === "restored_after_failure") {
+  if (hotkeyDiag.registrationStatus === "restored_after_failure") {
     return {
       status: "Needs attention",
-      issue: diag.registrationError || "Previous hotkey restored after update failure",
-      lastChecked: "Just now",
+      issue: hotkeyDiag.registrationError || "Previous hotkey restored after update failure",
+      lastChecked,
     };
   }
 
-  if (!diag.lastEventAt) {
+  if (hotkeyTestIssue) {
     return {
-      status: "Not tested yet",
-      issue: "No issue found yet — run a check to verify input capture",
-      lastChecked: "Just now",
+      status: "Needs attention",
+      issue: hotkeyTestIssue,
+      lastChecked,
     };
   }
 
   return {
-    status: "All good",
-    issue: "None",
-    lastChecked: "Just now",
+    status: "Ready",
+    issue: "No readiness issue detected",
+    lastChecked,
   };
 }
 
@@ -183,6 +247,8 @@ export function HelpSection() {
   const [openItems, setOpenItems] = useState<string[]>([]);
   const [hotkeyDiagnostics, setHotkeyDiagnostics] = useState<HotkeyDiagnostics | null>(null);
   const [testingHotkey, setTestingHotkey] = useState(false);
+  const [hotkeyTestIssue, setHotkeyTestIssue] = useState<string | null>(null);
+  const [lastDiagnosticsCheckAt, setLastDiagnosticsCheckAt] = useState<string | null>(null);
   const [showEmailModal, setShowEmailModal] = useState(false);
   const [emailSubject, setEmailSubject] = useState<string>("");
   const [emailBody, setEmailBody] = useState<string>("");
@@ -190,8 +256,15 @@ export function HelpSection() {
   const [reportBugInitialMessage, setReportBugInitialMessage] = useState<string | undefined>();
   const [reportBugDiagnosticContext, setReportBugDiagnosticContext] = useState<string | undefined>();
   const { settings } = useSettings();
-  const canRecord = useCanRecord();
-  const canAutoInsert = useCanAutoInsert();
+  const readiness = useReadiness();
+  const canRecord = readiness.canRecord;
+  const canAutoInsert = readiness.canAutoInsert;
+  const readinessState: ReadinessSnapshot = {
+    has_accessibility_permission: readiness.hasAccessibilityPermission,
+    has_microphone_permission: readiness.hasMicrophonePermission,
+    has_models: readiness.hasModels,
+    selected_model_available: readiness.selectedModelAvailable,
+  };
   const hotkeyTestRunRef = useRef(0);
 
   useEffect(() => {
@@ -229,6 +302,7 @@ export function HelpSection() {
         setDeviceId(deviceId);
         setPlatformName(`${os} ${osVer}`);
         setHotkeyDiagnostics(hotkeyDiag);
+        setLastDiagnosticsCheckAt(new Date().toISOString());
       } catch (error) {
         console.error("Failed to get system info:", error);
       }
@@ -254,10 +328,10 @@ export function HelpSection() {
       issue: "Global hotkey doesn't trigger recording",
       solution:
         osPlatform === "windows"
-          ? "Use Run Check below. If it finds an issue, try another combination and allow VoiceTypr in your security or antivirus software."
+          ? "Use Test Hotkey to confirm Windows detects the shortcut. If it fails, try another combination and allow VoiceTypr in your security or antivirus software."
           : osPlatform === "macos"
-            ? "Use Run Check below. If it finds an issue, try another combination and check macOS Keyboard Shortcuts for conflicts."
-            : "Use Run Check below and check for system shortcut conflicts.",
+            ? "Use Test Hotkey to confirm macOS detects the shortcut. If it fails, try another combination and check macOS Keyboard Shortcuts for conflicts."
+            : "Use Test Hotkey to confirm shortcut input.",
       checkStatus: () =>
         hotkeyDiagnostics?.isRegistered === true ||
         hotkeyDiagnostics?.registrationStatus === "registered",
@@ -374,6 +448,8 @@ Actual behavior:
     const isCancelled = () => hotkeyTestRunRef.current !== runId;
 
     setTestingHotkey(true);
+    setHotkeyTestIssue(null);
+    setLastDiagnosticsCheckAt(new Date().toISOString());
     toast.info("Press your hotkey now");
 
     try {
@@ -393,10 +469,44 @@ Actual behavior:
         if (isCancelled()) return;
 
         setHotkeyDiagnostics(current);
+        setLastDiagnosticsCheckAt(new Date().toISOString());
 
         if (current.eventCount > startCount) {
-          await cancelRecordingStartedByHotkeyTest(baseline, current, isCancelled);
+          let latest = current;
+          const baselineState = baseline?.currentRecordingState;
+          const shouldVerifyRecordingStart = baselineState === "idle" || baselineState === "error";
+
+          if (shouldVerifyRecordingStart) {
+            const actionDeadline = Date.now() + HOTKEY_ACTION_TIMEOUT_MS;
+
+            while (
+              latest.currentRecordingState !== "error" &&
+              !shouldCancelRecordingAfterHotkeyTest(baseline, latest) &&
+              Date.now() < actionDeadline
+            ) {
+              await sleep(HOTKEY_TEST_POLL_MS);
+              if (isCancelled()) return;
+
+              latest = await invoke<HotkeyDiagnostics>("get_hotkey_diagnostics");
+              if (isCancelled()) return;
+
+              setHotkeyDiagnostics(latest);
+              setLastDiagnosticsCheckAt(new Date().toISOString());
+            }
+
+            if (!shouldCancelRecordingAfterHotkeyTest(baseline, latest)) {
+              if (!isCancelled()) {
+                setHotkeyTestIssue("Hotkey detected, but recording did not start");
+                setLastDiagnosticsCheckAt(new Date().toISOString());
+                toast.error("Hotkey detected, but recording did not start");
+              }
+              return;
+            }
+
+            await cancelRecordingStartedByHotkeyTest(baseline, latest, isCancelled);
+          }
           if (!isCancelled()) {
+            setHotkeyTestIssue(null);
             toast.success("Hotkey detected");
           }
           return;
@@ -404,11 +514,15 @@ Actual behavior:
       }
 
       if (!isCancelled()) {
+        setHotkeyTestIssue("Hotkey press was not detected");
+        setLastDiagnosticsCheckAt(new Date().toISOString());
         toast.error("No hotkey was detected");
       }
     } catch (error) {
       if (!isCancelled()) {
         console.error("Failed to test hotkey:", error);
+        setHotkeyTestIssue("Hotkey test failed to run");
+        setLastDiagnosticsCheckAt(new Date().toISOString());
         toast.error("Failed to test hotkey");
       }
     } finally {
@@ -430,7 +544,14 @@ Actual behavior:
     setShowReportBugDialog(true);
   };
 
-  const diagnosticsSummary = getDiagnosticsSummary(hotkeyDiagnostics);
+  const diagnosticsSummary = getDiagnosticsSummary({
+    canRecord,
+    canAutoInsert,
+    readiness: readinessState,
+    hotkeyDiag: hotkeyDiagnostics,
+    hotkeyTestIssue,
+    checkedAt: lastDiagnosticsCheckAt,
+  });
 
   const diagnostics = buildSystemDiagnostics({
     appVer: appVersion || "Unknown",
@@ -463,8 +584,8 @@ Actual behavior:
 
             <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
               <div className="flex items-center gap-2">
-                <Keyboard className="h-4 w-4 text-muted-foreground" />
-                <h3 className="text-sm font-medium">System check</h3>
+                <Monitor className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-sm font-medium">Current status</h3>
               </div>
 
               <dl className="grid gap-2 text-xs">
@@ -482,7 +603,7 @@ Actual behavior:
                 </div>
               </dl>
 
-              <p className="text-xs text-muted-foreground">{getDiagnosticsGuidance(osPlatform)}</p>
+              <p className="text-xs text-muted-foreground">{getDiagnosticsGuidance()}</p>
 
               <div className="flex flex-wrap gap-2">
                 <Button
@@ -492,7 +613,7 @@ Actual behavior:
                   onClick={() => void handleTestHotkey()}
                   disabled={testingHotkey}
                 >
-                  {testingHotkey ? "Testing…" : "Run Check"}
+                  {testingHotkey ? "Testing…" : "Test Hotkey"}
                 </Button>
                 <Button
                   type="button"

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -34,12 +34,9 @@ import { open } from "@tauri-apps/plugin-shell";
 import { useSettings } from "@/contexts/SettingsContext";
 import { useCanRecord, useCanAutoInsert } from "@/contexts/ReadinessContext";
 import { ReportBugDialog } from "@/components/ReportBugDialog";
-import { formatHotkey } from "@/lib/hotkey-utils";
 import {
-  formatRegistrationStatus,
   formatHotkeyDiagnosticContext,
   formatHotkeyDiagnosticLines,
-  formatLastEventSummary,
   type HotkeyDiagnostics,
 } from "@/utils/hotkeyDiagnostics";
 
@@ -84,14 +81,58 @@ function buildSystemDiagnostics(params: {
   return lines.join("\n");
 }
 
-function getHotkeyGuidance(os: string): string {
+function getDiagnosticsGuidance(os: string): string {
   if (os === "windows") {
-    return "If your hotkey does not work, try a different combination. Security software or antivirus can block global shortcuts.";
+    return "If diagnostics find an issue, try a different shortcut combination. Security software or antivirus can block global input checks.";
   }
   if (os === "macos") {
-    return "If Test Hotkey fails, try a different combination and check for conflicts in macOS Keyboard Shortcuts.";
+    return "If diagnostics find an issue, try a different shortcut combination and check for conflicts in macOS Keyboard Shortcuts.";
   }
-  return "If your hotkey does not work, try a different combination and check system shortcut settings.";
+  return "If diagnostics find an issue, try a different shortcut combination and check system shortcut settings.";
+}
+
+function getDiagnosticsSummary(diag: HotkeyDiagnostics | null): {
+  status: "All good" | "Needs attention" | "Not tested yet";
+  issue: string;
+  lastChecked: "Just now" | "Not checked";
+} {
+  if (!diag) {
+    return {
+      status: "Not tested yet",
+      issue: "Diagnostics not loaded",
+      lastChecked: "Not checked",
+    };
+  }
+
+  if (diag.registrationStatus === "failed" || diag.isRegistered === false) {
+    return {
+      status: "Needs attention",
+      issue: "Global hotkey is not registered",
+      lastChecked: "Just now",
+    };
+  }
+
+  if (diag.registrationStatus === "restored_after_failure") {
+    return {
+      status: "Needs attention",
+      issue: diag.registrationError || "Previous hotkey restored after update failure",
+      lastChecked: "Just now",
+    };
+  }
+
+  if (!diag.lastEventAt) {
+    return {
+      status: "Not tested yet",
+      issue: "No issue found yet — run a check to verify input capture",
+      lastChecked: "Just now",
+    };
+  }
+
+  return {
+    status: "All good",
+    issue: "None",
+    lastChecked: "Just now",
+  };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -213,10 +254,10 @@ export function HelpSection() {
       issue: "Global hotkey doesn't trigger recording",
       solution:
         osPlatform === "windows"
-          ? "Use Test Hotkey below. If it fails, try another combination and allow VoiceTypr in your security or antivirus software."
+          ? "Use Run Check below. If it finds an issue, try another combination and allow VoiceTypr in your security or antivirus software."
           : osPlatform === "macos"
-            ? "Use Test Hotkey below. If it fails, try another combination and check macOS Keyboard Shortcuts for conflicts."
-            : "Use Test Hotkey below and check for system shortcut conflicts.",
+            ? "Use Run Check below. If it finds an issue, try another combination and check macOS Keyboard Shortcuts for conflicts."
+            : "Use Run Check below and check for system shortcut conflicts.",
       checkStatus: () =>
         hotkeyDiagnostics?.isRegistered === true ||
         hotkeyDiagnostics?.registrationStatus === "registered",
@@ -379,6 +420,7 @@ Actual behavior:
 
   const handleReportHotkeyIssue = async () => {
     const diag = await loadHotkeyDiagnostics();
+
     setReportBugInitialMessage(
       "I'm having trouble with my global hotkey.\n\nWhat I tried:\n\nWhat I expected:\n\nWhat happened instead:\n"
     );
@@ -388,11 +430,7 @@ Actual behavior:
     setShowReportBugDialog(true);
   };
 
-  const configuredHotkeyLabel = hotkeyDiagnostics?.configuredHotkey
-    ? formatHotkey(hotkeyDiagnostics.configuredHotkey)
-    : settings?.hotkey
-      ? formatHotkey(settings.hotkey)
-      : "—";
+  const diagnosticsSummary = getDiagnosticsSummary(hotkeyDiagnostics);
 
   const diagnostics = buildSystemDiagnostics({
     appVer: appVersion || "Unknown",
@@ -420,6 +458,92 @@ Actual behavior:
 
       <ScrollArea className="flex-1 min-h-0">
         <div className="p-6 space-y-6">
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold">Diagnostics</h2>
+
+            <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <Keyboard className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-sm font-medium">System check</h3>
+              </div>
+
+              <dl className="grid gap-2 text-xs">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Status</dt>
+                  <dd className="font-medium text-right">{diagnosticsSummary.status}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Latest issue</dt>
+                  <dd className="font-medium text-right">{diagnosticsSummary.issue}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Last checked</dt>
+                  <dd className="font-medium text-right">{diagnosticsSummary.lastChecked}</dd>
+                </div>
+              </dl>
+
+              <p className="text-xs text-muted-foreground">{getDiagnosticsGuidance(osPlatform)}</p>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void handleTestHotkey()}
+                  disabled={testingHotkey}
+                >
+                  {testingHotkey ? "Testing…" : "Run Check"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void handleReportHotkeyIssue()}
+                >
+                  Report Issue
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <button
+                onClick={handleCopySystemInfo}
+                className="w-full rounded-lg border border-border/50 bg-card hover:bg-accent/50 transition-colors p-4 flex items-center justify-between group"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                    <Copy className="h-4 w-4" />
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-medium">Copy System Info</p>
+                    <p className="text-xs text-muted-foreground">
+                      Copy system diagnostics to clipboard
+                    </p>
+                  </div>
+                </div>
+                <ChevronDown className="h-4 w-4 text-muted-foreground -rotate-90" />
+              </button>
+
+              <button
+                onClick={handleOpenLogs}
+                className="w-full rounded-lg border border-border/50 bg-card hover:bg-accent/50 transition-colors p-4 flex items-center justify-between group"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                    <FileText className="h-4 w-4" />
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-medium">Open Logs Folder</p>
+                    <p className="text-xs text-muted-foreground">
+                      Open logs folder to attach to support messages
+                    </p>
+                  </div>
+                </div>
+                <ChevronDown className="h-4 w-4 text-muted-foreground -rotate-90" />
+              </button>
+            </div>
+          </div>
+
           <div className="space-y-4">
             <h2 className="text-base font-semibold">Quick Fixes</h2>
 
@@ -501,94 +625,6 @@ Actual behavior:
                     <p className="text-sm font-medium">Email Support</p>
                     <p className="text-xs text-muted-foreground">
                       Send us an email with diagnostic info
-                    </p>
-                  </div>
-                </div>
-                <ChevronDown className="h-4 w-4 text-muted-foreground -rotate-90" />
-              </button>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <h2 className="text-base font-semibold">Diagnostics</h2>
-
-            <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <Keyboard className="h-4 w-4 text-muted-foreground" />
-                <h3 className="text-sm font-medium">Hotkey Diagnostics</h3>
-              </div>
-
-              <dl className="grid gap-2 text-xs">
-                <div className="flex justify-between gap-4">
-                  <dt className="text-muted-foreground">Configured hotkey</dt>
-                  <dd className="font-medium text-right">{configuredHotkeyLabel}</dd>
-                </div>
-                <div className="flex justify-between gap-4">
-                  <dt className="text-muted-foreground">Registration</dt>
-                  <dd className="font-medium text-right">
-                    {formatRegistrationStatus(hotkeyDiagnostics?.registrationStatus)}
-                  </dd>
-                </div>
-                <div className="flex justify-between gap-4">
-                  <dt className="text-muted-foreground">Last event</dt>
-                  <dd className="font-medium text-right">{formatLastEventSummary(hotkeyDiagnostics)}</dd>
-                </div>
-              </dl>
-
-              <p className="text-xs text-muted-foreground">{getHotkeyGuidance(osPlatform)}</p>
-
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void handleTestHotkey()}
-                  disabled={testingHotkey}
-                >
-                  {testingHotkey ? "Testing…" : "Test Hotkey"}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void handleReportHotkeyIssue()}
-                >
-                  Report Hotkey Issue
-                </Button>
-              </div>
-            </div>
-
-            <div className="space-y-3">
-              <button
-                onClick={handleCopySystemInfo}
-                className="w-full rounded-lg border border-border/50 bg-card hover:bg-accent/50 transition-colors p-4 flex items-center justify-between group"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                    <Copy className="h-4 w-4" />
-                  </div>
-                  <div className="text-left">
-                    <p className="text-sm font-medium">Copy System Info</p>
-                    <p className="text-xs text-muted-foreground">
-                      Copy system and hotkey diagnostics to clipboard
-                    </p>
-                  </div>
-                </div>
-                <ChevronDown className="h-4 w-4 text-muted-foreground -rotate-90" />
-              </button>
-
-              <button
-                onClick={handleOpenLogs}
-                className="w-full rounded-lg border border-border/50 bg-card hover:bg-accent/50 transition-colors p-4 flex items-center justify-between group"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                    <FileText className="h-4 w-4" />
-                  </div>
-                  <div className="text-left">
-                    <p className="text-sm font-medium">Open Logs Folder</p>
-                    <p className="text-xs text-muted-foreground">
-                      Open logs folder to attach to support messages
                     </p>
                   </div>
                 </div>

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -456,7 +456,14 @@ Actual behavior:
       const baseline = await loadHotkeyDiagnostics();
       if (isCancelled()) return;
 
-      const startCount = baseline?.eventCount ?? 0;
+      if (!baseline) {
+        setHotkeyTestIssue("Shortcut diagnostics unavailable");
+        setLastDiagnosticsCheckAt(new Date().toISOString());
+        toast.error("Shortcut diagnostics unavailable");
+        return;
+      }
+
+      const startCount = baseline.eventCount;
       const deadline = Date.now() + HOTKEY_TEST_TIMEOUT_MS;
 
       while (Date.now() < deadline) {

--- a/src/components/sections/HelpSection.tsx
+++ b/src/components/sections/HelpSection.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { 
+import {
   ChevronDown,
   Mail,
   Mic,
@@ -22,117 +22,256 @@ import {
   Copy,
   FileText,
   Globe,
-  Monitor
+  Monitor,
 } from "lucide-react";
 import XIcon from "@/components/icons/XIcon";
-import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
-import { invoke } from '@tauri-apps/api/core';
-import { getVersion } from '@tauri-apps/api/app';
-import { platform, version as osVersion } from '@tauri-apps/plugin-os';
-import { open } from '@tauri-apps/plugin-shell';
-import { useSettings } from '@/contexts/SettingsContext';
-import { useCanRecord, useCanAutoInsert } from '@/contexts/ReadinessContext';
+import { useState, useEffect, useCallback, type ComponentType } from "react";
+import { toast } from "sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
+import { platform, version as osVersion } from "@tauri-apps/plugin-os";
+import { open } from "@tauri-apps/plugin-shell";
+import { useSettings } from "@/contexts/SettingsContext";
+import { useCanRecord, useCanAutoInsert } from "@/contexts/ReadinessContext";
+import { ReportBugDialog } from "@/components/ReportBugDialog";
+import { formatHotkey } from "@/lib/hotkey-utils";
+
+interface HotkeyDiagnostics {
+  configuredHotkey: string;
+  normalizedHotkey: string;
+  recordingMode: string;
+  useDifferentPttKey: boolean;
+  pttHotkey: string | null;
+  normalizedPttHotkey: string | null;
+  registrationStatus: string;
+  registrationError?: string | null;
+  lastRegistrationAttemptAt?: string | null;
+  lastSuccessfulRegistrationAt?: string | null;
+  lastEventAt?: string | null;
+  lastEventKind?: string | null;
+  lastEventState?: string | null;
+  eventCount: number;
+  currentRecordingState?: string | null;
+  generatedAt: string;
+  isRegistered: boolean | null;
+}
 
 interface QuickFix {
   id: string;
   title: string;
-  icon: any;
+  icon: ComponentType<{ className?: string }>;
   issue: string;
   solution: string;
   checkStatus?: () => boolean;
 }
 
+const HOTKEY_TEST_POLL_MS = 500;
+const HOTKEY_TEST_TIMEOUT_MS = 10_000;
+
+function formatDiagnosticValue(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+  return String(value);
+}
+
+function formatHotkeyDiagnosticLines(diag: HotkeyDiagnostics | null): string[] {
+  if (!diag) {
+    return ["Hotkey Diagnostics: Unavailable"];
+  }
+
+  const lines = [
+    `Configured Hotkey: ${formatDiagnosticValue(diag.configuredHotkey)}`,
+    `Normalized Hotkey: ${formatDiagnosticValue(diag.normalizedHotkey)}`,
+    `Recording Mode: ${formatDiagnosticValue(diag.recordingMode)}`,
+    `Registration Status: ${formatDiagnosticValue(diag.registrationStatus)}`,
+  ];
+
+  if (diag.registrationError) {
+    lines.push(`Registration Error: ${diag.registrationError}`);
+  }
+  if (diag.isRegistered !== undefined) {
+    lines.push(`Is Registered: ${formatDiagnosticValue(diag.isRegistered)}`);
+  }
+  if (diag.useDifferentPttKey) {
+    lines.push(`PTT Hotkey: ${formatDiagnosticValue(diag.pttHotkey)}`);
+    lines.push(`Normalized PTT Hotkey: ${formatDiagnosticValue(diag.normalizedPttHotkey)}`);
+  }
+  if (diag.lastEventAt) {
+    lines.push(
+      `Last Event: ${formatDiagnosticValue(diag.lastEventKind)} (${formatDiagnosticValue(diag.lastEventState)}) at ${diag.lastEventAt}`
+    );
+  } else {
+    lines.push("Last Event: None detected");
+  }
+  lines.push(`Event Count: ${diag.eventCount ?? 0}`);
+  lines.push(`Current Recording State: ${formatDiagnosticValue(diag.currentRecordingState)}`);
+  lines.push(`Generated At: ${formatDiagnosticValue(diag.generatedAt)}`);
+
+  return lines;
+}
+
+export function formatHotkeyDiagnosticContext(diag: HotkeyDiagnostics): string {
+  return formatHotkeyDiagnosticLines(diag).join("\n");
+}
+
+function buildSystemDiagnostics(params: {
+  appVer: string;
+  os: string;
+  osVer: string;
+  deviceId: string;
+  model: string;
+  canRecord: boolean;
+  canAutoInsert: boolean;
+  hotkeyDiag: HotkeyDiagnostics | null;
+}): string {
+  const { appVer, os, osVer, deviceId, model, canRecord, canAutoInsert, hotkeyDiag } = params;
+  const lines: string[] = [
+    `App Version: ${appVer}`,
+    `OS: ${os} ${osVer}`,
+    `Device ID: ${deviceId}`,
+    `Model: ${model}`,
+  ];
+
+  if (os !== "windows") {
+    lines.push(
+      `Microphone Permission: ${canRecord ? "Granted" : "Not granted"}`,
+      `Accessibility Permission: ${canAutoInsert ? "Granted" : "Not granted"}`
+    );
+  }
+
+  lines.push(...formatHotkeyDiagnosticLines(hotkeyDiag));
+  return lines.join("\n");
+}
+
+function getHotkeyGuidance(os: string): string {
+  if (os === "windows") {
+    return "If your hotkey does not work, try a different combination. Security software or antivirus can block global shortcuts.";
+  }
+  if (os === "macos") {
+    return "If Test Hotkey fails, try a different combination and check for conflicts in macOS Keyboard Shortcuts.";
+  }
+  return "If your hotkey does not work, try a different combination and check system shortcut settings.";
+}
+
+function formatLastEventSummary(diag: HotkeyDiagnostics | null): string {
+  if (!diag?.lastEventAt) {
+    return "None detected";
+  }
+  const kind = formatDiagnosticValue(diag.lastEventKind);
+  const state = formatDiagnosticValue(diag.lastEventState);
+  return `${kind} (${state})`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 export function HelpSection() {
-  const [appVersion, setAppVersion] = useState<string>('');
-  const [platformName, setPlatformName] = useState<string>('');
+  const [appVersion, setAppVersion] = useState<string>("");
+  const [platformName, setPlatformName] = useState<string>("");
+  const [osPlatform, setOsPlatform] = useState<string>("");
+  const [osVersionText, setOsVersionText] = useState<string>("");
+  const [deviceId, setDeviceId] = useState<string>("Unknown");
   const [openItems, setOpenItems] = useState<string[]>([]);
-  const [diagnostics, setDiagnostics] = useState<string>('');
+  const [hotkeyDiagnostics, setHotkeyDiagnostics] = useState<HotkeyDiagnostics | null>(null);
+  const [testingHotkey, setTestingHotkey] = useState(false);
   const [showEmailModal, setShowEmailModal] = useState(false);
-  const [emailSubject, setEmailSubject] = useState<string>('');
-  const [emailBody, setEmailBody] = useState<string>('');
+  const [emailSubject, setEmailSubject] = useState<string>("");
+  const [emailBody, setEmailBody] = useState<string>("");
+  const [showReportBugDialog, setShowReportBugDialog] = useState(false);
+  const [reportBugInitialMessage, setReportBugInitialMessage] = useState<string | undefined>();
+  const [reportBugDiagnosticContext, setReportBugDiagnosticContext] = useState<string | undefined>();
   const { settings } = useSettings();
   const canRecord = useCanRecord();
   const canAutoInsert = useCanAutoInsert();
 
+  const loadHotkeyDiagnostics = useCallback(async (): Promise<HotkeyDiagnostics | null> => {
+    try {
+      const diag = await invoke<HotkeyDiagnostics>("get_hotkey_diagnostics");
+      setHotkeyDiagnostics(diag);
+      return diag;
+    } catch (error) {
+      console.error("Failed to get hotkey diagnostics:", error);
+      setHotkeyDiagnostics(null);
+      return null;
+    }
+  }, []);
+
   useEffect(() => {
     const fetchSystemInfo = async () => {
       try {
-        const [appVer, os, osVer, deviceId] = await Promise.all([
+        const [appVer, os, osVer, deviceId, hotkeyDiag] = await Promise.all([
           getVersion(),
           platform(),
           osVersion(),
-          // Best-effort: if backend not ready, ignore and continue
-          invoke<string>('get_device_id').catch(() => 'Unknown')
+          invoke<string>("get_device_id").catch(() => "Unknown"),
+          invoke<HotkeyDiagnostics>("get_hotkey_diagnostics").catch(() => null),
         ]);
+
         setAppVersion(appVer);
+        setOsPlatform(os);
+        setOsVersionText(osVer);
+        setDeviceId(deviceId);
         setPlatformName(`${os} ${osVer}`);
-        
-        // Prepare diagnostics info
-        const lines: string[] = [
-          `App Version: ${appVer}`,
-          `OS: ${os} ${osVer}`,
-          `Device ID: ${deviceId}`,
-          `Model: ${settings?.current_model || 'None selected'}`,
-        ];
-
-        // Hide permission lines on Windows (not required there)
-        if (os !== 'windows') {
-          lines.push(
-            `Microphone Permission: ${canRecord ? 'Granted' : 'Not granted'}`,
-            `Accessibility Permission: ${canAutoInsert ? 'Granted' : 'Not granted'}`
-          );
-        }
-
-        const diag = lines.join('\n');
-        setDiagnostics(diag);
+        setHotkeyDiagnostics(hotkeyDiag);
       } catch (error) {
-        console.error('Failed to get system info:', error);
+        console.error("Failed to get system info:", error);
       }
     };
 
-    fetchSystemInfo();
+    void fetchSystemInfo();
   }, [settings, canRecord, canAutoInsert]);
 
   const quickFixes: QuickFix[] = [
     {
-      id: 'recording',
-      title: 'Recording not working',
+      id: "recording",
+      title: "Recording not working",
       icon: Mic,
-      issue: 'Voice recording doesn\'t start when using hotkey',
-      solution: 'Go to Advanced section and check if Microphone permission is granted. Also check Settings to ensure a recording device is selected.',
-      checkStatus: () => canRecord
+      issue: "Voice recording doesn't start when using hotkey",
+      solution:
+        "Go to Advanced section and check if Microphone permission is granted. Also check Settings to ensure a recording device is selected.",
+      checkStatus: () => canRecord,
     },
     {
-      id: 'hotkey',
-      title: 'Hotkey not responding',
+      id: "hotkey",
+      title: "Hotkey not responding",
       icon: Keyboard,
-      issue: 'Global hotkey doesn\'t trigger recording',
-      solution: 'Go to Advanced section and grant Accessibility permission. This is required for global hotkeys to work.',
-      checkStatus: () => canAutoInsert
+      issue: "Global hotkey doesn't trigger recording",
+      solution:
+        osPlatform === "windows"
+          ? "Use Test Hotkey below. If it fails, try another combination and allow VoiceTypr in your security or antivirus software."
+          : osPlatform === "macos"
+            ? "Use Test Hotkey below. If it fails, try another combination and check macOS Keyboard Shortcuts for conflicts."
+            : "Use Test Hotkey below and check for system shortcut conflicts.",
+      checkStatus: () =>
+        hotkeyDiagnostics?.isRegistered === true ||
+        hotkeyDiagnostics?.registrationStatus === "registered",
     },
     {
-      id: 'insertion',
-      title: 'Text not inserting',
+      id: "insertion",
+      title: "Text not inserting",
       icon: Type,
-      issue: 'Transcribed text doesn\'t appear at cursor',
-      solution: 'Make sure your cursor is in an active text field. Accessibility permission must be granted in Advanced section.',
-      checkStatus: () => canAutoInsert
+      issue: "Transcribed text doesn't appear at cursor",
+      solution:
+        "Make sure your cursor is in an active text field. Accessibility permission must be granted in Advanced section.",
+      checkStatus: () => canAutoInsert,
     },
     {
-      id: 'download',
-      title: 'Model download stuck',
+      id: "download",
+      title: "Model download stuck",
       icon: Download,
-      issue: 'Whisper model download not progressing',
-      solution: 'Go to Models section, cancel the current download and try again. Check your internet connection.'
-    }
+      issue: "Whisper model download not progressing",
+      solution:
+        "Go to Models section, cancel the current download and try again. Check your internet connection.",
+    },
   ];
 
   const toggleItem = (itemId: string) => {
-    setOpenItems(prev => 
-      prev.includes(itemId) 
-        ? prev.filter(id => id !== itemId)
-        : [...prev, itemId]
+    setOpenItems((prev) =>
+      prev.includes(itemId) ? prev.filter((id) => id !== itemId) : [...prev, itemId]
     );
   };
 
@@ -155,7 +294,7 @@ Expected behavior:
 Actual behavior:
 
 `;
-    
+
     setEmailSubject(subject);
     setEmailBody(body);
     setShowEmailModal(true);
@@ -166,10 +305,10 @@ Actual behavior:
     try {
       await open(gmailUrl);
       setShowEmailModal(false);
-      toast.success('Opening Gmail in browser');
+      toast.success("Opening Gmail in browser");
     } catch (error) {
-      console.error('Failed to open Gmail:', error);
-      toast.error('Failed to open Gmail');
+      console.error("Failed to open Gmail:", error);
+      toast.error("Failed to open Gmail");
     }
   };
 
@@ -178,47 +317,104 @@ Actual behavior:
     try {
       await open(mailtoUrl);
       setShowEmailModal(false);
-      toast.success('Opening default email client');
+      toast.success("Opening default email client");
     } catch (error) {
-      console.error('Failed to open email client:', error);
-      toast.error('Failed to open email client');
+      console.error("Failed to open email client:", error);
+      toast.error("Failed to open email client");
     }
   };
 
-
   const handleXSupport = async () => {
-    const xUrl = 'https://x.com/voicetypr';
+    const xUrl = "https://x.com/voicetypr";
     try {
       await open(xUrl);
     } catch (error) {
-      console.error('Failed to open X profile:', error);
-      toast.error('Failed to open X profile');
+      console.error("Failed to open X profile:", error);
+      toast.error("Failed to open X profile");
     }
   };
 
   const handleCopySystemInfo = async () => {
     try {
       await navigator.clipboard.writeText(diagnostics);
-      toast.success('System info copied to clipboard');
+      toast.success("System info copied to clipboard");
     } catch (error) {
-      console.error('Failed to copy system info:', error);
-      toast.error('Failed to copy system info');
+      console.error("Failed to copy system info:", error);
+      toast.error("Failed to copy system info");
     }
   };
 
   const handleOpenLogs = async () => {
     try {
-      await invoke('open_logs_folder');
-      toast.info('Please attach the latest log file to your support message');
+      await invoke("open_logs_folder");
+      toast.info("Please attach the latest log file to your support message");
     } catch (error) {
-      console.error('Failed to open logs folder:', error);
-      toast.error('Failed to open logs folder');
+      console.error("Failed to open logs folder:", error);
+      toast.error("Failed to open logs folder");
     }
   };
 
+  const handleTestHotkey = async () => {
+    if (testingHotkey) return;
+
+    setTestingHotkey(true);
+    toast.info("Press your hotkey now");
+
+    try {
+      const baseline = await loadHotkeyDiagnostics();
+      const startCount = baseline?.eventCount ?? 0;
+      const deadline = Date.now() + HOTKEY_TEST_TIMEOUT_MS;
+
+      while (Date.now() < deadline) {
+        await sleep(HOTKEY_TEST_POLL_MS);
+        const current = await invoke<HotkeyDiagnostics>("get_hotkey_diagnostics");
+        setHotkeyDiagnostics(current);
+
+        if (current.eventCount > startCount) {
+          toast.success("Hotkey detected");
+          return;
+        }
+      }
+
+      toast.error("No hotkey was detected");
+    } catch (error) {
+      console.error("Failed to test hotkey:", error);
+      toast.error("Failed to test hotkey");
+    } finally {
+      setTestingHotkey(false);
+    }
+  };
+
+  const handleReportHotkeyIssue = async () => {
+    const diag = await loadHotkeyDiagnostics();
+    setReportBugInitialMessage(
+      "I'm having trouble with my global hotkey.\n\nWhat I tried:\n\nWhat I expected:\n\nWhat happened instead:\n"
+    );
+    setReportBugDiagnosticContext(
+      diag ? formatHotkeyDiagnosticContext(diag) : "Hotkey diagnostics unavailable."
+    );
+    setShowReportBugDialog(true);
+  };
+
+  const configuredHotkeyLabel = hotkeyDiagnostics?.configuredHotkey
+    ? formatHotkey(hotkeyDiagnostics.configuredHotkey)
+    : settings?.hotkey
+      ? formatHotkey(settings.hotkey)
+      : "—";
+
+  const diagnostics = buildSystemDiagnostics({
+    appVer: appVersion || "Unknown",
+    os: osPlatform || "unknown",
+    osVer: osVersionText || "Unknown",
+    deviceId,
+    model: settings?.current_model || "None selected",
+    canRecord,
+    canAutoInsert,
+    hotkeyDiag: hotkeyDiagnostics,
+  });
+
   return (
     <div className="h-full min-h-0 flex flex-col">
-      {/* Header */}
       <div className="shrink-0 px-6 py-4 border-b border-border/40">
         <div className="flex items-center justify-between">
           <div>
@@ -232,15 +428,14 @@ Actual behavior:
 
       <ScrollArea className="flex-1 min-h-0">
         <div className="p-6 space-y-6">
-          {/* Quick Fixes Section */}
           <div className="space-y-4">
             <h2 className="text-base font-semibold">Quick Fixes</h2>
-            
+
             <div className="space-y-2">
-              {quickFixes.map(fix => {
+              {quickFixes.map((fix) => {
                 const Icon = fix.icon;
                 const isOpen = openItems.includes(fix.id);
-                
+
                 return (
                   <Collapsible
                     key={fix.id}
@@ -253,9 +448,11 @@ Actual behavior:
                           <Icon className="h-4 w-4 text-muted-foreground" />
                           <span className="text-sm font-medium">{fix.title}</span>
                         </div>
-                        <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+                        <ChevronDown
+                          className={`h-4 w-4 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""}`}
+                        />
                       </CollapsibleTrigger>
-                      
+
                       <CollapsibleContent>
                         <div className="px-4 pb-4 pt-2 space-y-3 border-t border-border/50">
                           <div className="space-y-2">
@@ -263,7 +460,7 @@ Actual behavior:
                               <p className="text-xs font-medium text-muted-foreground">Issue</p>
                               <p className="text-sm">{fix.issue}</p>
                             </div>
-                            
+
                             <div className="space-y-1 mt-3">
                               <p className="text-xs font-medium text-muted-foreground">Solution</p>
                               <p className="text-sm">{fix.solution}</p>
@@ -278,10 +475,9 @@ Actual behavior:
             </div>
           </div>
 
-          {/* Contact Support Section */}
           <div className="space-y-4">
             <h2 className="text-base font-semibold">Get Support</h2>
-            
+
             <div className="space-y-3">
               <button
                 onClick={handleXSupport}
@@ -321,10 +517,55 @@ Actual behavior:
             </div>
           </div>
 
-          {/* Diagnostics Section */}
           <div className="space-y-4">
             <h2 className="text-base font-semibold">Diagnostics</h2>
-            
+
+            <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <Keyboard className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-sm font-medium">Hotkey Diagnostics</h3>
+              </div>
+
+              <dl className="grid gap-2 text-xs">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Configured hotkey</dt>
+                  <dd className="font-medium text-right">{configuredHotkeyLabel}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Registration</dt>
+                  <dd className="font-medium text-right">
+                    {formatDiagnosticValue(hotkeyDiagnostics?.registrationStatus)}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">Last event</dt>
+                  <dd className="font-medium text-right">{formatLastEventSummary(hotkeyDiagnostics)}</dd>
+                </div>
+              </dl>
+
+              <p className="text-xs text-muted-foreground">{getHotkeyGuidance(osPlatform)}</p>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void handleTestHotkey()}
+                  disabled={testingHotkey}
+                >
+                  {testingHotkey ? "Testing…" : "Test Hotkey"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void handleReportHotkeyIssue()}
+                >
+                  Report Hotkey Issue
+                </Button>
+              </div>
+            </div>
+
             <div className="space-y-3">
               <button
                 onClick={handleCopySystemInfo}
@@ -337,7 +578,7 @@ Actual behavior:
                   <div className="text-left">
                     <p className="text-sm font-medium">Copy System Info</p>
                     <p className="text-xs text-muted-foreground">
-                      Copy basic system information to clipboard
+                      Copy system and hotkey diagnostics to clipboard
                     </p>
                   </div>
                 </div>
@@ -364,7 +605,6 @@ Actual behavior:
             </div>
           </div>
 
-          {/* System Info Footer */}
           <div className="pt-4">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>VoiceTypr v{appVersion}</span>
@@ -374,7 +614,6 @@ Actual behavior:
         </div>
       </ScrollArea>
 
-      {/* Email Client Selection Modal */}
       <Dialog open={showEmailModal} onOpenChange={setShowEmailModal}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -413,6 +652,13 @@ Actual behavior:
           </div>
         </DialogContent>
       </Dialog>
+
+      <ReportBugDialog
+        isOpen={showReportBugDialog}
+        onClose={() => setShowReportBugDialog(false)}
+        initialMessage={reportBugInitialMessage}
+        diagnosticContext={reportBugDiagnosticContext}
+      />
     </div>
   );
 }

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -179,6 +179,41 @@ describe('HelpSection hotkey flows', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it('cancels recording if Test Hotkey starts one from idle', async () => {
+    let hotkeyDiagCall = 0;
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'cancel_recording') {
+        return Promise.resolve(undefined);
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        hotkeyDiagCall += 1;
+        const detected = hotkeyDiagCall >= 3;
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          eventCount: detected ? 1 : 0,
+          currentRecordingState: detected ? 'recording' : 'idle',
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    await waitFor(
+      () => {
+        expect(mockInvoke).toHaveBeenCalledWith('cancel_recording');
+        expect(toast.success).toHaveBeenCalledWith('Hotkey detected');
+      },
+      { timeout: 3000 }
+    );
+  });
+
   it('shows timeout error when no hotkey event is detected', async () => {
     const dateNow = vi.spyOn(Date, 'now');
     let now = 1_000_000;

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -134,7 +134,7 @@ function mockDefaultInvoke() {
   });
 }
 
-describe('HelpSection hotkey flows', () => {
+describe('HelpSection diagnostics flows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDefaultInvoke();
@@ -147,9 +147,99 @@ describe('HelpSection hotkey flows', () => {
   async function renderHelpSection() {
     render(<HelpSection />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /run check/i })).toBeInTheDocument();
     });
   }
+
+  it('shows generic diagnostics labels and current hotkey-only issue summary', async () => {
+    await renderHelpSection();
+
+    expect(screen.getByRole('heading', { name: 'Diagnostics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'System check' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('No issue found yet — run a check to verify input capture')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Not tested yet')).toBeInTheDocument();
+    expect(screen.getByText('Latest issue')).toBeInTheDocument();
+    expect(screen.getByText('Last checked')).toBeInTheDocument();
+    expect(screen.getByText('Just now')).toBeInTheDocument();
+    expect(screen.queryByText('Hotkey Diagnostics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Configured hotkey')).not.toBeInTheDocument();
+    expect(screen.queryByText('Last event')).not.toBeInTheDocument();
+  });
+
+  it('shows generic attention summary when registration failed', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          registrationStatus: 'failed',
+          isRegistered: false,
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Needs attention')).toBeInTheDocument();
+      expect(screen.getByText('Global hotkey is not registered')).toBeInTheDocument();
+    });
+  });
+
+  it('shows restored-after-failure registration error as latest issue', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          registrationStatus: 'restored_after_failure',
+          registrationError: 'Shortcut already registered by another app',
+          isRegistered: true,
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Needs attention')).toBeInTheDocument();
+      expect(screen.getByText('Shortcut already registered by another app')).toBeInTheDocument();
+    });
+  });
+
+  it('shows all good summary when input capture has been observed', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          lastEventAt: '2026-05-31T00:00:02Z',
+          lastEventKind: 'recording',
+          lastEventState: 'pressed',
+          eventCount: 1,
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument();
+      expect(screen.getByText('None')).toBeInTheDocument();
+    });
+  });
 
   it('shows success when eventCount increases during hotkey test', async () => {
     let hotkeyDiagCall = 0;
@@ -168,7 +258,7 @@ describe('HelpSection hotkey flows', () => {
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
 
     await waitFor(
       () => {
@@ -203,7 +293,7 @@ describe('HelpSection hotkey flows', () => {
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
 
     await waitFor(
       () => {
@@ -236,7 +326,7 @@ describe('HelpSection hotkey flows', () => {
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
 
     await waitFor(
       () => {
@@ -254,7 +344,7 @@ describe('HelpSection hotkey flows', () => {
 
     await renderHelpSection();
 
-    await user.click(screen.getByRole('button', { name: /report hotkey issue/i }));
+    await user.click(screen.getByRole('button', { name: /report issue/i }));
 
     await waitFor(() => {
       expect(mockReportBugDialog).toHaveBeenCalled();
@@ -283,11 +373,11 @@ describe('HelpSection hotkey flows', () => {
 
     const { unmount } = render(<HelpSection />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /run check/i })).toBeInTheDocument();
     });
 
     vi.useFakeTimers({ toFake: ['setTimeout', 'Date'] });
-    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
 
     const callsWhenStarted = invokeCallsBeforeUnmount.count;
     unmount();

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -7,6 +7,17 @@ import { toast } from 'sonner';
 
 const mockInvoke = vi.fn();
 const mockReportBugDialog = vi.fn();
+let mockCanRecord = true;
+let mockCanAutoInsert = true;
+let mockReadinessSnapshot = {
+  has_accessibility_permission: true as boolean | null,
+  has_microphone_permission: true as boolean | null,
+  has_models: true as boolean | null,
+  selected_model_available: true as boolean | null,
+};
+const mockCheckMicrophonePermission = vi.fn();
+const mockCheckAccessibilityPermission = vi.fn();
+const mockCheckModels = vi.fn();
 
 const baseHotkeyDiag = {
   configuredHotkey: 'CommandOrControl+Shift+Space',
@@ -49,8 +60,23 @@ vi.mock('@/contexts/SettingsContext', () => ({
 }));
 
 vi.mock('@/contexts/ReadinessContext', () => ({
-  useCanRecord: () => true,
-  useCanAutoInsert: () => true,
+  useReadiness: () => ({
+    canRecord: mockCanRecord,
+    canAutoInsert: mockCanAutoInsert,
+    hasAccessibilityPermission: mockReadinessSnapshot.has_accessibility_permission,
+    hasMicrophonePermission: mockReadinessSnapshot.has_microphone_permission,
+    hasModels: mockReadinessSnapshot.has_models,
+    selectedModelAvailable: mockReadinessSnapshot.selected_model_available,
+    licenseValid: true,
+    isFullyReady: mockCanRecord && mockCanAutoInsert,
+    isLoading: false,
+    checkAccessibilityPermission: mockCheckAccessibilityPermission,
+    checkMicrophonePermission: mockCheckMicrophonePermission,
+    checkModels: mockCheckModels,
+    checkLicense: vi.fn(),
+    requestAccessibilityPermission: vi.fn(),
+    requestMicrophonePermission: vi.fn(),
+  }),
 }));
 
 vi.mock('sonner', () => ({
@@ -137,6 +163,14 @@ function mockDefaultInvoke() {
 describe('HelpSection diagnostics flows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanRecord = true;
+    mockCanAutoInsert = true;
+    mockReadinessSnapshot = {
+      has_accessibility_permission: true,
+      has_microphone_permission: true,
+      has_models: true,
+      selected_model_available: true,
+    };
     mockDefaultInvoke();
   });
 
@@ -147,26 +181,45 @@ describe('HelpSection diagnostics flows', () => {
   async function renderHelpSection() {
     render(<HelpSection />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run check/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
     });
   }
 
-  it('shows generic diagnostics labels and current hotkey-only issue summary', async () => {
+  it('shows generic diagnostics labels and pipeline summary', async () => {
     await renderHelpSection();
 
     expect(screen.getByRole('heading', { name: 'Diagnostics' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'System check' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Current status' })).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByText('No issue found yet — run a check to verify input capture')).toBeInTheDocument();
+      expect(screen.getByText('No readiness issue detected')).toBeInTheDocument();
     });
     expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Not tested yet')).toBeInTheDocument();
+    expect(screen.getByText('Ready')).toBeInTheDocument();
     expect(screen.getByText('Latest issue')).toBeInTheDocument();
     expect(screen.getByText('Last checked')).toBeInTheDocument();
     expect(screen.getByText('Just now')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /run check/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
     expect(screen.queryByText('Hotkey Diagnostics')).not.toBeInTheDocument();
     expect(screen.queryByText('Configured hotkey')).not.toBeInTheDocument();
     expect(screen.queryByText('Last event')).not.toBeInTheDocument();
+  });
+
+  it('shows microphone readiness issue before shortcut details', async () => {
+    mockCanRecord = false;
+    mockReadinessSnapshot = {
+      has_accessibility_permission: true,
+      has_microphone_permission: false,
+      has_models: true,
+      selected_model_available: true,
+    };
+
+    await renderHelpSection();
+
+    await waitFor(() => {
+      expect(screen.getByText('Needs attention')).toBeInTheDocument();
+      expect(screen.getByText('Microphone permission is missing')).toBeInTheDocument();
+    });
   });
 
   it('shows generic attention summary when registration failed', async () => {
@@ -216,28 +269,12 @@ describe('HelpSection diagnostics flows', () => {
     });
   });
 
-  it('shows all good summary when input capture has been observed', async () => {
-    mockInvoke.mockImplementation((cmd: string) => {
-      if (cmd === 'get_device_id') {
-        return Promise.resolve('device-1');
-      }
-      if (cmd === 'get_hotkey_diagnostics') {
-        return Promise.resolve({
-          ...baseHotkeyDiag,
-          lastEventAt: '2026-05-31T00:00:02Z',
-          lastEventKind: 'recording',
-          lastEventState: 'pressed',
-          eventCount: 1,
-        });
-      }
-      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
-    });
-
+  it('shows ready summary when pipeline signals are healthy', async () => {
     await renderHelpSection();
 
     await waitFor(() => {
-      expect(screen.getByText('All good')).toBeInTheDocument();
-      expect(screen.getByText('None')).toBeInTheDocument();
+      expect(screen.getByText('Ready')).toBeInTheDocument();
+      expect(screen.getByText('No readiness issue detected')).toBeInTheDocument();
     });
   });
 
@@ -248,17 +285,24 @@ describe('HelpSection diagnostics flows', () => {
       if (cmd === 'get_device_id') {
         return Promise.resolve('device-1');
       }
+      if (cmd === 'cancel_recording') {
+        return Promise.resolve(undefined);
+      }
       if (cmd === 'get_hotkey_diagnostics') {
         hotkeyDiagCall += 1;
         const eventCount = hotkeyDiagCall >= 3 ? 1 : 0;
-        return Promise.resolve({ ...baseHotkeyDiag, eventCount });
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          eventCount,
+          currentRecordingState: eventCount > 0 ? 'recording' : 'idle',
+        });
       }
       return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
     });
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
 
     await waitFor(
       () => {
@@ -293,7 +337,7 @@ describe('HelpSection diagnostics flows', () => {
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
 
     await waitFor(
       () => {
@@ -304,6 +348,38 @@ describe('HelpSection diagnostics flows', () => {
     );
   });
 
+  it('reports when the shortcut event arrives but recording never starts', async () => {
+    let hotkeyDiagCall = 0;
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        hotkeyDiagCall += 1;
+        const detected = hotkeyDiagCall >= 3;
+        return Promise.resolve({
+          ...baseHotkeyDiag,
+          eventCount: detected ? 1 : 0,
+          currentRecordingState: detected ? 'error' : 'idle',
+        });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    await waitFor(
+      () => {
+        expect(toast.error).toHaveBeenCalledWith('Hotkey detected, but recording did not start');
+      },
+      { timeout: 3000 }
+    );
+    expect(screen.getByText('Hotkey detected, but recording did not start')).toBeInTheDocument();
+
+  });
   it('shows timeout error when no hotkey event is detected', async () => {
     const dateNow = vi.spyOn(Date, 'now');
     let now = 1_000_000;
@@ -326,7 +402,7 @@ describe('HelpSection diagnostics flows', () => {
 
     await renderHelpSection();
 
-    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
 
     await waitFor(
       () => {
@@ -373,11 +449,11 @@ describe('HelpSection diagnostics flows', () => {
 
     const { unmount } = render(<HelpSection />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /run check/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
     });
 
     vi.useFakeTimers({ toFake: ['setTimeout', 'Date'] });
-    fireEvent.click(screen.getByRole('button', { name: /run check/i }));
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
 
     const callsWhenStarted = invokeCallsBeforeUnmount.count;
     unmount();

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -278,6 +278,38 @@ describe('HelpSection diagnostics flows', () => {
     });
   });
 
+  it('does not treat stale event counts as success when baseline diagnostics fail', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let failNextDiagnostics = false;
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        if (failNextDiagnostics) {
+          failNextDiagnostics = false;
+          return Promise.reject(new Error('diagnostics unavailable'));
+        }
+        return Promise.resolve({ ...baseHotkeyDiag, eventCount: 3 });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+    await waitFor(() => {
+      expect(screen.getByText('Ready')).toBeInTheDocument();
+    });
+    failNextDiagnostics = true;
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Shortcut diagnostics unavailable');
+    });
+    expect(toast.success).not.toHaveBeenCalledWith('Hotkey detected');
+    expect(screen.getByText('Shortcut diagnostics unavailable')).toBeInTheDocument();
+  });
+
   it('shows success when eventCount increases during hotkey test', async () => {
     let hotkeyDiagCall = 0;
 
@@ -378,8 +410,8 @@ describe('HelpSection diagnostics flows', () => {
       { timeout: 3000 }
     );
     expect(screen.getByText('Hotkey detected, but recording did not start')).toBeInTheDocument();
-
   });
+
   it('shows timeout error when no hotkey event is detected', async () => {
     const dateNow = vi.spyOn(Date, 'now');
     let now = 1_000_000;

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/app', () => ({ getVersion: vi.fn() }));
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: vi.fn(() => 'macos'),
+  type: vi.fn(() => 'macos'),
+  version: vi.fn(() => '15.0'),
+}));
+vi.mock('@tauri-apps/plugin-shell', () => ({ open: vi.fn() }));
+import { formatHotkeyDiagnosticContext } from '../HelpSection';
+
+describe('formatHotkeyDiagnosticContext', () => {
+  it('formats hotkey registration and event fields for support reports', () => {
+    const context = formatHotkeyDiagnosticContext({
+      configuredHotkey: 'CommandOrControl+Shift+Space',
+      normalizedHotkey: 'CommandOrControl+Shift+Space',
+      recordingMode: 'toggle',
+      useDifferentPttKey: false,
+      pttHotkey: null,
+      normalizedPttHotkey: null,
+      registrationStatus: 'registered',
+      registrationError: null,
+      lastRegistrationAttemptAt: '2026-05-31T00:00:00Z',
+      lastSuccessfulRegistrationAt: '2026-05-31T00:00:01Z',
+      lastEventAt: '2026-05-31T00:00:02Z',
+      lastEventKind: 'recording',
+      lastEventState: 'pressed',
+      eventCount: 3,
+      currentRecordingState: 'idle',
+      generatedAt: '2026-05-31T00:00:03Z',
+      isRegistered: true,
+    });
+
+    expect(context).toContain('Configured Hotkey: CommandOrControl+Shift+Space');
+    expect(context).toContain('Registration Status: registered');
+    expect(context).toContain('Is Registered: true');
+    expect(context).toContain('Last Event: recording (pressed) at 2026-05-31T00:00:02Z');
+    expect(context).toContain('Event Count: 3');
+  });
+});

--- a/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
+++ b/src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx
@@ -1,41 +1,269 @@
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HelpSection } from '../HelpSection';
+import { formatHotkeyDiagnosticContext } from '@/utils/hotkeyDiagnostics';
+import { toast } from 'sonner';
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
-vi.mock('@tauri-apps/api/app', () => ({ getVersion: vi.fn() }));
+const mockInvoke = vi.fn();
+const mockReportBugDialog = vi.fn();
+
+const baseHotkeyDiag = {
+  configuredHotkey: 'CommandOrControl+Shift+Space',
+  normalizedHotkey: 'CommandOrControl+Shift+Space',
+  recordingMode: 'toggle',
+  useDifferentPttKey: false,
+  pttHotkey: null,
+  normalizedPttHotkey: null,
+  registrationStatus: 'registered',
+  registrationError: null,
+  lastRegistrationAttemptAt: '2026-05-31T00:00:00Z',
+  lastSuccessfulRegistrationAt: '2026-05-31T00:00:01Z',
+  lastEventAt: null,
+  lastEventKind: null,
+  lastEventState: null,
+  eventCount: 0,
+  currentRecordingState: 'idle',
+  generatedAt: '2026-05-31T00:00:03Z',
+  isRegistered: true,
+};
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('1.0.0'),
+}));
+
 vi.mock('@tauri-apps/plugin-os', () => ({
   platform: vi.fn(() => 'macos'),
   type: vi.fn(() => 'macos'),
   version: vi.fn(() => '15.0'),
 }));
+
 vi.mock('@tauri-apps/plugin-shell', () => ({ open: vi.fn() }));
-import { formatHotkeyDiagnosticContext } from '../HelpSection';
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({ settings: { current_model: 'base.en' } }),
+}));
+
+vi.mock('@/contexts/ReadinessContext', () => ({
+  useCanRecord: () => true,
+  useCanAutoInsert: () => true,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/ReportBugDialog', () => ({
+  ReportBugDialog: (props: {
+    isOpen: boolean;
+    initialMessage?: string;
+    diagnosticContext?: string;
+    onClose: () => void;
+  }) => {
+    mockReportBugDialog(props);
+    return props.isOpen ? <div data-testid="report-bug-dialog" /> : null;
+  },
+}));
+
+vi.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
 
 describe('formatHotkeyDiagnosticContext', () => {
   it('formats hotkey registration and event fields for support reports', () => {
     const context = formatHotkeyDiagnosticContext({
-      configuredHotkey: 'CommandOrControl+Shift+Space',
-      normalizedHotkey: 'CommandOrControl+Shift+Space',
-      recordingMode: 'toggle',
-      useDifferentPttKey: false,
-      pttHotkey: null,
-      normalizedPttHotkey: null,
-      registrationStatus: 'registered',
-      registrationError: null,
-      lastRegistrationAttemptAt: '2026-05-31T00:00:00Z',
-      lastSuccessfulRegistrationAt: '2026-05-31T00:00:01Z',
+      ...baseHotkeyDiag,
       lastEventAt: '2026-05-31T00:00:02Z',
       lastEventKind: 'recording',
       lastEventState: 'pressed',
       eventCount: 3,
-      currentRecordingState: 'idle',
-      generatedAt: '2026-05-31T00:00:03Z',
-      isRegistered: true,
     });
 
     expect(context).toContain('Configured Hotkey: CommandOrControl+Shift+Space');
-    expect(context).toContain('Registration Status: registered');
+    expect(context).toContain('Registration Status: Registered');
     expect(context).toContain('Is Registered: true');
     expect(context).toContain('Last Event: recording (pressed) at 2026-05-31T00:00:02Z');
     expect(context).toContain('Event Count: 3');
+  });
+
+  it('formats restored_after_failure status readably and keeps registration error', () => {
+    const context = formatHotkeyDiagnosticContext({
+      ...baseHotkeyDiag,
+      registrationStatus: 'restored_after_failure',
+      registrationError: 'Shortcut already registered by another app',
+      isRegistered: true,
+    });
+
+    expect(context).toContain('Registration Status: Restored previous hotkey after failure');
+    expect(context).toContain('Registration Error: Shortcut already registered by another app');
+  });
+});
+
+function mockDefaultInvoke() {
+  mockInvoke.mockImplementation((cmd: string) => {
+    if (cmd === 'get_device_id') {
+      return Promise.resolve('device-1');
+    }
+    if (cmd === 'get_hotkey_diagnostics') {
+      return Promise.resolve({ ...baseHotkeyDiag });
+    }
+    return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+  });
+}
+
+describe('HelpSection hotkey flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDefaultInvoke();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function renderHelpSection() {
+    render(<HelpSection />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
+    });
+  }
+
+  it('shows success when eventCount increases during hotkey test', async () => {
+    let hotkeyDiagCall = 0;
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        hotkeyDiagCall += 1;
+        const eventCount = hotkeyDiagCall >= 3 ? 1 : 0;
+        return Promise.resolve({ ...baseHotkeyDiag, eventCount });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    await waitFor(
+      () => {
+        expect(toast.success).toHaveBeenCalledWith('Hotkey detected');
+      },
+      { timeout: 3000 }
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows timeout error when no hotkey event is detected', async () => {
+    const dateNow = vi.spyOn(Date, 'now');
+    let now = 1_000_000;
+    let hotkeyDiagCall = 0;
+    dateNow.mockImplementation(() => now);
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        hotkeyDiagCall += 1;
+        if (hotkeyDiagCall > 2) {
+          now += 11_000;
+        }
+        return Promise.resolve({ ...baseHotkeyDiag, eventCount: 0 });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    await renderHelpSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    await waitFor(
+      () => {
+        expect(toast.error).toHaveBeenCalledWith('No hotkey was detected');
+      },
+      { timeout: 3000 }
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+
+    dateNow.mockRestore();
+  });
+
+  it('opens Report Bug dialog with hotkey diagnostic context', async () => {
+    const user = userEvent.setup();
+
+    await renderHelpSection();
+
+    await user.click(screen.getByRole('button', { name: /report hotkey issue/i }));
+
+    await waitFor(() => {
+      expect(mockReportBugDialog).toHaveBeenCalled();
+    });
+
+    const lastCall = mockReportBugDialog.mock.calls[mockReportBugDialog.mock.calls.length - 1]?.[0];
+    expect(lastCall?.isOpen).toBe(true);
+    expect(lastCall?.initialMessage).toContain('global hotkey');
+    expect(lastCall?.diagnosticContext).toContain('Configured Hotkey: CommandOrControl+Shift+Space');
+    expect(screen.getByTestId('report-bug-dialog')).toBeInTheDocument();
+  });
+
+  it('stops hotkey test polling after unmount', async () => {
+    const invokeCallsBeforeUnmount = { count: 0 };
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_device_id') {
+        return Promise.resolve('device-1');
+      }
+      if (cmd === 'get_hotkey_diagnostics') {
+        invokeCallsBeforeUnmount.count += 1;
+        return Promise.resolve({ ...baseHotkeyDiag, eventCount: 0 });
+      }
+      return Promise.reject(new Error(`unexpected invoke: ${cmd}`));
+    });
+
+    const { unmount } = render(<HelpSection />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /test hotkey/i })).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'Date'] });
+    fireEvent.click(screen.getByRole('button', { name: /test hotkey/i }));
+
+    const callsWhenStarted = invokeCallsBeforeUnmount.count;
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_500);
+    });
+    vi.useRealTimers();
+
+    expect(invokeCallsBeforeUnmount.count).toBeLessThanOrEqual(callsWhenStarted + 1);
+    expect(toast.error).not.toHaveBeenCalledWith('No hotkey was detected');
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/src/services/updateService.test.ts
+++ b/src/services/updateService.test.ts
@@ -149,6 +149,21 @@ describe('UpdateService update consent', () => {
     expect(relaunch).not.toHaveBeenCalled();
   });
 
+  it('auto-installs background updates only after explicit opt-in', async () => {
+    await service.initialize({
+      hotkey: 'CommandOrControl+Shift+Space',
+      current_model: 'base.en',
+      language: 'en',
+      theme: 'system',
+      install_updates_automatically: true,
+    });
+
+    expect(check).toHaveBeenCalledOnce();
+    expect(ask).not.toHaveBeenCalled();
+    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(relaunch).toHaveBeenCalledOnce();
+  });
+
   it('downloads and relaunches only after user accepts', async () => {
     vi.mocked(ask).mockResolvedValue(true);
 

--- a/src/services/updateService.test.ts
+++ b/src/services/updateService.test.ts
@@ -32,6 +32,10 @@ vi.mock('sonner', () => ({
   },
 }));
 
+import { check, type Update } from '@tauri-apps/plugin-updater';
+import { ask } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
+import { relaunch } from '@tauri-apps/plugin-process';
 import { UpdateService } from './updateService';
 
 const JUST_UPDATED_KEY = 'just_updated_version';
@@ -95,5 +99,64 @@ describe('UpdateService version marker', () => {
 
     const result = freshService.getJustUpdatedVersion();
     expect(result).toBe('1.12.1');
+  });
+});
+
+describe('UpdateService update consent', () => {
+  let service: UpdateService;
+  let update: Update;
+  let downloadAndInstall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    // @ts-expect-error accessing private static for test isolation
+    UpdateService.instance = undefined;
+    service = UpdateService.getInstance();
+    downloadAndInstall = vi.fn(async () => undefined);
+    update = {
+      available: true,
+      version: '1.12.4',
+      currentVersion: '1.12.3',
+      body: 'Bug fixes',
+      date: null,
+      rawJson: {},
+      downloadAndInstall,
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Update;
+    vi.mocked(check).mockResolvedValue(update);
+    vi.mocked(invoke).mockResolvedValue({ state: 'idle' });
+  });
+
+  it('prompts on startup but does not download when user declines', async () => {
+    vi.mocked(ask).mockResolvedValue(false);
+
+    await service.initialize({
+      hotkey: 'CommandOrControl+Shift+Space',
+      current_model: 'base.en',
+      language: 'en',
+      theme: 'system',
+    });
+
+    expect(check).toHaveBeenCalledOnce();
+    expect(ask).toHaveBeenCalledWith(expect.stringContaining('Update 1.12.4 is available'), {
+      title: 'Update Available',
+      kind: 'info',
+      okLabel: 'Update',
+      cancelLabel: 'Later',
+    });
+    expect(downloadAndInstall).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it('downloads and relaunches only after user accepts', async () => {
+    vi.mocked(ask).mockResolvedValue(true);
+
+    await service.checkForUpdatesManually();
+
+    expect(check).toHaveBeenCalledOnce();
+    expect(ask).toHaveBeenCalled();
+    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(relaunch).toHaveBeenCalledOnce();
   });
 });

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -17,6 +17,7 @@ export class UpdateService {
   private isSessionActive = false;
   private pendingRelaunch = false;
   private pendingUpdateVersion: string | null = null;
+  private installUpdatesAutomatically = false;
 
   private constructor() {}
 
@@ -95,8 +96,9 @@ export class UpdateService {
    * - Sets up daily update checks
    */
   async initialize(settings: AppSettings): Promise<void> {
-    // Check if automatic updates are enabled (default to true if not set)
+    // Check for updates automatically by default, but only install automatically after explicit opt-in.
     const autoUpdateEnabled = settings.check_updates_automatically ?? true;
+    this.installUpdatesAutomatically = settings.install_updates_automatically ?? false;
 
     if (!autoUpdateEnabled) {
       console.log('Automatic updates are disabled');
@@ -182,7 +184,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update);
+        await this.handleBackgroundUpdateAvailable(update);
       }
     } catch (error) {
       console.error('Background update check failed:', error);
@@ -211,7 +213,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update);
+        await this.showUpdateDialog(update);
       } else {
         toast.success("You're on the latest version!");
       }
@@ -224,10 +226,72 @@ export class UpdateService {
   }
 
   /**
-   * Handle when an update is available
+   * Handle updates found by automatic/background checks.
    */
-  private async handleUpdateAvailable(update: Update): Promise<void> {
+  private async handleBackgroundUpdateAvailable(update: Update): Promise<void> {
+    if (this.installUpdatesAutomatically) {
+      await this.autoInstallUpdate(update);
+      return;
+    }
+
     await this.showUpdateDialog(update);
+  }
+
+  /**
+   * Auto-install update with progress feedback after the user opted in.
+   */
+  private async autoInstallUpdate(update: Update, retryCount = 0): Promise<void> {
+    const MAX_RETRIES = 3;
+    const RETRY_DELAY = 30000; // 30 seconds
+
+    // Defer auto-update if user is in active session (recording/transcribing)
+    if (this.isSessionActive) {
+      if (retryCount < MAX_RETRIES) {
+        console.log(`Deferring auto-update - session active (retry ${retryCount + 1}/${MAX_RETRIES} in 30s)`);
+        setTimeout(() => this.autoInstallUpdate(update, retryCount + 1), RETRY_DELAY);
+        return;
+      }
+      console.log('Skipping auto-update - session still active after max retries');
+      return;
+    }
+
+    const toastId = 'update-progress';
+
+    try {
+      await update.downloadAndInstall((event) => {
+        if (event.event === 'Started') {
+          toast.info(`Downloading update ${update.version}...`, {
+            id: toastId,
+            duration: Infinity,
+          });
+        } else if (event.event === 'Finished') {
+          toast.success('Update ready, restarting...', {
+            id: toastId,
+            duration: Infinity,
+          });
+        }
+      });
+    } catch (error) {
+      console.error('Auto-update failed:', error);
+      toast.error('Update failed. You can try again from Settings > About.', {
+        id: toastId,
+        duration: 5000,
+      });
+      return;
+    }
+
+    // Re-check session state before relaunch (user may have started recording during download)
+    if (this.isSessionActive) {
+      console.log('Update downloaded but session active - will relaunch when recording ends');
+      this.pendingRelaunch = true;
+      this.pendingUpdateVersion = update.version;
+      toast.dismiss(toastId);
+      await this.sendSystemNotification('Update Ready', 'VoiceTypr will restart when recording ends');
+      return;
+    }
+
+    this.pendingUpdateVersion = update.version;
+    await this.performRelaunch();
   }
 
   /**

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -97,7 +97,7 @@ export class UpdateService {
   async initialize(settings: AppSettings): Promise<void> {
     // Check if automatic updates are enabled (default to true if not set)
     const autoUpdateEnabled = settings.check_updates_automatically ?? true;
-    
+
     if (!autoUpdateEnabled) {
       console.log('Automatic updates are disabled');
       return;
@@ -153,8 +153,7 @@ export class UpdateService {
   }
 
   /**
-   * Check for updates in the background and auto-install if available.
-   * Shows progress toasts during download/install, then relaunches the app.
+   * Check for updates in the background and prompt before installing if available.
    * Runs on startup and daily when automatic updates are enabled.
    */
   async checkForUpdatesInBackground(): Promise<void> {
@@ -165,7 +164,6 @@ export class UpdateService {
 
     try {
       this.checkInProgress = true;
-      
       // Check if we should skip based on last check time
       const lastCheck = localStorage.getItem(LAST_UPDATE_CHECK_KEY);
       if (lastCheck) {
@@ -184,7 +182,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update, true);
+        await this.handleUpdateAvailable(update);
       }
     } catch (error) {
       console.error('Background update check failed:', error);
@@ -213,7 +211,7 @@ export class UpdateService {
       localStorage.setItem(LAST_UPDATE_CHECK_KEY, Date.now().toString());
       
       if (update?.available) {
-        await this.handleUpdateAvailable(update, false);
+        await this.handleUpdateAvailable(update);
       } else {
         toast.success("You're on the latest version!");
       }
@@ -228,71 +226,8 @@ export class UpdateService {
   /**
    * Handle when an update is available
    */
-  private async handleUpdateAvailable(update: Update, isBackgroundCheck: boolean): Promise<void> {
-    if (isBackgroundCheck) {
-      // For background checks, auto-install silently
-      await this.autoInstallUpdate(update);
-    } else {
-      // For manual checks, show dialog to let user decide
-      await this.showUpdateDialog(update);
-    }
-  }
-
-  /**
-   * Auto-install update silently with progress feedback
-   */
-  private async autoInstallUpdate(update: Update, retryCount = 0): Promise<void> {
-    const MAX_RETRIES = 3;
-    const RETRY_DELAY = 30000; // 30 seconds
-
-    // Defer auto-update if user is in active session (recording/transcribing)
-    if (this.isSessionActive) {
-      if (retryCount < MAX_RETRIES) {
-        console.log(`Deferring auto-update - session active (retry ${retryCount + 1}/${MAX_RETRIES} in 30s)`);
-        setTimeout(() => this.autoInstallUpdate(update, retryCount + 1), RETRY_DELAY);
-        return;
-      }
-      console.log('Skipping auto-update - session still active after max retries');
-      return;
-    }
-
-    const toastId = 'update-progress';
-    
-    try {
-      await update.downloadAndInstall((event) => {
-        if (event.event === 'Started') {
-          toast.info(`Downloading update ${update.version}...`, { 
-            id: toastId,
-            duration: Infinity 
-          });
-        } else if (event.event === 'Finished') {
-          toast.success('Update ready, restarting...', { 
-            id: toastId,
-            duration: Infinity 
-          });
-        }
-      });
-    } catch (error) {
-      console.error('Auto-update failed:', error);
-      toast.error('Update failed. You can try again from Settings > About.', { 
-        id: toastId,
-        duration: 5000 
-      });
-      return;
-    }
-
-    // Re-check session state before relaunch (user may have started recording during download)
-    if (this.isSessionActive) {
-      console.log('Update downloaded but session active - will relaunch when session ends');
-      this.pendingRelaunch = true;
-      this.pendingUpdateVersion = update.version;
-      toast.dismiss(toastId);
-      await this.sendSystemNotification('Update Ready', 'VoiceTypr will restart when recording ends');
-      return;
-    }
-
-    this.pendingUpdateVersion = update.version;
-    await this.performRelaunch();
+  private async handleUpdateAvailable(update: Update): Promise<void> {
+    await this.showUpdateDialog(update);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export interface AppSettings {
   launch_at_startup?: boolean;
   onboarding_completed?: boolean;
   check_updates_automatically?: boolean;
+  install_updates_automatically?: boolean;
   selected_microphone?: string | null;
   // Push-to-talk support
   recording_mode?: RecordingMode;

--- a/src/utils/crashReport.test.ts
+++ b/src/utils/crashReport.test.ts
@@ -73,8 +73,6 @@ describe('buildReportBody', () => {
     expect(body).toContain('INFO redacted log line');
   });
 
-
-
   it('includes additional diagnostics when diagnostic context is provided', () => {
     const body = buildReportBody({
       ...baseReport,
@@ -99,7 +97,6 @@ describe('buildReportBody', () => {
   });
 });
 
-
 describe('report submission payloads', () => {
   it('builds the manual report endpoint payload', () => {
     expect(buildManualReportPayload(baseReport)).toEqual({
@@ -122,7 +119,6 @@ describe('report submission payloads', () => {
       },
     });
   });
-
 
   it('includes additional diagnostics in the manual payload', () => {
     expect(buildManualReportPayload({

--- a/src/utils/crashReport.test.ts
+++ b/src/utils/crashReport.test.ts
@@ -74,6 +74,18 @@ describe('buildReportBody', () => {
   });
 
 
+
+  it('includes additional diagnostics when diagnostic context is provided', () => {
+    const body = buildReportBody({
+      ...baseReport,
+      diagnosticContext: 'Configured Hotkey: Cmd+Shift+Space\nRegistration Status: registered',
+    });
+
+    expect(body).toContain('## Additional Diagnostics');
+    expect(body).toContain('Configured Hotkey: Cmd+Shift+Space');
+    expect(body).toContain('Registration Status: registered');
+  });
+
   it('labels latest log status notes without log content', () => {
     const body = buildReportBody({
       ...baseReport,
@@ -93,6 +105,33 @@ describe('report submission payloads', () => {
     expect(buildManualReportPayload(baseReport)).toEqual({
       kind: 'manual',
       message: 'The app failed after recording.',
+      environment: {
+        appVersion: '1.12.2',
+        platform: 'macos',
+        osVersion: '15.0',
+        architecture: 'aarch64',
+        currentModel: 'base.en',
+        deviceId: 'device-123',
+        timestamp: '2026-04-27T00:00:00.000Z',
+      },
+      latestLog: {
+        fileName: 'voicetypr-2026-04-27.log',
+        content: 'INFO redacted log line',
+        truncated: false,
+        statusNote: '',
+      },
+    });
+  });
+
+
+  it('includes additional diagnostics in the manual payload', () => {
+    expect(buildManualReportPayload({
+      ...baseReport,
+      diagnosticContext: 'Configured Hotkey: Cmd+Shift+Space',
+    })).toEqual({
+      kind: 'manual',
+      message: 'The app failed after recording.',
+      additionalDiagnostics: 'Configured Hotkey: Cmd+Shift+Space',
       environment: {
         appVersion: '1.12.2',
         platform: 'macos',

--- a/src/utils/crashReport.test.ts
+++ b/src/utils/crashReport.test.ts
@@ -120,30 +120,21 @@ describe('report submission payloads', () => {
     });
   });
 
-  it('includes additional diagnostics in the manual payload', () => {
-    expect(buildManualReportPayload({
+  it('preserves diagnostics in the manual message for the current support endpoint', () => {
+    const payload = buildManualReportPayload({
       ...baseReport,
       diagnosticContext: 'Configured Hotkey: Cmd+Shift+Space',
-    })).toEqual({
-      kind: 'manual',
-      message: 'The app failed after recording.',
-      additionalDiagnostics: 'Configured Hotkey: Cmd+Shift+Space',
-      environment: {
-        appVersion: '1.12.2',
-        platform: 'macos',
-        osVersion: '15.0',
-        architecture: 'aarch64',
-        currentModel: 'base.en',
-        deviceId: 'device-123',
-        timestamp: '2026-04-27T00:00:00.000Z',
-      },
-      latestLog: {
-        fileName: 'voicetypr-2026-04-27.log',
-        content: 'INFO redacted log line',
-        truncated: false,
-        statusNote: '',
-      },
     });
+
+    expect(payload).toMatchObject({
+      kind: 'manual',
+      message: expect.stringContaining('The app failed after recording.'),
+    });
+    expect(payload).not.toHaveProperty('additionalDiagnostics');
+    if (payload.kind === 'manual') {
+      expect(payload.message).toContain('## Additional Diagnostics');
+      expect(payload.message).toContain('Configured Hotkey: Cmd+Shift+Space');
+    }
   });
 
   it('builds the crash report endpoint payload', () => {

--- a/src/utils/crashReport.ts
+++ b/src/utils/crashReport.ts
@@ -68,6 +68,7 @@ export interface ManualReportData {
   name?: string;
   email?: string;
   message: string;
+  diagnosticContext?: string;
   appVersion: string;
   platform: string;
   osVersion: string;
@@ -101,7 +102,8 @@ export async function gatherManualReportData(
   name: string | undefined,
   email: string | undefined,
   message: string,
-  currentModel?: string | null
+  currentModel?: string | null,
+  diagnosticContext?: string
 ): Promise<ManualReportData> {
   const [appVer, deviceId, logAttachment] = await Promise.all([
     getVersion().catch(() => 'Unknown'),
@@ -121,10 +123,13 @@ export async function gatherManualReportData(
     console.error('Failed to get OS info:', e);
   }
 
+  const trimmedDiagnosticContext = diagnosticContext?.trim();
+
   return {
     name,
     email,
     message,
+    diagnosticContext: trimmedDiagnosticContext || undefined,
     appVersion: appVer,
     platform: os,
     osVersion: osVer,
@@ -155,6 +160,15 @@ export function buildReportBody(data: ManualReportData): string {
   parts.push('### Message');
   parts.push(data.message);
   parts.push('');
+
+  if (data.diagnosticContext) {
+    parts.push('## Additional Diagnostics');
+    parts.push('');
+    parts.push('```');
+    parts.push(data.diagnosticContext);
+    parts.push('```');
+    parts.push('');
+  }
 
   parts.push('## Environment');
   parts.push('');
@@ -224,6 +238,7 @@ export type BugReportPayload =
       name?: string;
       email?: string;
       message: string;
+      additionalDiagnostics?: string;
       environment: ReportEnvironmentPayload;
       latestLog: LatestLogPayload;
     }
@@ -250,6 +265,7 @@ export function buildManualReportPayload(data: ManualReportData): BugReportPaylo
     name: data.name,
     email: data.email,
     message: data.message,
+    ...(data.diagnosticContext ? { additionalDiagnostics: data.diagnosticContext } : {}),
     environment: buildEnvironmentPayload(data),
     latestLog: buildLatestLogPayload(data),
   };

--- a/src/utils/crashReport.ts
+++ b/src/utils/crashReport.ts
@@ -238,7 +238,6 @@ export type BugReportPayload =
       name?: string;
       email?: string;
       message: string;
-      additionalDiagnostics?: string;
       environment: ReportEnvironmentPayload;
       latestLog: LatestLogPayload;
     }
@@ -259,13 +258,20 @@ export interface ReportSubmitResult {
   message: string;
 }
 
+function buildManualReportMessage(data: ManualReportData): string {
+  if (!data.diagnosticContext) {
+    return data.message;
+  }
+
+  return `${data.message}\n\n## Additional Diagnostics\n\n\`\`\`\n${data.diagnosticContext}\n\`\`\``;
+}
+
 export function buildManualReportPayload(data: ManualReportData): BugReportPayload {
   return {
     kind: 'manual',
     name: data.name,
     email: data.email,
-    message: data.message,
-    ...(data.diagnosticContext ? { additionalDiagnostics: data.diagnosticContext } : {}),
+    message: buildManualReportMessage(data),
     environment: buildEnvironmentPayload(data),
     latestLog: buildLatestLogPayload(data),
   };

--- a/src/utils/hotkeyDiagnostics.ts
+++ b/src/utils/hotkeyDiagnostics.ts
@@ -1,0 +1,96 @@
+export interface HotkeyDiagnostics {
+  configuredHotkey: string;
+  normalizedHotkey: string;
+  recordingMode: string;
+  useDifferentPttKey: boolean;
+  pttHotkey: string | null;
+  normalizedPttHotkey: string | null;
+  registrationStatus: string;
+  registrationError?: string | null;
+  lastRegistrationAttemptAt?: string | null;
+  lastSuccessfulRegistrationAt?: string | null;
+  lastEventAt?: string | null;
+  lastEventKind?: string | null;
+  lastEventState?: string | null;
+  eventCount: number;
+  currentRecordingState?: string | null;
+  generatedAt: string;
+  isRegistered: boolean | null;
+}
+
+const REGISTRATION_STATUS_LABELS: Record<string, string> = {
+  registered: "Registered",
+  failed: "Failed",
+  unregistered: "Unregistered",
+  restored_after_failure: "Restored previous hotkey after failure",
+};
+
+export function formatDiagnosticValue(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+  return String(value);
+}
+
+export function formatRegistrationStatus(status: string | null | undefined): string {
+  if (!status) {
+    return "—";
+  }
+
+  return (
+    REGISTRATION_STATUS_LABELS[status] ??
+    status
+      .split("_")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+export function formatHotkeyDiagnosticLines(diag: HotkeyDiagnostics | null): string[] {
+  if (!diag) {
+    return ["Hotkey Diagnostics: Unavailable"];
+  }
+
+  const lines = [
+    `Configured Hotkey: ${formatDiagnosticValue(diag.configuredHotkey)}`,
+    `Normalized Hotkey: ${formatDiagnosticValue(diag.normalizedHotkey)}`,
+    `Recording Mode: ${formatDiagnosticValue(diag.recordingMode)}`,
+    `Registration Status: ${formatRegistrationStatus(diag.registrationStatus)}`,
+  ];
+
+  if (diag.registrationError) {
+    lines.push(`Registration Error: ${diag.registrationError}`);
+  }
+  if (diag.isRegistered !== undefined) {
+    lines.push(`Is Registered: ${formatDiagnosticValue(diag.isRegistered)}`);
+  }
+  if (diag.useDifferentPttKey) {
+    lines.push(`PTT Hotkey: ${formatDiagnosticValue(diag.pttHotkey)}`);
+    lines.push(`Normalized PTT Hotkey: ${formatDiagnosticValue(diag.normalizedPttHotkey)}`);
+  }
+  if (diag.lastEventAt) {
+    lines.push(
+      `Last Event: ${formatDiagnosticValue(diag.lastEventKind)} (${formatDiagnosticValue(diag.lastEventState)}) at ${diag.lastEventAt}`
+    );
+  } else {
+    lines.push("Last Event: None detected");
+  }
+  lines.push(`Event Count: ${diag.eventCount ?? 0}`);
+  lines.push(`Current Recording State: ${formatDiagnosticValue(diag.currentRecordingState)}`);
+  lines.push(`Generated At: ${formatDiagnosticValue(diag.generatedAt)}`);
+
+  return lines;
+}
+
+export function formatHotkeyDiagnosticContext(diag: HotkeyDiagnostics): string {
+  return formatHotkeyDiagnosticLines(diag).join("\n");
+}
+
+export function formatLastEventSummary(diag: HotkeyDiagnostics | null): string {
+  if (!diag?.lastEventAt) {
+    return "None detected";
+  }
+  const kind = formatDiagnosticValue(diag.lastEventKind);
+  const state = formatDiagnosticValue(diag.lastEventState);
+  return `${kind} (${state})`;
+}


### PR DESCRIPTION
## Summary
- add backend hotkey diagnostic state and `get_hotkey_diagnostics` command with registration, plugin `isRegistered`, and last-event data
- add Help tab Hotkey Diagnostics card with Test Hotkey and Report Hotkey Issue actions
- include hotkey diagnostics in support reports and report payloads
- preserve the previous registered hotkey when saving a new shortcut fails

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/components/ReportBugDialog.test.tsx src/utils/crashReport.test.ts src/components/sections/__tests__/HelpSection.hotkey-diagnostics.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml hotkey`
- `pnpm test -- --run`
- `pnpm test:backend`
- `git diff --check`