### PR TITLE
fix: optimize Windows transcription fallback

### DIFF
--- a/scripts/ensure-ffmpeg-sidecar.cjs
+++ b/scripts/ensure-ffmpeg-sidecar.cjs
@@ -2,7 +2,7 @@
 // Ensures ffmpeg/ffprobe sidecar binaries exist without relying on system installs.
 // Downloads pinned archives per platform, extracts, and places binaries under sidecar/ffmpeg/dist.
 // macOS (arm64): sidecar/ffmpeg/dist/ffmpeg, ffprobe (+ arch symlinks)
-// Windows (x64): sidecar/ffmpeg/dist/ffmpeg.exe, ffprobe.exe (+ arch copies)
+// Windows (x64): sidecar/ffmpeg/dist/ffmpeg.exe, ffprobe.exe (+ target-triple copies)
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -103,9 +103,62 @@ function verifyChecksum(file, expected, label) {
   console.log(`[ensure-ffmpeg-sidecar] Verified ${label} SHA256: ${actual}`);
 }
 
+const TAURI_CONFIGS = [
+  'src-tauri/tauri.conf.json',
+  'src-tauri/tauri.windows.conf.json',
+];
+
+const OBSOLETE_WINDOWS_DOUBLE_EXTENSION_COPIES = [
+  'ffmpeg.exe-x86_64-pc-windows-msvc.exe',
+  'ffprobe.exe-x86_64-pc-windows-msvc.exe',
+];
+
+function assertExtensionlessExternalBins() {
+  const offenders = [];
+
+  for (const config of TAURI_CONFIGS) {
+    const configPath = path.resolve(__dirname, '..', config);
+    if (!fs.existsSync(configPath)) continue;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (err) {
+      fail(`Failed to parse ${config}: ${err.message}`);
+    }
+
+    for (const entry of parsed.bundle?.externalBin ?? []) {
+      if (path.win32.basename(entry).toLowerCase().endsWith('.exe')) {
+        offenders.push(`${config}: ${entry}`);
+      }
+    }
+  }
+
+  if (offenders.length > 0) {
+    fail(
+      'Tauri externalBin entries must be extensionless. ' +
+        'Tauri appends the target triple and platform extension itself; .exe entries package as .exe.exe on Windows.\n' +
+        offenders.join('\n')
+    );
+  }
+}
+
+function removeObsoleteDoubleExtensionCopies(distDir) {
+  for (const file of OBSOLETE_WINDOWS_DOUBLE_EXTENSION_COPIES) {
+    const obsoletePath = path.join(distDir, file);
+    if (fs.existsSync(obsoletePath)) {
+      fs.rmSync(obsoletePath, { force: true });
+      console.log(`[ensure-ffmpeg-sidecar] Removed obsolete double-extension sidecar copy: ${file}`);
+    }
+  }
+}
+
+
 (function main() {
   const distDir = path.resolve(__dirname, '..', 'sidecar', 'ffmpeg', 'dist');
   ensureDir(distDir);
+  assertExtensionlessExternalBins();
+  removeObsoleteDoubleExtensionCopies(distDir);
 
   const isMac = process.platform === 'darwin';
   const isWin = process.platform === 'win32';
@@ -239,14 +292,9 @@ function verifyChecksum(file, expected, label) {
     const ffmpegDst = path.join(distDir, 'ffmpeg.exe');
     const ffprobeDst = path.join(distDir, 'ffprobe.exe');
     if (fs.existsSync(ffmpegDst) && fs.existsSync(ffprobeDst)) {
-      // Ensure arch-named copies for bundler compatibility
-      // Some bundlers look for both patterns:
-      //  - ffmpeg-x86_64-pc-windows-msvc.exe
-      //  - ffmpeg.exe-x86_64-pc-windows-msvc.exe
+      // Tauri externalBin entries are extensionless and require target-triple copies.
       ensureCopy(ffmpegDst, path.join(distDir, 'ffmpeg-x86_64-pc-windows-msvc.exe'));
       ensureCopy(ffprobeDst, path.join(distDir, 'ffprobe-x86_64-pc-windows-msvc.exe'));
-      ensureCopy(ffmpegDst, path.join(distDir, 'ffmpeg.exe-x86_64-pc-windows-msvc.exe'));
-      ensureCopy(ffprobeDst, path.join(distDir, 'ffprobe.exe-x86_64-pc-windows-msvc.exe'));
       console.log('[ensure-ffmpeg-sidecar] ffmpeg/ffprobe sidecars present. Copies ensured.');
       return;
     }
@@ -295,8 +343,6 @@ function verifyChecksum(file, expected, label) {
       fs.copyFileSync(srcFfprobe, ffprobeDst);
       ensureCopy(ffmpegDst, path.join(distDir, 'ffmpeg-x86_64-pc-windows-msvc.exe'));
       ensureCopy(ffprobeDst, path.join(distDir, 'ffprobe-x86_64-pc-windows-msvc.exe'));
-      ensureCopy(ffmpegDst, path.join(distDir, 'ffmpeg.exe-x86_64-pc-windows-msvc.exe'));
-      ensureCopy(ffprobeDst, path.join(distDir, 'ffprobe.exe-x86_64-pc-windows-msvc.exe'));
       console.log('[ensure-ffmpeg-sidecar] Installed Windows sidecar binaries by download.');
     } finally {
       cleanupTmp(tmp);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "voicetypr"
-version = "1.12.4"
+version = "1.12.5"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ tauri-plugin-macos-permissions = "2"
 core-graphics = "0.24"
 media-remote = "0.3"
 [target.'cfg(target_os = "windows")'.dependencies]
+whisper-rs = { version = "0.16.0", features = ["openmp"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",

--- a/src-tauri/src/audio/normalizer_tests.rs
+++ b/src-tauri/src/audio/normalizer_tests.rs
@@ -104,7 +104,7 @@ fn normalize_resamples_48k_to_16k() {
     assert_eq!(spec.channels, 1);
 
     // Duration should be roughly preserved (0.3s)
-    let frames = reader.duration() / spec.channels as u32;
+    let frames = reader.duration();
     let duration = frames as f32 / spec.sample_rate as f32;
     assert!(
         (duration - 0.3).abs() < 0.05,

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::audio::recorder::AudioRecorder;
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 use serde_json;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tauri::async_runtime::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
@@ -91,17 +91,14 @@ fn should_hide_pill_when_idle(mode: &str) -> bool {
     mode != "always"
 }
 
-async fn transcribe_whisper_with_acceleration<F>(
+async fn transcribe_whisper_with_acceleration(
     app: &AppHandle,
     model_path: &Path,
     audio_path: &Path,
     language: Option<&str>,
     translate: bool,
-    should_cancel: F,
-) -> Result<String, String>
-where
-    F: Fn() -> bool,
-{
+    cancel_flag: Arc<AtomicBool>,
+) -> Result<String, String> {
     #[cfg(target_os = "windows")]
     let mode = {
         let settings = get_settings(app.clone()).await?;
@@ -113,7 +110,7 @@ where
 
     #[cfg(target_os = "windows")]
     if mode != "cpu" {
-        if should_cancel() {
+        if is_cancelled(&cancel_flag) {
             return Err("Transcription cancelled".to_string());
         }
 
@@ -122,13 +119,29 @@ where
         let should_try_gpu = mode == "gpu" || status.gpu_available != Some(false);
 
         if should_try_gpu {
-            match gpu_client
-                .transcribe(app, model_path, audio_path, language, translate, &mode)
-                .await
-            {
+            let gpu_result = tokio::select! {
+                result = gpu_client.transcribe(
+                    app,
+                    model_path,
+                    audio_path,
+                    language,
+                    translate,
+                    &mode,
+                ) => result,
+                _ = wait_for_cancellation(cancel_flag.clone()) => {
+                    Err("Transcription cancelled".to_string())
+                }
+            };
+
+            match gpu_result {
                 Ok(text) => {
                     log::info!("Whisper transcription completed with Vulkan sidecar");
                     return Ok(text);
+                }
+                Err(error) if error == "Transcription cancelled" => {
+                    log::info!("Cancelling in-flight Whisper Vulkan sidecar transcription");
+                    gpu_client.abort_active_process().await;
+                    return Err(error);
                 }
                 Err(error) => {
                     preserve_gpu_status = true;
@@ -159,7 +172,7 @@ where
     };
 
     let result =
-        transcriber.transcribe_with_cancellation(audio_path, language, translate, should_cancel);
+        transcriber.transcribe_with_cancellation(audio_path, language, translate, cancel_flag);
 
     #[cfg(target_os = "windows")]
     {
@@ -221,7 +234,10 @@ pub async fn should_hide_pill(app: &AppHandle) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_hide_pill_when_idle;
+    use super::{
+        is_likely_silence, select_best_fallback_model, should_hide_pill_when_idle,
+        NormalizedAudioStats,
+    };
 
     #[test]
     fn should_hide_pill_when_idle_for_never() {
@@ -236,6 +252,31 @@ mod tests {
     #[test]
     fn should_hide_pill_when_idle_for_always() {
         assert!(!should_hide_pill_when_idle("always"));
+    }
+
+    #[test]
+    fn select_best_fallback_uses_priority_within_requested_family() {
+        let available = vec!["large-v3".to_string(), "large-v3-q5_0".to_string()];
+        let priority = vec!["large-v3-q5_0".to_string(), "large-v3".to_string()];
+
+        assert_eq!(
+            select_best_fallback_model(&available, "large-v3-turbo", &priority),
+            "large-v3-q5_0"
+        );
+    }
+
+    #[test]
+    fn normalized_audio_silence_requires_low_rms_and_peak() {
+        assert!(is_likely_silence(NormalizedAudioStats {
+            duration_s: 2.0,
+            rms: 0.0,
+            peak: 0.0,
+        }));
+        assert!(!is_likely_silence(NormalizedAudioStats {
+            duration_s: 2.0,
+            rms: 0.01,
+            peak: 0.02,
+        }));
     }
 }
 
@@ -607,36 +648,135 @@ pub async fn get_recording_config(app: &AppHandle) -> Result<RecordingConfig, St
 // Global audio recorder state
 pub struct RecorderState(pub Mutex<AudioRecorder>);
 
-/// Select the best fallback model based on available models
-/// Prioritizes models by size (smaller to larger for better performance)
+/// Select the best fallback model based on the provided priority order.
 fn select_best_fallback_model(
     available_models: &[String],
     requested: &str,
     model_priority: &[String],
 ) -> String {
-    // First try to find a model similar to the requested one
     if !requested.is_empty() {
-        // If requested "large-v3", try other large variants first
-        for model in available_models {
-            if model.starts_with(requested.split('-').next().unwrap_or(requested)) {
-                return model.clone();
+        let requested_family = requested.split('-').next().unwrap_or(requested);
+        for priority_model in model_priority {
+            if available_models.contains(priority_model)
+                && priority_model.starts_with(requested_family)
+            {
+                return priority_model.clone();
             }
         }
     }
 
-    // Otherwise use priority order from WhisperManager
     for priority_model in model_priority {
         if available_models.contains(priority_model) {
             return priority_model.clone();
         }
     }
 
-    // If no priority model found, return first available
     available_models.first().cloned().unwrap_or_else(|| {
         log::error!("No models available for fallback selection");
-        // This should never happen as we check for empty models before calling this function
-        // But return a default to prevent panic
         "base.en".to_string()
+    })
+}
+
+async fn should_prefer_cpu_whisper_models(app: &AppHandle) -> bool {
+    #[cfg(not(target_os = "windows"))]
+    let _ = app;
+    #[cfg(target_os = "windows")]
+    {
+        let mode = get_settings(app.clone())
+            .await
+            .map(|settings| {
+                normalize_transcription_acceleration(Some(&settings.transcription_acceleration))
+            })
+            .unwrap_or_else(|_| "auto".to_string());
+
+        if mode == "cpu" {
+            true
+        } else if mode == "gpu" {
+            false
+        } else {
+            let gpu_client = app.state::<crate::whisper::gpu_sidecar::GpuSidecarClient>();
+            gpu_client.status().await.gpu_available == Some(false)
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        std::env::consts::ARCH != "aarch64"
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        false
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NormalizedAudioStats {
+    duration_s: f32,
+    rms: f64,
+    peak: f64,
+}
+
+const SILENCE_RMS_THRESHOLD: f64 = 0.0005;
+const SILENCE_PEAK_THRESHOLD: f64 = 0.003;
+
+#[cfg(target_os = "windows")]
+fn is_cancelled(cancel_flag: &AtomicBool) -> bool {
+    cancel_flag.load(AtomicOrdering::SeqCst)
+}
+
+#[cfg(target_os = "windows")]
+async fn wait_for_cancellation(cancel_flag: Arc<AtomicBool>) {
+    while !is_cancelled(&cancel_flag) {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+fn is_likely_silence(stats: NormalizedAudioStats) -> bool {
+    stats.rms < SILENCE_RMS_THRESHOLD && stats.peak < SILENCE_PEAK_THRESHOLD
+}
+
+fn inspect_normalized_wav(path: &Path) -> Result<NormalizedAudioStats, String> {
+    let mut reader =
+        hound::WavReader::open(path).map_err(|e| format!("Failed to open normalized wav: {e}"))?;
+    let spec = reader.spec();
+    if spec.channels == 0 {
+        return Err("Normalized wav has zero channels".to_string());
+    }
+    if spec.sample_format != hound::SampleFormat::Int || spec.bits_per_sample != 16 {
+        return Err(format!(
+            "Normalized wav must be 16-bit PCM, got {:?}/{} bits",
+            spec.sample_format, spec.bits_per_sample
+        ));
+    }
+
+    let frames = reader.duration();
+    let duration_s = frames as f32 / spec.sample_rate as f32;
+    let mut sum_squares = 0.0f64;
+    let mut peak = 0.0f64;
+    let mut samples = 0u64;
+
+    for sample in reader.samples::<i16>() {
+        let value =
+            f64::from(sample.map_err(|e| format!("Failed to read normalized wav: {e}"))?) / 32768.0;
+        let abs = value.abs();
+        sum_squares += value * value;
+        if abs > peak {
+            peak = abs;
+        }
+        samples += 1;
+    }
+
+    let rms = if samples == 0 {
+        0.0
+    } else {
+        (sum_squares / samples as f64).sqrt()
+    };
+
+    Ok(NormalizedAudioStats {
+        duration_s,
+        rms,
+        peak,
     })
 }
 
@@ -1633,11 +1773,24 @@ pub async fn stop_recording(
                     );
                     configured_model
                 } else {
-                    let models_by_size = whisper_manager.read().await.get_models_by_size();
+                    let prefer_cpu_models = should_prefer_cpu_whisper_models(&app).await;
+                    let strategy = if prefer_cpu_models {
+                        "cpu_preference"
+                    } else {
+                        "quality_preference"
+                    };
+                    let model_priority = {
+                        let manager = whisper_manager.read().await;
+                        if prefer_cpu_models {
+                            manager.get_models_by_cpu_preference()
+                        } else {
+                            manager.get_models_by_quality_preference()
+                        }
+                    };
                     let fallback_model = select_best_fallback_model(
                         &downloaded_models,
                         &configured_model,
-                        &models_by_size,
+                        &model_priority,
                     );
 
                     log_model_operation(
@@ -1651,6 +1804,7 @@ pub async fn stop_recording(
                                 "reason".to_string(),
                                 "configured_not_available".to_string(),
                             );
+                            ctx.insert("strategy".to_string(), strategy.to_string());
                             ctx
                         }),
                     );
@@ -1668,9 +1822,22 @@ pub async fn stop_recording(
                     fallback_model
                 }
             } else {
-                let models_by_size = whisper_manager.read().await.get_models_by_size();
+                let prefer_cpu_models = should_prefer_cpu_whisper_models(&app).await;
+                let strategy = if prefer_cpu_models {
+                    "cpu_preference"
+                } else {
+                    "quality_preference"
+                };
+                let model_priority = {
+                    let manager = whisper_manager.read().await;
+                    if prefer_cpu_models {
+                        manager.get_models_by_cpu_preference()
+                    } else {
+                        manager.get_models_by_quality_preference()
+                    }
+                };
                 let best_model =
-                    select_best_fallback_model(&downloaded_models, "", &models_by_size);
+                    select_best_fallback_model(&downloaded_models, "", &model_priority);
 
                 log_model_operation(
                     "AUTO_SELECTION",
@@ -1679,7 +1846,7 @@ pub async fn stop_recording(
                     Some(&{
                         let mut ctx = std::collections::HashMap::new();
                         ctx.insert("reason".to_string(), "no_model_configured".to_string());
-                        ctx.insert("strategy".to_string(), "best_available".to_string());
+                        ctx.insert("strategy".to_string(), strategy.to_string());
                         ctx
                     }),
                 );
@@ -1751,29 +1918,43 @@ pub async fn stop_recording(
                 }
             };
 
-            // Duration gate (mode-specific) using normalized file
-            let too_short = (|| -> Result<bool, String> {
-                let reader = hound::WavReader::open(&normalized_path)
-                    .map_err(|e| format!("Failed to open normalized wav: {}", e))?;
-                let spec = reader.spec();
-                let frames = reader.duration() / spec.channels as u32; // mono expected
-                let duration = frames as f32 / spec.sample_rate as f32;
-                log_with_context(
-                    log::Level::Info,
-                    "NORMALIZED_AUDIO",
-                    &[
-                        ("path", format!("{:?}", normalized_path).as_str()),
-                        ("sample_rate", spec.sample_rate.to_string().as_str()),
-                        ("channels", spec.channels.to_string().as_str()),
-                        ("bits", spec.bits_per_sample.to_string().as_str()),
-                        ("duration_s", format!("{:.2}", duration).as_str()),
-                    ],
-                );
-                Ok(duration < min_duration_s_f32)
-            })();
+            let audio_stats = match inspect_normalized_wav(&normalized_path) {
+                Ok(stats) => stats,
+                Err(e) => {
+                    log::error!("Audio inspection failed: {}", e);
+                    update_recording_state(
+                        &app,
+                        RecordingState::Error,
+                        Some("Audio inspection failed".to_string()),
+                    );
+                    let _ = std::fs::remove_file(&normalized_path);
+                    return Err(e);
+                }
+            };
 
-            if let Ok(true) = too_short {
-                // Emit friendly feedback and stop here
+            log_with_context(
+                log::Level::Info,
+                "NORMALIZED_AUDIO",
+                &[
+                    ("path", format!("{:?}", normalized_path).as_str()),
+                    ("sample_rate", "16000"),
+                    ("channels", "1"),
+                    ("bits", "16"),
+                    (
+                        "duration_s",
+                        format!("{:.2}", audio_stats.duration_s).as_str(),
+                    ),
+                ],
+            );
+            log_audio_metrics(
+                "NORMALIZED_AUDIO",
+                audio_stats.rms,
+                audio_stats.peak,
+                audio_stats.duration_s,
+                None,
+            );
+
+            if audio_stats.duration_s < min_duration_s_f32 {
                 let _ = emit_to_window(
                     &app,
                     "pill",
@@ -1783,7 +1964,32 @@ pub async fn stop_recording(
                 if let Err(e) = std::fs::remove_file(&normalized_path) {
                     log::debug!("Failed to remove short normalized audio: {}", e);
                 }
-                // Frontend will hide pill after showing feedback
+                update_recording_state(&app, RecordingState::Idle, None);
+                return Ok("".to_string());
+            }
+
+            if is_likely_silence(audio_stats) {
+                log::info!(
+                    "Normalized audio is below speech threshold: rms={:.6}, peak={:.6}",
+                    audio_stats.rms,
+                    audio_stats.peak
+                );
+                pill_toast(
+                    &app,
+                    "No speech detected - try speaking closer to the microphone",
+                    1500,
+                );
+                let _ = app.emit(
+                    "no-speech-detected",
+                    serde_json::json!({
+                        "severity": "warning",
+                        "title": "No Speech Detected",
+                        "message": "No speech was detected in the recording. Try speaking closer to the microphone.",
+                    }),
+                );
+                if let Err(e) = std::fs::remove_file(&normalized_path) {
+                    log::debug!("Failed to remove silent normalized audio: {}", e);
+                }
                 update_recording_state(&app, RecordingState::Idle, None);
                 return Ok("".to_string());
             }
@@ -1848,6 +2054,7 @@ pub async fn stop_recording(
 
         // Check for cancellation before loading model
         let app_state = app_for_task.state::<AppState>();
+        let cancel_flag = app_state.should_cancel_recording.clone();
         if app_state.is_cancellation_requested() {
             log::info!("Transcription cancelled before model loading");
 
@@ -1884,7 +2091,7 @@ pub async fn stop_recording(
                         &audio_path_clone,
                         language_for_task.as_deref(),
                         translate_to_english,
-                        || app_state.is_cancellation_requested(),
+                        cancel_flag.clone(),
                     )
                     .await;
 
@@ -2569,7 +2776,7 @@ pub async fn transcribe_audio_file(
                 &normalized_path,
                 Some(&language),
                 translate_to_english,
-                || false,
+                Arc::new(AtomicBool::new(false)),
             )
             .await?;
             let _ = std::fs::remove_file(&normalized_path);
@@ -2692,7 +2899,7 @@ pub async fn transcribe_audio(
                 &temp_path,
                 Some(language.as_str()),
                 translate_to_english,
-                || false,
+                Arc::new(AtomicBool::new(false)),
             )
             .await?
         }
@@ -2916,6 +3123,12 @@ pub async fn cancel_recording(app: AppHandle) -> Result<(), String> {
             log::info!("Aborting transcription task");
             task.abort();
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    if matches!(current_state, RecordingState::Transcribing) {
+        let gpu_client = app.state::<crate::whisper::gpu_sidecar::GpuSidecarClient>();
+        gpu_client.abort_active_process().await;
     }
 
     // Stop recording if active

--- a/src-tauri/src/parakeet/error.rs
+++ b/src-tauri/src/parakeet/error.rs
@@ -12,6 +12,11 @@ pub enum ParakeetError {
     SidecarError { code: String, message: String },
     #[error("sidecar terminated unexpectedly")]
     Terminated,
+    #[error("parakeet {operation} timed out after {timeout_secs}s")]
+    Timeout {
+        operation: String,
+        timeout_secs: u64,
+    },
     #[error("invalid transcription response payload")]
     InvalidResponse,
     #[error("{0}")]

--- a/src-tauri/src/parakeet/messages.rs
+++ b/src-tauri/src/parakeet/messages.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::Path;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -58,6 +59,67 @@ pub enum ParakeetCommand {
         model_version: Option<String>,
     },
     Shutdown {},
+}
+
+pub const SHORT_REQUEST_TIMEOUT_SECS: u64 = 30;
+pub const LOAD_MODEL_TIMEOUT_SECS: u64 = 300;
+pub const DOWNLOAD_MODEL_TIMEOUT_SECS: u64 = 60 * 60;
+pub const TRANSCRIBE_TIMEOUT_SECS: u64 = 180;
+pub const MAX_TRANSCRIBE_TIMEOUT_SECS: u64 = 30 * 60;
+
+impl ParakeetCommand {
+    pub fn operation_name(&self) -> &'static str {
+        match self {
+            Self::LoadModel { .. } => "load_model",
+            Self::UnloadModel { .. } => "unload_model",
+            Self::Transcribe { .. } => "transcribe",
+            Self::Status { .. } => "status",
+            Self::DeleteModel { .. } => "delete_model",
+            Self::Shutdown { .. } => "shutdown",
+        }
+    }
+
+    pub fn request_timeout_secs(&self) -> u64 {
+        match self {
+            Self::LoadModel { force_download, .. } if force_download.unwrap_or(false) => {
+                DOWNLOAD_MODEL_TIMEOUT_SECS
+            }
+            Self::LoadModel { .. } => LOAD_MODEL_TIMEOUT_SECS,
+            Self::Transcribe { audio_path, .. } => transcribe_timeout_secs(audio_path),
+            Self::Status { .. }
+            | Self::Shutdown { .. }
+            | Self::DeleteModel { .. }
+            | Self::UnloadModel { .. } => SHORT_REQUEST_TIMEOUT_SECS,
+        }
+    }
+}
+
+fn transcribe_timeout_secs(audio_path: &str) -> u64 {
+    wav_duration_seconds(Path::new(audio_path))
+        .map(transcribe_timeout_secs_for_duration)
+        .unwrap_or(TRANSCRIBE_TIMEOUT_SECS)
+}
+
+fn transcribe_timeout_secs_for_duration(duration_secs: f64) -> u64 {
+    if !duration_secs.is_finite() || duration_secs <= 0.0 {
+        return TRANSCRIBE_TIMEOUT_SECS;
+    }
+
+    (duration_secs.ceil() as u64)
+        .saturating_mul(4)
+        .saturating_add(60)
+        .clamp(TRANSCRIBE_TIMEOUT_SECS, MAX_TRANSCRIBE_TIMEOUT_SECS)
+}
+
+fn wav_duration_seconds(audio_path: &Path) -> Option<f64> {
+    let reader = hound::WavReader::open(audio_path).ok()?;
+    let spec = reader.spec();
+    if spec.sample_rate == 0 || spec.channels == 0 {
+        return None;
+    }
+
+    let frames = reader.duration() as f64;
+    Some(frames / f64::from(spec.sample_rate))
 }
 
 fn default_precision() -> String {
@@ -118,4 +180,171 @@ pub struct ParakeetSegment {
     pub end: Option<f32>,
     #[serde(default)]
     pub tokens: Option<Vec<Value>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ParakeetCommand, DOWNLOAD_MODEL_TIMEOUT_SECS, LOAD_MODEL_TIMEOUT_SECS,
+        SHORT_REQUEST_TIMEOUT_SECS, TRANSCRIBE_TIMEOUT_SECS,
+    };
+
+    #[test]
+    fn operation_name_maps_each_command_variant() {
+        assert_eq!(ParakeetCommand::Status {}.operation_name(), "status");
+        assert_eq!(ParakeetCommand::Shutdown {}.operation_name(), "shutdown");
+        assert_eq!(
+            ParakeetCommand::UnloadModel {}.operation_name(),
+            "unload_model"
+        );
+        assert_eq!(
+            ParakeetCommand::DeleteModel {
+                model_id: None,
+                model_version: None,
+            }
+            .operation_name(),
+            "delete_model"
+        );
+        assert_eq!(
+            ParakeetCommand::LoadModel {
+                model_id: "parakeet-tdt-0.6b-v2".to_string(),
+                model_version: None,
+                force_download: None,
+                local_path: None,
+                cache_dir: None,
+                precision: "bf16".to_string(),
+                attention: "full".to_string(),
+                local_attention_context: 256,
+                chunk_duration: None,
+                overlap_duration: None,
+                eager_unload: None,
+            }
+            .operation_name(),
+            "load_model"
+        );
+        assert_eq!(
+            ParakeetCommand::Transcribe {
+                audio_path: "/tmp/audio.wav".to_string(),
+                language: None,
+                translate_to_english: false,
+                prompt: None,
+                use_word_timestamps: None,
+                chunk_duration: None,
+                overlap_duration: None,
+                attention: None,
+                local_attention_context: None,
+            }
+            .operation_name(),
+            "transcribe"
+        );
+    }
+
+    #[test]
+    fn request_timeout_secs_uses_short_timeout_for_control_commands() {
+        assert_eq!(
+            ParakeetCommand::Status {}.request_timeout_secs(),
+            SHORT_REQUEST_TIMEOUT_SECS
+        );
+        assert_eq!(
+            ParakeetCommand::Shutdown {}.request_timeout_secs(),
+            SHORT_REQUEST_TIMEOUT_SECS
+        );
+        assert_eq!(
+            ParakeetCommand::UnloadModel {}.request_timeout_secs(),
+            SHORT_REQUEST_TIMEOUT_SECS
+        );
+        assert_eq!(
+            ParakeetCommand::DeleteModel {
+                model_id: None,
+                model_version: None,
+            }
+            .request_timeout_secs(),
+            SHORT_REQUEST_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn request_timeout_secs_distinguishes_cached_load_from_download() {
+        assert_eq!(
+            ParakeetCommand::LoadModel {
+                model_id: "parakeet-tdt-0.6b-v2".to_string(),
+                model_version: None,
+                force_download: None,
+                local_path: None,
+                cache_dir: None,
+                precision: "bf16".to_string(),
+                attention: "full".to_string(),
+                local_attention_context: 256,
+                chunk_duration: None,
+                overlap_duration: None,
+                eager_unload: None,
+            }
+            .request_timeout_secs(),
+            LOAD_MODEL_TIMEOUT_SECS
+        );
+        assert_eq!(
+            ParakeetCommand::LoadModel {
+                model_id: "parakeet-tdt-0.6b-v2".to_string(),
+                model_version: None,
+                force_download: Some(true),
+                local_path: None,
+                cache_dir: None,
+                precision: "bf16".to_string(),
+                attention: "full".to_string(),
+                local_attention_context: 256,
+                chunk_duration: None,
+                overlap_duration: None,
+                eager_unload: None,
+            }
+            .request_timeout_secs(),
+            DOWNLOAD_MODEL_TIMEOUT_SECS
+        );
+        assert_eq!(
+            ParakeetCommand::Transcribe {
+                audio_path: "/tmp/audio.wav".to_string(),
+                language: None,
+                translate_to_english: false,
+                prompt: None,
+                use_word_timestamps: None,
+                chunk_duration: None,
+                overlap_duration: None,
+                attention: None,
+                local_attention_context: None,
+            }
+            .request_timeout_secs(),
+            TRANSCRIBE_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn request_timeout_secs_uses_channel_independent_wav_duration() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        let spec = hound::WavSpec {
+            channels: 2,
+            sample_rate: 100,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).unwrap();
+        for _ in 0..(31 * 100 * 2) {
+            writer.write_sample::<i16>(0).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let timeout = ParakeetCommand::Transcribe {
+            audio_path: path.to_string_lossy().to_string(),
+            language: None,
+            translate_to_english: false,
+            prompt: None,
+            use_word_timestamps: None,
+            chunk_duration: None,
+            overlap_duration: None,
+            attention: None,
+            local_attention_context: None,
+        }
+        .request_timeout_secs();
+
+        assert_eq!(timeout, 184);
+    }
 }

--- a/src-tauri/src/parakeet/sidecar.rs
+++ b/src-tauri/src/parakeet/sidecar.rs
@@ -3,6 +3,7 @@
 use super::error::ParakeetError;
 use super::messages::{ParakeetCommand, ParakeetResponse};
 use log::{error, warn};
+use std::time::Duration;
 use tauri::async_runtime::{Receiver, RwLock};
 use tauri::AppHandle;
 use tauri_plugin_shell::{
@@ -37,6 +38,23 @@ fn parse_response_line(raw: &str) -> Result<ParakeetResponse, ParakeetError> {
                 }
             }
         }
+    }
+}
+
+async fn timed_request(
+    sidecar: &mut ParakeetSidecar,
+    command: &ParakeetCommand,
+) -> Result<ParakeetResponse, ParakeetError> {
+    let operation = command.operation_name().to_string();
+    let timeout_secs = command.request_timeout_secs();
+    let timeout = Duration::from_secs(timeout_secs);
+
+    match tokio::time::timeout(timeout, sidecar.request(command)).await {
+        Ok(result) => result,
+        Err(_) => Err(ParakeetError::Timeout {
+            operation,
+            timeout_secs,
+        }),
     }
 }
 
@@ -154,6 +172,12 @@ impl ParakeetClient {
         Ok(guard)
     }
 
+    fn clear_sidecar(guard: &mut RwLockWriteGuard<'_, Option<ParakeetSidecar>>) {
+        if let Some(sidecar) = guard.take() {
+            sidecar.kill();
+        }
+    }
+
     pub async fn send(
         &self,
         app: &AppHandle,
@@ -161,23 +185,27 @@ impl ParakeetClient {
     ) -> Result<ParakeetResponse, ParakeetError> {
         let mut guard = self.ensure(app).await?;
         let response = match guard.as_mut() {
-            Some(sidecar) => sidecar.request(command).await,
+            Some(sidecar) => timed_request(sidecar, command).await,
             None => return Err(ParakeetError::Terminated),
         };
 
         match response {
+            Err(ParakeetError::Timeout { .. }) => {
+                Self::clear_sidecar(&mut guard);
+                response
+            }
             Err(ParakeetError::Terminated) => {
-                let old = guard.take();
+                Self::clear_sidecar(&mut guard);
                 drop(guard);
-                if let Some(sidecar) = old {
-                    sidecar.kill();
-                }
                 let mut guard = self.ensure(app).await?;
-                if let Some(sidecar) = guard.as_mut() {
-                    sidecar.request(command).await
-                } else {
-                    Err(ParakeetError::Terminated)
+                let response = match guard.as_mut() {
+                    Some(sidecar) => timed_request(sidecar, command).await,
+                    None => Err(ParakeetError::Terminated),
+                };
+                if matches!(response, Err(ParakeetError::Timeout { .. })) {
+                    Self::clear_sidecar(&mut guard);
                 }
+                response
             }
             other => other,
         }

--- a/src-tauri/src/recognition/model_selection.rs
+++ b/src-tauri/src/recognition/model_selection.rs
@@ -80,7 +80,44 @@ fn pick_best_parakeet_model(models: Vec<parakeet::ParakeetModelStatus>) -> Optio
     downloaded.first().map(|m| m.name.clone())
 }
 
+async fn should_prefer_cpu_whisper_models(app: &tauri::AppHandle) -> bool {
+    #[cfg(not(target_os = "windows"))]
+    let _ = app;
+    #[cfg(target_os = "windows")]
+    {
+        let mode = app
+            .store("settings")
+            .ok()
+            .and_then(|store| {
+                store
+                    .get("transcription_acceleration")
+                    .and_then(|value| value.as_str().map(str::to_owned))
+            })
+            .unwrap_or_else(|| "auto".to_string());
+        if mode == "cpu" {
+            true
+        } else if mode == "gpu" {
+            false
+        } else if let Some(client) = app.try_state::<whisper::gpu_sidecar::GpuSidecarClient>() {
+            client.status().await.gpu_available == Some(false)
+        } else {
+            false
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        std::env::consts::ARCH != "aarch64"
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        false
+    }
+}
+
 async fn pick_best_whisper_model(
+    app: &tauri::AppHandle,
     manager: &AsyncRwLock<whisper::manager::WhisperManager>,
 ) -> Option<String> {
     let manager = manager.read().await;
@@ -89,12 +126,22 @@ async fn pick_best_whisper_model(
         .into_iter()
         .filter(|(_, info)| info.downloaded)
         .collect();
-    downloaded.sort_by(|a, b| {
-        b.1.recommended
-            .cmp(&a.1.recommended)
-            .then(b.1.accuracy_score.cmp(&a.1.accuracy_score))
-            .then(a.1.size.cmp(&b.1.size))
-    });
+    if should_prefer_cpu_whisper_models(app).await {
+        downloaded.sort_by(|a, b| {
+            b.1.recommended
+                .cmp(&a.1.recommended)
+                .then(b.1.speed_score.cmp(&a.1.speed_score))
+                .then(b.1.accuracy_score.cmp(&a.1.accuracy_score))
+                .then(a.1.size.cmp(&b.1.size))
+        });
+    } else {
+        downloaded.sort_by(|a, b| {
+            b.1.recommended
+                .cmp(&a.1.recommended)
+                .then(b.1.accuracy_score.cmp(&a.1.accuracy_score))
+                .then(a.1.size.cmp(&b.1.size))
+        });
+    }
     downloaded.first().map(|(name, _)| name.clone())
 }
 
@@ -127,7 +174,7 @@ pub async fn auto_select_model_if_needed(
         if let Some(whisper_state) =
             app.try_state::<AsyncRwLock<whisper::manager::WhisperManager>>()
         {
-            if let Some(model) = pick_best_whisper_model(&whisper_state).await {
+            if let Some(model) = pick_best_whisper_model(app, &whisper_state).await {
                 selection = Some(("whisper".to_string(), model));
             }
         }

--- a/src-tauri/src/tests/model_commands.rs
+++ b/src-tauri/src/tests/model_commands.rs
@@ -71,6 +71,8 @@ mod tests {
         // Should have all the default models
         assert!(models.contains_key("base.en"));
         assert!(models.contains_key("large-v3"));
+        assert!(models.contains_key("large-v3-q5_0"));
+        assert!(models.contains_key("large-v3-turbo"));
 
         // All models should initially be not downloaded
         for (_, model) in models.iter() {
@@ -114,34 +116,25 @@ mod tests {
     }
 
     #[test]
-    fn test_list_downloaded_files() {
+    fn test_list_downloaded_files_only_returns_exact_catalog_matches() {
         let temp_dir = TempDir::new().unwrap();
         let models_dir = temp_dir.path().join("models");
         std::fs::create_dir_all(&models_dir).unwrap();
 
-        // Create a WhisperManager with known models
-        let manager = WhisperManager::new(models_dir.clone());
+        let mut manager = WhisperManager::new_for_test(models_dir.clone());
 
-        // Create model files for known models only (current catalog)
-        for model_name in ["base.en", "large-v3", "large-v3-turbo"] {
-            let file_path = models_dir.join(format!("{}.bin", model_name));
-            std::fs::write(&file_path, b"dummy model data").unwrap();
-        }
-
-        // Create a non-model file that should be ignored
-        std::fs::write(models_dir.join("readme.txt"), b"not a model").unwrap();
-
-        // Also create a .bin file that's not a known model - should be ignored
+        std::fs::write(models_dir.join("base.en.bin"), vec![0u8; 1024]).unwrap();
+        std::fs::write(models_dir.join("large-v3.bin"), vec![0u8; 2048]).unwrap();
+        std::fs::write(models_dir.join("large-v3-q5_0.bin"), b"wrong size").unwrap();
         std::fs::write(models_dir.join("unknown.bin"), b"unknown model").unwrap();
 
+        manager.refresh_downloaded_status();
         let downloaded = manager.list_downloaded_files();
 
-        // Should only list known models that have .bin files
-        assert_eq!(downloaded.len(), 3);
+        assert_eq!(downloaded.len(), 2);
         assert!(downloaded.contains(&"base.en".to_string()));
         assert!(downloaded.contains(&"large-v3".to_string()));
-        assert!(downloaded.contains(&"large-v3-turbo".to_string()));
-        assert!(!downloaded.contains(&"readme".to_string()));
+        assert!(!downloaded.contains(&"large-v3-q5_0".to_string()));
         assert!(!downloaded.contains(&"unknown".to_string()));
     }
 
@@ -205,17 +198,25 @@ mod tests {
 
     #[test]
     fn test_model_validation() {
-        // Test valid model names
-        let valid_models = vec!["base.en", "large-v3", "large-v3-q5_0", "large-v3-turbo"];
+        let temp_dir = TempDir::new().unwrap();
+        let manager = WhisperManager::new(temp_dir.path().to_path_buf());
+        let models = manager.get_models_status();
 
-        for model in &valid_models {
-            assert!(valid_models.contains(&model));
+        for name in [
+            "base.en",
+            "large-v3",
+            "large-v3-q5_0",
+            "large-v3-turbo",
+            "small.en",
+        ] {
+            assert!(models.contains_key(name), "missing catalog model: {name}");
         }
 
-        // Test invalid model names
-        let invalid_models = vec!["invalid", "large-v2", "tiny.en", "custom"];
-        for model in &invalid_models {
-            assert!(!valid_models.contains(model));
+        for name in ["invalid", "large-v2", "tiny.en", "custom"] {
+            assert!(
+                !models.contains_key(name),
+                "unexpected catalog model: {name}"
+            );
         }
     }
 
@@ -245,6 +246,18 @@ mod tests {
         let status = manager.get_models_status();
         assert!(status.get("base.en").unwrap().downloaded);
         assert!(!status.get("large-v3").unwrap().downloaded);
+
+        // Wrong-size files must not count as downloaded
+        std::fs::write(models_dir.join("large-v3.bin"), vec![0u8; 512]).unwrap();
+        manager.refresh_downloaded_status();
+        let status = manager.get_models_status();
+        assert!(!status.get("large-v3").unwrap().downloaded);
+
+        // Exact-size files must count as downloaded
+        std::fs::write(models_dir.join("large-v3.bin"), vec![0u8; 2048]).unwrap();
+        manager.refresh_downloaded_status();
+        let status = manager.get_models_status();
+        assert!(status.get("large-v3").unwrap().downloaded);
     }
 
     #[test]
@@ -261,6 +274,14 @@ mod tests {
         let large = models.get("large-v3").unwrap();
         assert!(large.speed_score < base_en.speed_score); // Slower
         assert!(large.accuracy_score > base_en.accuracy_score); // More accurate
+
+        let q5 = models.get("large-v3-q5_0").unwrap();
+        let turbo = models.get("large-v3-turbo").unwrap();
+        assert!(q5.speed_score > large.speed_score);
+        assert!(q5.speed_score < turbo.speed_score);
+        assert!(q5.accuracy_score < large.accuracy_score);
+        assert!(q5.accuracy_score >= turbo.accuracy_score - 1);
+        assert!(q5.recommended);
 
         // Verify all scores are in valid range (1-10)
         for (_, model) in &models {
@@ -280,11 +301,18 @@ mod tests {
         assert!(base_en.size > 100 * 1024 * 1024); // > 100MB
         assert!(base_en.size < 200 * 1024 * 1024); // < 200MB
 
-        // Note: large-v3 is actually 2.9GB, well within our 3.5GB limit
         let large = models.get("large-v3").unwrap();
-        assert!(large.size > base_en.size); // Large should be larger than base
-        assert!(large.size > 2 * 1024 * 1024 * 1024); // > 2GB
-        assert!(large.size < 3584 * 1024 * 1024); // < 3.5GB
+        assert_eq!(large.size, 3_095_033_483);
+
+        let q5 = models.get("large-v3-q5_0").unwrap();
+        assert_eq!(q5.size, 1_081_140_203);
+        assert!(q5.size > base_en.size);
+        assert!(q5.size < large.size);
+
+        let turbo = models.get("large-v3-turbo").unwrap();
+        assert_eq!(turbo.size, 1_624_555_275);
+        assert!(turbo.size > q5.size);
+        assert!(turbo.size < large.size);
     }
 
     #[test]
@@ -297,10 +325,14 @@ mod tests {
         for (name, model) in &models {
             assert!(model.url.starts_with("https://huggingface.co/"));
             assert!(model.url.contains("whisper.cpp"));
-            assert!(model.url.ends_with(&format!("{}.bin", name)));
+            assert!(model.url.ends_with(&format!("ggml-{name}.bin")));
 
             // Verify SHA256 field (actually contains SHA1) is 40 characters
             assert_eq!(model.sha256.len(), 40);
         }
+
+        let q5 = models.get("large-v3-q5_0").unwrap();
+        assert_eq!(q5.display_name, "Large v3 (Q5)");
+        assert_eq!(q5.sha256, "e6e2ed78495d403bef4b7cff42ef4aaadcfea8de");
     }
 }

--- a/src-tauri/src/whisper/gpu_sidecar.rs
+++ b/src-tauri/src/whisper/gpu_sidecar.rs
@@ -262,6 +262,15 @@ impl GpuSidecarClient {
         self.status.read().await.clone()
     }
 
+    pub async fn abort_active_process(&self) {
+        let mut guard = self.process.lock().await;
+        if let Some(process) = guard.as_mut() {
+            log::info!("Aborting active Whisper Vulkan sidecar process");
+            process.kill_and_wait().await;
+        }
+        guard.take();
+    }
+
     pub async fn set_cpu_status(&self, mode: &str, message: impl Into<String>) {
         *self.status.write().await = AccelerationRuntimeStatus {
             mode: mode.to_string(),
@@ -474,7 +483,7 @@ fn wav_duration_seconds(audio_path: &Path) -> Option<f64> {
         return None;
     }
 
-    let frames = reader.duration() as f64 / f64::from(spec.channels);
+    let frames = reader.duration() as f64;
     Some(frames / f64::from(spec.sample_rate))
 }
 

--- a/src-tauri/src/whisper/manager.rs
+++ b/src-tauri/src/whisper/manager.rs
@@ -122,7 +122,7 @@ impl WhisperManager {
             ModelInfo {
                 name: "large-v3".to_string(),
                 display_name: "Large v3".to_string(),
-                size: 3_117_854_720, // 2.9 GiB = 2.9 * 1024 * 1024 * 1024 bytes
+                size: 3_095_033_483,
                 url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"
                     .to_string(),
                 sha256: "ad82bf6a9043ceed055076d0fd39f5f186ff8062".to_string(), // SHA1 (correct)
@@ -133,12 +133,26 @@ impl WhisperManager {
             },
         );
 
-        // Removed: large-v3-q5_0 to simplify model list
+        models.insert(
+            "large-v3-q5_0".to_string(),
+            ModelInfo {
+                name: "large-v3-q5_0".to_string(),
+                display_name: "Large v3 (Q5)".to_string(),
+                size: 1_081_140_203,
+                url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin"
+                    .to_string(),
+                sha256: "e6e2ed78495d403bef4b7cff42ef4aaadcfea8de".to_string(), // SHA1 (correct)
+                downloaded: false,
+                speed_score: 4,    // Faster than full large-v3, slower than turbo
+                accuracy_score: 8, // Comparable but below full large-v3
+                recommended: true, // CPU-friendly fallback
+            },
+        );
 
         models.insert("large-v3-turbo".to_string(), ModelInfo {
             name: "large-v3-turbo".to_string(),
             display_name: "Large v3 Turbo".to_string(),
-            size: 1_610_612_736, // 1.5 GiB = 1.5 * 1024 * 1024 * 1024 bytes
+            size: 1_624_555_275,
             url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin".to_string(),
             sha256: "4af2b29d7ec73d781377bfd1758ca957a807e941".to_string(), // SHA1 (correct)
             downloaded: false,
@@ -187,17 +201,15 @@ impl WhisperManager {
                     let file_size = metadata.len();
                     let expected_size = model_info.size;
 
-                    // Allow 5% tolerance for size differences
-                    let size_tolerance = (expected_size as f64 * 0.05) as u64;
-                    let min_size = expected_size.saturating_sub(size_tolerance);
-
-                    if file_size >= min_size {
+                    if file_size == expected_size {
                         log::info!("[check_downloaded_models] Model '{}' found at {:?} (size: {} bytes, expected: {} bytes)",
                             model_name, model_path, file_size, expected_size);
                         model_info.downloaded = true;
                     } else if file_size > 0 {
-                        log::warn!("[check_downloaded_models] Model '{}' exists but appears incomplete: {} bytes (expected: {} bytes)", 
-                            model_name, file_size, expected_size);
+                        log::warn!(
+                            "[check_downloaded_models] Model '{}' exists but size mismatch: {} bytes (expected exactly {} bytes)",
+                            model_name, file_size, expected_size
+                        );
                         model_info.downloaded = false;
                     } else {
                         log::warn!(
@@ -289,35 +301,34 @@ impl WhisperManager {
             .await
             .map_err(|e| format!("Failed to create models directory: {}", e))?;
 
-        // Check if the file already exists and is corrupted
+        // Check if the file already exists. A model is usable only when its byte
+        // size matches the catalog exactly; anything else is stale, partial, or
+        // from an older catalog entry and must be replaced before download.
         if output_path.exists() {
             if let Ok(metadata) = fs::metadata(&output_path).await {
                 let file_size = metadata.len();
                 let expected_size = model_info.size;
 
-                // Allow 5% tolerance for size differences
-                let size_tolerance = (expected_size as f64 * 0.05) as u64;
-                let min_size = expected_size.saturating_sub(size_tolerance);
-
-                if file_size < min_size {
-                    log::warn!(
-                        "Found incomplete/corrupted model file for '{}': {} bytes (expected: {} bytes). Removing...",
-                        model_info.name, file_size, expected_size
-                    );
-
-                    // Delete the corrupted file
-                    if let Err(e) = fs::remove_file(&output_path).await {
-                        log::error!("Failed to remove corrupted model file: {}", e);
-                        return Err(format!("Failed to remove corrupted model file: {}", e));
-                    }
-
-                    log::info!("Corrupted model file removed successfully");
-                } else {
+                if file_size == expected_size {
                     return Err(format!(
                         "Model '{}' already exists with correct size. Delete it manually if you want to re-download.",
                         model_info.name
                     ));
                 }
+
+                log::warn!(
+                    "Found model file for '{}' with size mismatch: {} bytes (expected exactly {} bytes). Removing before re-download...",
+                    model_info.name,
+                    file_size,
+                    expected_size
+                );
+
+                if let Err(e) = fs::remove_file(&output_path).await {
+                    log::error!("Failed to remove mismatched model file: {}", e);
+                    return Err(format!("Failed to remove mismatched model file: {}", e));
+                }
+
+                log::info!("Mismatched model file removed successfully");
             }
         }
 
@@ -614,17 +625,9 @@ impl WhisperManager {
     }
 
     /// Returns the names of downloaded model files that are recognized by the manager
-    /// This prevents exposing arbitrary .bin files that may exist in the models directory
+    /// and match the current catalog exactly.
     pub fn list_downloaded_files(&self) -> Vec<String> {
-        // Only return files that correspond to known models
-        self.models
-            .iter()
-            .filter(|(name, _)| {
-                let path = self.models_dir.join(format!("{}.bin", name));
-                path.exists()
-            })
-            .map(|(name, _)| name.clone())
-            .collect()
+        self.get_downloaded_model_names()
     }
 
     /// Delete a model file from disk and refresh the downloaded status map.
@@ -657,13 +660,30 @@ impl WhisperManager {
         (speed as f32 * 0.4 + accuracy as f32 * 0.6) / 10.0 * 100.0
     }
 
-    /// Get model names ordered by size (smallest to largest)
-    pub fn get_models_by_size(&self) -> Vec<String> {
+    /// Get model names ordered for CPU-only transcription latency.
+    pub fn get_models_by_cpu_preference(&self) -> Vec<String> {
         let mut models: Vec<(&String, &ModelInfo)> = self.models.iter().collect();
-        models.sort_by_key(|(_, info)| info.size);
+        models.sort_by(|a, b| {
+            b.1.recommended
+                .cmp(&a.1.recommended)
+                .then(b.1.speed_score.cmp(&a.1.speed_score))
+                .then(b.1.accuracy_score.cmp(&a.1.accuracy_score))
+                .then(a.1.size.cmp(&b.1.size))
+        });
         models.into_iter().map(|(name, _)| name.clone()).collect()
     }
 
+    /// Get model names ordered for quality-first transcription.
+    pub fn get_models_by_quality_preference(&self) -> Vec<String> {
+        let mut models: Vec<(&String, &ModelInfo)> = self.models.iter().collect();
+        models.sort_by(|a, b| {
+            b.1.recommended
+                .cmp(&a.1.recommended)
+                .then(b.1.accuracy_score.cmp(&a.1.accuracy_score))
+                .then(a.1.size.cmp(&b.1.size))
+        });
+        models.into_iter().map(|(name, _)| name.clone()).collect()
+    }
     /// Get models sorted by a specific metric
     #[allow(dead_code)]
     pub fn get_models_sorted(&self, sort_by: &str) -> Vec<(String, ModelInfo)> {
@@ -757,14 +777,14 @@ impl WhisperManager {
             "large-v3-q5_0".to_string(),
             ModelInfo {
                 name: "large-v3-q5_0".to_string(),
-                display_name: "Large v3 Q5".to_string(),
+                display_name: "Large v3 (Q5)".to_string(),
                 size: 1536, // 1.5KB for tests
                 url: "https://test.example.com/large-v3-q5_0.bin".to_string(),
                 sha256: "test_hash_q5".to_string(),
                 downloaded: false,
                 speed_score: 4,
                 accuracy_score: 8,
-                recommended: false,
+                recommended: true,
             },
         );
 

--- a/src-tauri/src/whisper/transcriber.rs
+++ b/src-tauri/src/whisper/transcriber.rs
@@ -1,16 +1,38 @@
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 use whisper_rs::{
-    convert_integer_to_float_audio, convert_stereo_to_mono_audio, FullParams, SamplingStrategy,
-    WhisperContext, WhisperContextParameters,
+    convert_integer_to_float_audio, convert_stereo_to_mono_audio, print_system_info, FullParams,
+    SamplingStrategy, WhisperContext, WhisperContextParameters,
 };
 
 use crate::utils::logger::*;
 #[cfg(debug_assertions)]
 use crate::utils::system_monitor;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TranscriptionBackend {
+    Cpu,
+    Metal,
+}
+
+impl TranscriptionBackend {
+    fn is_cpu(self) -> bool {
+        matches!(self, Self::Cpu)
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Cpu => "CPU",
+            Self::Metal => "Metal GPU",
+        }
+    }
+}
+
 pub struct Transcriber {
     context: WhisperContext,
+    backend: TranscriptionBackend,
 }
 
 impl Transcriber {
@@ -43,10 +65,10 @@ impl Transcriber {
             log::info!("🤖 Model file size: {}MB", size_mb);
         }
 
+        log::info!("🤖 whisper.cpp system info: {}", print_system_info());
+
         // Configure GPU usage based on platform and features
         let mut ctx_params = WhisperContextParameters::default();
-        #[allow(unused_assignments)] // gpu_used is assigned in multiple conditional blocks
-        let mut gpu_used = false;
 
         // macOS: Try Metal first, fallback to CPU if it fails
         // Note: Metal GPU acceleration only works on Apple Silicon (aarch64), not Intel Macs
@@ -92,24 +114,36 @@ impl Transcriber {
 
             match WhisperContext::new_with_params(model_path_str, ctx_params) {
                 Ok(ctx) => {
-                    #[allow(unused_assignments)]
-                    // This assignment is used later but flagged due to multiple conditional paths
-                    {
-                        gpu_used = true; // Metal GPU acceleration succeeded
-                    }
+                    let backend = if is_apple_silicon {
+                        TranscriptionBackend::Metal
+                    } else {
+                        TranscriptionBackend::Cpu
+                    };
                     let init_time = metal_start.elapsed().as_millis();
+                    let acceleration = if is_apple_silicon {
+                        "gpu_acceleration_enabled"
+                    } else {
+                        "cpu_only"
+                    };
 
-                    log_performance(
-                        "METAL_INIT",
-                        init_time as u64,
-                        Some("gpu_acceleration_enabled"),
-                    );
+                    log_performance("METAL_INIT", init_time as u64, Some(acceleration));
                     log_with_context(
                         log::Level::Info,
-                        "🎮 METAL_SUCCESS",
+                        if is_apple_silicon {
+                            "🎮 METAL_SUCCESS"
+                        } else {
+                            "🎮 CPU_INIT"
+                        },
                         &[
                             ("init_time_ms", init_time.to_string().as_str()),
-                            ("acceleration", "enabled"),
+                            (
+                                "acceleration",
+                                if is_apple_silicon {
+                                    "enabled"
+                                } else {
+                                    "disabled"
+                                },
+                            ),
                         ],
                     );
 
@@ -117,10 +151,13 @@ impl Transcriber {
                     log_with_context(
                         log::Level::Debug,
                         "Transcriber initialized",
-                        &[("backend", "Metal"), ("model_path", model_path_str)],
+                        &[("backend", backend.label()), ("model_path", model_path_str)],
                     );
 
-                    return Ok(Self { context: ctx });
+                    return Ok(Self {
+                        context: ctx,
+                        backend,
+                    });
                 }
                 Err(gpu_err) => {
                     log_with_context(
@@ -173,16 +210,8 @@ impl Transcriber {
             format!("Failed to load model: {}", e)
         })?;
 
-        // Determine backend type for logging
-        let backend_type = if gpu_used {
-            if cfg!(target_os = "macos") {
-                "Metal GPU"
-            } else {
-                "GPU"
-            }
-        } else {
-            "CPU"
-        };
+        let backend = TranscriptionBackend::Cpu;
+        let backend_type = backend.label();
 
         let cpu_time = cpu_start.elapsed().as_millis();
 
@@ -191,7 +220,7 @@ impl Transcriber {
             "🎮 WHISPER_BACKEND",
             &[
                 ("backend", backend_type),
-                ("gpu_used", gpu_used.to_string().as_str()),
+                ("gpu_used", "false"),
                 ("init_time_ms", cpu_time.to_string().as_str()),
             ],
         );
@@ -203,7 +232,7 @@ impl Transcriber {
             &[
                 ("backend", backend_type),
                 ("model_path", model_path_str),
-                ("gpu_acceleration", gpu_used.to_string().as_str()),
+                ("gpu_acceleration", "false"),
             ],
         );
 
@@ -231,19 +260,19 @@ impl Transcriber {
             ],
         );
 
-        Ok(Self { context: ctx })
+        Ok(Self {
+            context: ctx,
+            backend,
+        })
     }
 
-    pub fn transcribe_with_cancellation<F>(
+    pub fn transcribe_with_cancellation(
         &self,
         audio_path: &Path,
         language: Option<&str>,
         translate: bool,
-        should_cancel: F,
-    ) -> Result<String, String>
-    where
-        F: Fn() -> bool,
-    {
+        cancel_flag: Arc<AtomicBool>,
+    ) -> Result<String, String> {
         let transcription_start = Instant::now();
         let audio_path_str = format!("{:?}", audio_path);
 
@@ -278,8 +307,7 @@ impl Transcriber {
             return Err(error);
         }
 
-        // Early cancellation check
-        if should_cancel() {
+        if is_cancelled(&cancel_flag) {
             log::info!("[TRANSCRIPTION_DEBUG] Transcription cancelled before starting");
             return Err("Transcription cancelled".to_string());
         }
@@ -341,8 +369,7 @@ impl Transcriber {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| format!("Failed to read audio samples: {}", e))?;
 
-        // Check cancellation after reading samples
-        if should_cancel() {
+        if is_cancelled(&cancel_flag) {
             log::info!("[TRANSCRIPTION_DEBUG] Transcription cancelled after reading samples");
             return Err("Transcription cancelled".to_string());
         }
@@ -353,8 +380,7 @@ impl Transcriber {
         let mut audio: Vec<f32> = vec![0.0; samples_i16.len()];
         convert_integer_to_float_audio(&samples_i16, &mut audio).map_err(|e| e.to_string())?;
 
-        // Check cancellation after conversion
-        if should_cancel() {
+        if is_cancelled(&cancel_flag) {
             log::info!("[TRANSCRIPTION_DEBUG] Transcription cancelled after audio conversion");
             return Err("Transcription cancelled".to_string());
         }
@@ -419,8 +445,7 @@ impl Transcriber {
             ],
         );
 
-        // Check cancellation after resampling
-        if should_cancel() {
+        if is_cancelled(&cancel_flag) {
             log::info!("[TRANSCRIPTION_DEBUG] Transcription cancelled after resampling");
             return Err("Transcription cancelled".to_string());
         }
@@ -431,11 +456,16 @@ impl Transcriber {
             resampled_audio.len() as f32 / 16_000_f32
         );
 
-        // Create transcription parameters - use BeamSearch for better accuracy
-        let mut params = FullParams::new(SamplingStrategy::BeamSearch {
-            beam_size: 5,
-            patience: -1.0,
-        });
+        let cpu_profile = self.backend.is_cpu();
+        let mut params = if cpu_profile {
+            log::info!("[PERFORMANCE] Using CPU fast transcription profile");
+            FullParams::new(SamplingStrategy::Greedy { best_of: 1 })
+        } else {
+            FullParams::new(SamplingStrategy::BeamSearch {
+                beam_size: 5,
+                patience: -1.0,
+            })
+        };
 
         // Set language - use centralized validation
         log::info!("[LANGUAGE] Received language: {:?}", language);
@@ -497,7 +527,8 @@ impl Transcriber {
 
         params.set_n_threads(threads);
 
-        params.set_no_context(false); // Enable context for better word recognition
+        params.set_no_context(cpu_profile);
+        params.set_no_timestamps(cpu_profile);
         params.set_print_special(false);
         params.set_print_progress(false);
         params.set_print_realtime(false);
@@ -522,23 +553,13 @@ impl Transcriber {
         // Set initial prompt to help with context
         params.set_initial_prompt(""); // Empty prompt to avoid biasing the model
 
-        // Temperature settings - slight randomness helps avoid repetitive loops
-        params.set_temperature(0.2); // Small amount of randomness instead of deterministic
+        params.set_temperature(if cpu_profile { 0.0 } else { 0.2 });
         params.set_temperature_inc(0.2); // Increase by 0.2 on fallback (default)
         params.set_max_initial_ts(1.0); // Limit initial timestamp search
 
         // Limit segment length to prevent runaway hallucinations
         params.set_max_len(0); // 0 means no limit
         params.set_length_penalty(-1.0); // Default penalty
-
-        // Run transcription
-        log::info!("[TRANSCRIPTION_DEBUG] Creating Whisper state...");
-        let mut state = self.context.create_state().map_err(|e| {
-            let error = format!("Failed to create Whisper state: {}", e);
-            log::error!("[TRANSCRIPTION_DEBUG] {}", error);
-
-            error
-        })?;
 
         let samples_count = resampled_audio.len();
         let duration_seconds = samples_count as f32 / 16_000_f32;
@@ -550,7 +571,45 @@ impl Transcriber {
             return Err(error);
         }
 
-        log_audio_metrics("WHISPER_INPUT", 0.0, 0.0, duration_seconds, None);
+        let audio_metrics = calculate_audio_metrics(&resampled_audio);
+        log_audio_metrics(
+            "WHISPER_INPUT",
+            audio_metrics.rms,
+            audio_metrics.peak,
+            duration_seconds,
+            None,
+        );
+
+        if is_likely_silence(audio_metrics) {
+            log::info!(
+                "[TRANSCRIPTION_DEBUG] Skipping Whisper inference because audio is below speech threshold: rms={:.6}, peak={:.6}",
+                audio_metrics.rms,
+                audio_metrics.peak
+            );
+            return Ok(String::new());
+        }
+
+        let abort_flag = cancel_flag.clone();
+        let abort_callback: Box<dyn FnMut() -> bool> = Box::new(move || is_cancelled(&abort_flag));
+        params
+            .set_abort_callback_safe::<Option<Box<dyn FnMut() -> bool>>, Box<dyn FnMut() -> bool>>(
+                Some(abort_callback),
+            );
+        let progress_callback: Box<dyn FnMut(i32)> = Box::new(|progress| {
+            log::debug!("[TRANSCRIPTION_DEBUG] Whisper progress: {}%", progress);
+        });
+        params.set_progress_callback_safe::<Option<Box<dyn FnMut(i32)>>, Box<dyn FnMut(i32)>>(
+            Some(progress_callback),
+        );
+
+        // Run transcription
+        log::info!("[TRANSCRIPTION_DEBUG] Creating Whisper state...");
+        let mut state = self.context.create_state().map_err(|e| {
+            let error = format!("Failed to create Whisper state: {}", e);
+            log::error!("[TRANSCRIPTION_DEBUG] {}", error);
+
+            error
+        })?;
 
         let inference_start = Instant::now();
         log_start("WHISPER_INFERENCE");
@@ -588,6 +647,11 @@ impl Transcriber {
                 );
             }
             Err(e) => {
+                if is_cancelled(&cancel_flag) {
+                    log::info!("[TRANSCRIPTION_DEBUG] Whisper inference aborted by cancellation");
+                    return Err("Transcription cancelled".to_string());
+                }
+
                 let error = format!("Whisper inference failed: {}", e);
                 log_failed("WHISPER_INFERENCE", &error);
                 log_with_context(
@@ -697,8 +761,50 @@ impl Transcriber {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct AudioMetrics {
+    rms: f64,
+    peak: f64,
+}
+
+const SILENCE_RMS_THRESHOLD: f64 = 0.0005;
+const SILENCE_PEAK_THRESHOLD: f64 = 0.003;
+
+fn is_cancelled(cancel_flag: &AtomicBool) -> bool {
+    cancel_flag.load(Ordering::SeqCst)
+}
+
+fn calculate_audio_metrics(samples: &[f32]) -> AudioMetrics {
+    if samples.is_empty() {
+        return AudioMetrics {
+            rms: 0.0,
+            peak: 0.0,
+        };
+    }
+
+    let mut sum_squares = 0.0f64;
+    let mut peak = 0.0f64;
+
+    for &sample in samples {
+        let value = f64::from(sample);
+        let abs = value.abs();
+        sum_squares += value * value;
+        if abs > peak {
+            peak = abs;
+        }
+    }
+
+    AudioMetrics {
+        rms: (sum_squares / samples.len() as f64).sqrt(),
+        peak,
+    }
+}
+
+fn is_likely_silence(metrics: AudioMetrics) -> bool {
+    metrics.rms < SILENCE_RMS_THRESHOLD && metrics.peak < SILENCE_PEAK_THRESHOLD
+}
+
 /// Convert multi-channel audio to mono by averaging all channels
-///
 /// # Arguments
 /// * `audio` - Interleaved audio samples (ch1, ch2, ch3, ch4, ch1, ch2, ...)
 /// * `channels` - Number of channels in the audio
@@ -776,6 +882,26 @@ mod tests {
         let mono_audio = vec![1.0, 2.0, 3.0, 4.0];
         let result = convert_multichannel_to_mono(&mono_audio, 1).unwrap();
         assert_eq!(result, mono_audio);
+    }
+
+    #[test]
+    fn test_audio_metrics_for_silence() {
+        let samples = vec![0.0f32; 16_000];
+        let metrics = calculate_audio_metrics(&samples);
+
+        assert_eq!(metrics.rms, 0.0);
+        assert_eq!(metrics.peak, 0.0);
+        assert!(is_likely_silence(metrics));
+    }
+
+    #[test]
+    fn test_audio_metrics_detect_speech_like_signal() {
+        let samples = vec![0.02f32; 16_000];
+        let metrics = calculate_audio_metrics(&samples);
+
+        assert!(metrics.rms > SILENCE_RMS_THRESHOLD);
+        assert!(metrics.peak > SILENCE_PEAK_THRESHOLD);
+        assert!(!is_likely_silence(metrics));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,9 +46,7 @@
     ],
     "externalBin": [
       "../sidecar/ffmpeg/dist/ffmpeg",
-      "../sidecar/ffmpeg/dist/ffprobe",
-      "../sidecar/ffmpeg/dist/ffmpeg.exe",
-      "../sidecar/ffmpeg/dist/ffprobe.exe"
+      "../sidecar/ffmpeg/dist/ffprobe"
     ],
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -8,8 +8,6 @@
     "externalBin": [
       "../sidecar/ffmpeg/dist/ffmpeg",
       "../sidecar/ffmpeg/dist/ffprobe",
-      "../sidecar/ffmpeg/dist/ffmpeg.exe",
-      "../sidecar/ffmpeg/dist/ffprobe.exe",
       "../sidecar/whisper-vulkan/dist/whisper-vulkan-sidecar"
     ],
     "windows": {


### PR DESCRIPTION
## Summary
- add Windows OpenMP support for whisper-rs CPU fallback and CPU-fast Whisper params
- keep Windows Auto GPU-first while falling back safely to optimized CPU when Vulkan is unavailable
- add large-v3 q5 model catalog entry and exact-size model validation/redownload behavior
- add real audio metrics/silence gating and cancellation/no-hang handling for Whisper paths
- add Parakeet request timeouts, download-vs-load timeout split, and duration-scaled transcription timeout
- tighten FFmpeg sidecar packaging/no-console resolution paths

## Verification
- pnpm quality-gate
  - typecheck passed
  - lint passed
  - frontend tests: 235 passed
  - backend tests: 275 passed, 1 ignored
- cargo fmt --check
- focused reviewer pass found no remaining blockers

## Notes
- Local Windows MSVC target check could not complete on macOS because `ring` failed before app code on missing Windows C headers/toolchain; this PR is intended for CI Windows validation.