### PR TITLE
fix: repair Windows model catalog downloads

### DIFF
--- a/src-tauri/src/tests/model_commands.rs
+++ b/src-tauri/src/tests/model_commands.rs
@@ -70,6 +70,8 @@ mod tests {
 
         // Should have all the default models
         assert!(models.contains_key("base.en"));
+        assert!(models.contains_key("small.en"));
+        assert!(models.contains_key("medium"));
         assert!(models.contains_key("large-v3"));
         assert!(models.contains_key("large-v3-q5_0"));
         assert!(models.contains_key("large-v3-turbo"));
@@ -204,10 +206,11 @@ mod tests {
 
         for name in [
             "base.en",
+            "small.en",
+            "medium",
             "large-v3",
             "large-v3-q5_0",
             "large-v3-turbo",
-            "small.en",
         ] {
             assert!(models.contains_key(name), "missing catalog model: {name}");
         }
@@ -271,6 +274,11 @@ mod tests {
         assert_eq!(base_en.speed_score, 8); // Very fast
         assert_eq!(base_en.accuracy_score, 5); // Basic accuracy
 
+        let medium = models.get("medium").unwrap();
+        assert_eq!(medium.speed_score, 5);
+        assert_eq!(medium.accuracy_score, 7);
+        assert!(!medium.recommended);
+
         let large = models.get("large-v3").unwrap();
         assert!(large.speed_score < base_en.speed_score); // Slower
         assert!(large.accuracy_score > base_en.accuracy_score); // More accurate
@@ -296,17 +304,23 @@ mod tests {
         let manager = WhisperManager::new(temp_dir.path().to_path_buf());
         let models = manager.get_models_status();
 
-        // Verify model sizes are reasonable
         let base_en = models.get("base.en").unwrap();
-        assert!(base_en.size > 100 * 1024 * 1024); // > 100MB
-        assert!(base_en.size < 200 * 1024 * 1024); // < 200MB
+        assert_eq!(base_en.size, 147_964_211);
+
+        let small_en = models.get("small.en").unwrap();
+        assert_eq!(small_en.size, 487_614_201);
+        assert!(small_en.size > base_en.size);
+
+        let medium = models.get("medium").unwrap();
+        assert_eq!(medium.size, 1_533_763_059);
+        assert!(medium.size > small_en.size);
 
         let large = models.get("large-v3").unwrap();
         assert_eq!(large.size, 3_095_033_483);
 
         let q5 = models.get("large-v3-q5_0").unwrap();
         assert_eq!(q5.size, 1_081_140_203);
-        assert!(q5.size > base_en.size);
+        assert!(q5.size > small_en.size);
         assert!(q5.size < large.size);
 
         let turbo = models.get("large-v3-turbo").unwrap();
@@ -331,8 +345,55 @@ mod tests {
             assert_eq!(model.sha256.len(), 40);
         }
 
+        let base_en = models.get("base.en").unwrap();
+        assert_eq!(base_en.display_name, "Base (English)");
+        assert_eq!(base_en.sha256, "137c40403d78fd54d454da0f9bd998f78703390c");
+
+        let small_en = models.get("small.en").unwrap();
+        assert_eq!(small_en.display_name, "Small (English)");
+        assert_eq!(small_en.sha256, "db8a495a91d927739e50b3fc1cc4c6b8f6c2d022");
+
+        let medium = models.get("medium").unwrap();
+        assert_eq!(medium.display_name, "Medium");
+        assert_eq!(medium.sha256, "fd9727b6e1217c2f614f9b698455c4ffd82463b4");
+        assert!(medium.url.ends_with("ggml-medium.bin"));
+
         let q5 = models.get("large-v3-q5_0").unwrap();
         assert_eq!(q5.display_name, "Large v3 (Q5)");
         assert_eq!(q5.sha256, "e6e2ed78495d403bef4b7cff42ef4aaadcfea8de");
+    }
+
+    #[test]
+    fn test_production_catalog_sparse_file_size_regression() {
+        let temp_dir = TempDir::new().unwrap();
+        let models_dir = temp_dir.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+
+        let model_path = models_dir.join("base.en.bin");
+        {
+            let file = std::fs::File::create(&model_path).unwrap();
+            file.set_len(147_964_211).unwrap();
+        }
+
+        let mut manager = WhisperManager::new(models_dir.clone());
+        let status = manager.get_models_status();
+        assert!(status.get("base.en").unwrap().downloaded);
+
+        let path = manager.get_model_path("base.en");
+        assert!(path.is_some());
+        assert_eq!(path.unwrap(), model_path);
+
+        {
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&model_path)
+                .unwrap();
+            file.set_len(148_897_792).unwrap();
+        }
+
+        manager.refresh_downloaded_status();
+        let status = manager.get_models_status();
+        assert!(!status.get("base.en").unwrap().downloaded);
+        assert!(manager.get_model_path("base.en").is_none());
     }
 }

--- a/src-tauri/src/whisper/manager.rs
+++ b/src-tauri/src/whisper/manager.rs
@@ -98,15 +98,15 @@ impl WhisperManager {
         // These are SHA1 hashes (40 characters) as used by the official download script
         // Note: The field is named 'sha256' for historical reasons but contains SHA1 values
 
-        // Multilingual models only (no .en variants)
-        // Removed tiny, small, and medium models - keeping only base and large variants
+        // English-only (.en) and multilingual models from official whisper.cpp metadata
+        // Tiny variants omitted; medium restored with official size and checksum
 
         models.insert(
             "base.en".to_string(),
             ModelInfo {
                 name: "base.en".to_string(),
                 display_name: "Base (English)".to_string(),
-                size: 148_897_792, // 142 MiB = 142 * 1024 * 1024 bytes
+                size: 147_964_211,
                 url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin"
                     .to_string(),
                 sha256: "137c40403d78fd54d454da0f9bd998f78703390c".to_string(), // SHA1 (correct)
@@ -166,13 +166,29 @@ impl WhisperManager {
             ModelInfo {
                 name: "small.en".to_string(),
                 display_name: "Small (English)".to_string(),
-                size: 488_505_344, // 466 MiB = 466 * 1024 * 1024 bytes
+                size: 487_614_201,
                 url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin"
                     .to_string(),
                 sha256: "db8a495a91d927739e50b3fc1cc4c6b8f6c2d022".to_string(), // SHA1 (correct)
                 downloaded: false,
                 speed_score: 7,    // Fast for English-only
                 accuracy_score: 6, // Good accuracy for English
+                recommended: false,
+            },
+        );
+
+        models.insert(
+            "medium".to_string(),
+            ModelInfo {
+                name: "medium".to_string(),
+                display_name: "Medium".to_string(),
+                size: 1_533_763_059,
+                url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin"
+                    .to_string(),
+                sha256: "fd9727b6e1217c2f614f9b698455c4ffd82463b4".to_string(), // SHA1 (correct)
+                downloaded: false,
+                speed_score: 5,
+                accuracy_score: 7,
                 recommended: false,
             },
         );
@@ -785,6 +801,21 @@ impl WhisperManager {
                 speed_score: 4,
                 accuracy_score: 8,
                 recommended: true,
+            },
+        );
+
+        models.insert(
+            "medium".to_string(),
+            ModelInfo {
+                name: "medium".to_string(),
+                display_name: "Medium".to_string(),
+                size: 1792,
+                url: "https://test.example.com/medium.bin".to_string(),
+                sha256: "test_hash_medium".to_string(),
+                downloaded: false,
+                speed_score: 5,
+                accuracy_score: 7,
+                recommended: false,
             },
         );
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,7 +81,7 @@
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE2Q0M5NTZENjAwM0YyNDkKUldSSjhnTmdiWlhNRm0wdHQ1YmxNSzBWS2tiZlcyZ3FJZG5FajZ3MFBzTUZmRDgvZys5R1J6c2cK",
       "windows": {
-        "installMode": "basicUi"
+        "installMode": "passive"
       }
     }
   }

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -81,7 +81,7 @@
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE2Q0M5NTZENjAwM0YyNDkKUldSSjhnTmdiWlhNRm0wdHQ1YmxNSzBWS2tiZlcyZ3FJZG5FajZ3MFBzTUZmRDgvZys5R1J6c2cK",
       "windows": {
-        "installMode": "basicUi"
+        "installMode": "passive"
       }
     }
   }

--- a/src/hooks/useModelManagement.test.ts
+++ b/src/hooks/useModelManagement.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { sortModels } from './useModelManagement';
+import { LocalModelInfo } from '@/types';
+
+function whisperModel(
+  name: string,
+  accuracy_score: number,
+  speed_score: number,
+  size: number
+): LocalModelInfo {
+  return {
+    name,
+    display_name: name,
+    engine: 'whisper',
+    kind: 'local',
+    recommended: false,
+    downloaded: false,
+    requires_setup: false,
+    size,
+    url: `https://example.com/${name}.bin`,
+    sha256: `${name}-sha256`,
+    speed_score,
+    accuracy_score,
+  };
+}
+
+describe('sortModels', () => {
+  it('orders whisper models by accuracy with medium after small', () => {
+    const entries: [string, LocalModelInfo][] = [
+      ['large-v3-q5_0', whisperModel('large-v3-q5_0', 8, 4, 1_081_140_203)],
+      ['medium', whisperModel('medium', 7, 5, 1_533_763_059)],
+      ['small.en', whisperModel('small.en', 6, 7, 487_614_201)],
+      ['base.en', whisperModel('base.en', 5, 8, 147_964_211)],
+    ];
+
+    const sorted = sortModels(entries, 'accuracy');
+
+    expect(sorted.map(([name]) => name)).toEqual([
+      'base.en',
+      'small.en',
+      'medium',
+      'large-v3-q5_0',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Correct Whisper catalog byte sizes so verified Windows downloads stay marked downloaded
- Add the requested Medium model after Small
- Switch Windows updater install mode to passive so the app-owned update confirmation is followed by progress/restart instead of a second installer wizard
- Add regression coverage for the production base.en size and frontend model ordering

## Verification
- `pnpm quality-gate`
- `cargo fmt --check`
- `git diff --check`

No release is included in this PR.