### PR TITLE
fix: warm Windows Vulkan sidecar and spacing

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -91,6 +91,40 @@ fn should_hide_pill_when_idle(mode: &str) -> bool {
     mode != "always"
 }
 
+/// Best-effort warm of the Windows Vulkan sidecar when a Whisper model is preloaded.
+/// No-op on non-Windows platforms and when CPU acceleration is selected.
+pub(crate) async fn warm_whisper_gpu_sidecar_on_model_preload(
+    app: &AppHandle,
+    model_path: &Path,
+) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        let mode = get_settings(app.clone())
+            .await
+            .map(|settings| {
+                normalize_transcription_acceleration(Some(&settings.transcription_acceleration))
+            })
+            .unwrap_or_else(|error| {
+                log::warn!(
+                    "Failed to read settings for Vulkan sidecar preload warm; defaulting to auto: {error}"
+                );
+                crate::commands::settings::DEFAULT_TRANSCRIPTION_ACCELERATION.to_string()
+            });
+
+        let gpu_client = app.state::<crate::whisper::gpu_sidecar::GpuSidecarClient>();
+        let gpu_available = gpu_client.status().await.gpu_available;
+        gpu_client
+            .warm_on_preload(app, model_path, &mode, gpu_available)
+            .await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (app, model_path);
+        false
+    }
+}
+
 async fn transcribe_whisper_with_acceleration(
     app: &AppHandle,
     model_path: &Path,

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -698,12 +698,19 @@ pub async fn preload_model(
             .ok_or(format!("Model '{}' not found", model_name))?
     };
 
-    // Load into cache
-    let cache_state = app.state::<AsyncMutex<TranscriberCache>>();
-    let mut cache = cache_state.lock().await;
+    if crate::commands::audio::warm_whisper_gpu_sidecar_on_model_preload(&app, &model_path).await {
+        log::info!(
+            "Model '{}' preloaded successfully in Vulkan sidecar",
+            model_name
+        );
+        return Ok(());
+    }
 
-    // This will load the model and cache it
-    cache.get_or_create(&model_path)?;
+    {
+        let cache_state = app.state::<AsyncMutex<TranscriberCache>>();
+        let mut cache = cache_state.lock().await;
+        cache.get_or_create(&model_path)?;
+    }
 
     log::info!("Model '{}' preloaded successfully", model_name);
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1160,6 +1160,20 @@ mod tests {
             DEFAULT_TRANSCRIPTION_ACCELERATION
         );
     }
+
+    #[test]
+    fn vulkan_preload_warm_follows_transcription_acceleration_mode() {
+        use crate::whisper::gpu_sidecar::should_attempt_vulkan_warm_on_preload;
+
+        let cpu = normalize_transcription_acceleration(Some("cpu"));
+        assert!(!should_attempt_vulkan_warm_on_preload(&cpu, None));
+
+        let auto = normalize_transcription_acceleration(Some("auto"));
+        assert!(should_attempt_vulkan_warm_on_preload(&auto, None));
+
+        let gpu = normalize_transcription_acceleration(Some("gpu"));
+        assert!(should_attempt_vulkan_warm_on_preload(&gpu, None));
+    }
     /// Verify the autostart command functions exist and compile.
     /// Compilation IS the test: if the functions don't exist or have
     /// wrong signatures, the imports and generate_handler! macro will fail.

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -18,13 +18,51 @@ use enigo::{
 // Global flag to prevent concurrent text insertions
 static IS_INSERTING: AtomicBool = AtomicBool::new(false);
 
-/// Ensure prose ending in sentence punctuation has exactly one trailing space.
+const CLOSING_PUNCTUATION: [char; 8] = ['"', '\'', '“', '”', '’', ')', ']', '}'];
+
+/// Last non-closing character, allowing quotes/brackets after sentence punctuation.
+fn last_meaningful_char(text: &str) -> Option<char> {
+    text.chars()
+        .rev()
+        .find(|c| !CLOSING_PUNCTUATION.contains(c))
+}
+
+/// Detect contexts where a trailing insertion space would be harmful.
+fn should_skip_trailing_insertion_space(text: &str) -> bool {
+    let semantic_end = text.trim_end_matches(|c| CLOSING_PUNCTUATION.contains(&c));
+    let before_period = semantic_end.strip_suffix('.').unwrap_or(semantic_end);
+    let looks_like_url = semantic_end.contains("://")
+        || before_period.ends_with(".com")
+        || before_period.ends_with(".org")
+        || before_period.ends_with(".net")
+        || before_period.ends_with(".io")
+        || before_period.ends_with(".dev")
+        || before_period.ends_with(".app");
+    // Email-like: contains @ with no spaces (even if followed by period)
+    let looks_like_email = before_period.contains('@') && !before_period.contains(' ');
+    let looks_like_code = semantic_end.contains('=')
+        || semantic_end.contains("->")
+        || semantic_end.contains("::")
+        || semantic_end.contains('{')
+        || semantic_end.contains('}')
+        || semantic_end.contains(';');
+
+    looks_like_url || looks_like_email || looks_like_code
+}
+
+/// Whether to append exactly one trailing space before the next insertion.
+fn should_add_trailing_insertion_space(text: &str) -> bool {
+    !should_skip_trailing_insertion_space(text) && last_meaningful_char(text).is_some()
+}
+
+/// Ensure insertable prose has exactly one trailing space at the insertion boundary.
 ///
 /// This is applied at the insertion boundary only, so stored transcription
 /// history remains clean. Rules:
 /// - `Hello world.` → `Hello world. `
 /// - `Hello world. ` → `Hello world. ` (normalize to one)
-/// - `Hello world` → `Hello world` (no sentence end, no space)
+/// - `Hello world` → `Hello world ` (fragment boundary for continuous dictation)
+/// - `Hello world,` → `Hello world, ` (fragment boundary for continuous dictation)
 /// - `https://example.com.` → `https://example.com.` (URL-like, skip)
 /// - `foo@bar.com.` → `foo@bar.com.` (email-like, skip)
 /// - `x = y.` → `x = y.` (code-like, skip)
@@ -46,44 +84,11 @@ fn ensure_trailing_sentence_space(text: &str) -> String {
         return text.to_string();
     }
 
-    let closing_punctuation = ['"', '\'', '“', '”', '’', ')', ']', '}'];
-    let sentence_end = without_trailing_spaces
-        .chars()
-        .rev()
-        .find(|c| !closing_punctuation.contains(c));
-
-    // Only add space after sentence-ending punctuation, allowing closing
-    // quotes/brackets after the punctuation.
-    if !matches!(sentence_end, Some('.' | '!' | '?')) {
-        return text.to_string();
+    if should_add_trailing_insertion_space(without_trailing_spaces) {
+        format!("{} ", without_trailing_spaces)
+    } else {
+        text.to_string()
     }
-
-    // Detect contexts where a trailing space would be harmful.
-    let semantic_end =
-        without_trailing_spaces.trim_end_matches(|c| closing_punctuation.contains(&c));
-    let before_period = semantic_end.strip_suffix('.').unwrap_or(semantic_end);
-    let looks_like_url = semantic_end.contains("://")
-        || before_period.ends_with(".com")
-        || before_period.ends_with(".org")
-        || before_period.ends_with(".net")
-        || before_period.ends_with(".io")
-        || before_period.ends_with(".dev")
-        || before_period.ends_with(".app");
-    // Email-like: contains @ with no spaces (even if followed by period)
-    let looks_like_email = before_period.contains('@') && !before_period.contains(' ');
-    let looks_like_code = semantic_end.contains('=')
-        || semantic_end.contains("->")
-        || semantic_end.contains("::")
-        || semantic_end.contains('{')
-        || semantic_end.contains('}')
-        || semantic_end.contains(';');
-
-    if looks_like_url || looks_like_email || looks_like_code {
-        return text.to_string();
-    }
-
-    // Preserve exactly one trailing space after the original closing punctuation.
-    format!("{} ", without_trailing_spaces)
 }
 
 #[tauri::command]
@@ -574,16 +579,47 @@ mod tests {
     }
 
     #[test]
-    fn no_sentence_end_no_space() {
-        assert_eq!(ensure_trailing_sentence_space("Hello world"), "Hello world");
+    fn prose_fragment_gets_trailing_space() {
+        assert_eq!(
+            ensure_trailing_sentence_space("Hello world"),
+            "Hello world "
+        );
     }
 
     #[test]
-    fn comma_no_space() {
+    fn repeated_prose_fragments_keep_single_space_boundary() {
+        let combined = format!(
+            "{}{}",
+            ensure_trailing_sentence_space("hello world"),
+            ensure_trailing_sentence_space("next phrase"),
+        );
+
+        assert_eq!(combined, "hello world next phrase ");
+    }
+
+    #[test]
+    fn repeated_fragments_do_not_duplicate_spaces() {
+        assert_eq!(
+            ensure_trailing_sentence_space("hello world   "),
+            "hello world "
+        );
+        assert_eq!(
+            ensure_trailing_sentence_space("already spaced "),
+            "already spaced "
+        );
+    }
+
+    #[test]
+    fn comma_gets_trailing_space() {
         assert_eq!(
             ensure_trailing_sentence_space("Hello world,"),
-            "Hello world,"
+            "Hello world, "
         );
+    }
+
+    #[test]
+    fn colon_gets_trailing_space() {
+        assert_eq!(ensure_trailing_sentence_space("Note:"), "Note: ");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -856,17 +856,31 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                         };
 
                         if let Some(model_path) = model_path {
-                            // Load model into cache
-                            let cache_state = app_handle.state::<AsyncMutex<TranscriberCache>>();
-                            let mut cache = cache_state.lock().await;
+                            if crate::commands::audio::warm_whisper_gpu_sidecar_on_model_preload(
+                                &app_handle,
+                                &model_path,
+                            )
+                            .await
+                            {
+                                log::info!(
+                                    "Successfully preloaded model '{}' in Vulkan sidecar",
+                                    current_model
+                                );
+                            } else {
+                                let preload_result = {
+                                    let cache_state = app_handle.state::<AsyncMutex<TranscriberCache>>();
+                                    let mut cache = cache_state.lock().await;
+                                    cache.get_or_create(&model_path).map(|_| ())
+                                };
 
-                            match cache.get_or_create(&model_path) {
-                                Ok(_) => {
-                                    log::info!("Successfully preloaded model '{}' into cache", current_model);
-                                }
-                                Err(e) => {
-                                    log::warn!("Failed to preload model '{}': {}. App will continue without preloading.",
-                                             current_model, e);
+                                match preload_result {
+                                    Ok(()) => {
+                                        log::info!("Successfully preloaded model '{}' into cache", current_model);
+                                    }
+                                    Err(e) => {
+                                        log::warn!("Failed to preload model '{}': {}. App will continue without preloading.",
+                                                 current_model, e);
+                                    }
                                 }
                             }
                         } else {

--- a/src-tauri/src/whisper/gpu_sidecar.rs
+++ b/src-tauri/src/whisper/gpu_sidecar.rs
@@ -281,6 +281,40 @@ impl GpuSidecarClient {
         };
     }
 
+    /// Best-effort warm of the Vulkan sidecar and model during Whisper preload.
+    /// Returns true only when the sidecar accepted the model and kept it warm.
+    pub async fn warm_on_preload(
+        &self,
+        app: &AppHandle,
+        model_path: &Path,
+        mode: &str,
+        gpu_available: Option<bool>,
+    ) -> bool {
+        if !should_attempt_vulkan_warm_on_preload(mode, gpu_available) {
+            log::debug!(
+                "Skipping Vulkan sidecar warm on preload (mode={mode}, gpu_available={gpu_available:?})"
+            );
+            return false;
+        }
+
+        log::info!(
+            "Warming Whisper Vulkan sidecar for preloaded model: {}",
+            model_path.display()
+        );
+        match self.probe(app, model_path, mode).await {
+            Ok(()) => {
+                log::info!("Whisper Vulkan sidecar warmed successfully on preload");
+                true
+            }
+            Err(error) => {
+                log::warn!(
+                    "Whisper Vulkan sidecar warm on preload failed; CPU fallback remains available: {error}"
+                );
+                false
+            }
+        }
+    }
+
     pub async fn probe(
         &self,
         app: &AppHandle,
@@ -455,6 +489,20 @@ impl GpuSidecarClient {
     }
 }
 
+/// Whether preload should spawn/probe the Vulkan sidecar for the given acceleration mode.
+pub(crate) fn should_attempt_vulkan_warm_on_preload(
+    mode: &str,
+    gpu_available: Option<bool>,
+) -> bool {
+    if mode == "cpu" {
+        return false;
+    }
+    if mode == "auto" && gpu_available == Some(false) {
+        return false;
+    }
+    true
+}
+
 fn transcription_timeout(audio_path: &Path) -> Duration {
     wav_duration_seconds(audio_path)
         .map(transcription_timeout_for_duration)
@@ -565,7 +613,8 @@ fn dev_sidecar_cwd() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        sidecar_search_dirs, transcription_timeout_for_duration, SidecarRequest, SidecarResponse,
+        should_attempt_vulkan_warm_on_preload, sidecar_search_dirs,
+        transcription_timeout_for_duration, SidecarRequest, SidecarResponse,
         CONTROL_REQUEST_TIMEOUT, DEFAULT_TRANSCRIPTION_TIMEOUT, MAX_TRANSCRIPTION_TIMEOUT_SECS,
         MIN_TRANSCRIPTION_TIMEOUT_SECS,
     };
@@ -616,6 +665,17 @@ mod tests {
             transcription_timeout_for_duration(600.0),
             std::time::Duration::from_secs(MAX_TRANSCRIPTION_TIMEOUT_SECS)
         );
+    }
+
+    #[test]
+    fn should_attempt_vulkan_warm_on_preload_respects_mode_and_prior_failure() {
+        assert!(!should_attempt_vulkan_warm_on_preload("cpu", None));
+        assert!(!should_attempt_vulkan_warm_on_preload("cpu", Some(true)));
+        assert!(should_attempt_vulkan_warm_on_preload("gpu", None));
+        assert!(should_attempt_vulkan_warm_on_preload("gpu", Some(false)));
+        assert!(should_attempt_vulkan_warm_on_preload("auto", None));
+        assert!(should_attempt_vulkan_warm_on_preload("auto", Some(true)));
+        assert!(!should_attempt_vulkan_warm_on_preload("auto", Some(false)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Warm the Windows Vulkan sidecar during Whisper preload for Auto/GPU modes so first transcription does not pay the sidecar/model cold-start
- Fall back to CPU cache preload when sidecar warm is skipped or fails; CPU mode remains CPU-only
- Fix repeated dictation spacing by adding one insertion-boundary space for safe single-line fragments
- Keep URL/email/code/multiline guards intact

## Whisper params note
- Existing CPU WhisperRS path already uses the fast profile: greedy decode, no timestamps, no context, suppressed blank/non-speech tokens, deterministic temperature and thresholds
- Vulkan sidecar keeps the old GPU beam-search profile for accuracy/parity
- WhisperRS has no direct built-in filler-cleanup/force-punctuation switch; filler cleanup is a separate post-processing feature and is intentionally not added to this hotfix

## Verification
- `cargo test commands::text::tests`
- `cargo test should_attempt_vulkan_warm_on_preload_respects_mode_and_prior_failure`
- `cargo test vulkan_preload_warm_follows_transcription_acceleration_mode`
- `pnpm quality-gate`
- `git diff --check`

No release is included in this PR.