### PR TITLE
fix: keep model management responsive during downloads

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "voicetypr"
-version = "1.12.6"
+version = "1.12.7"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -16,6 +16,40 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 type ActiveDownloadsState<'a> = State<'a, Arc<StdMutex<HashMap<String, Arc<AtomicBool>>>>>;
 
+/// Register an in-flight download, rejecting duplicates so the original cancel flag is preserved.
+pub(crate) fn register_active_download(
+    active_downloads: &Arc<StdMutex<HashMap<String, Arc<AtomicBool>>>>,
+    model_name: &str,
+    cancel_flag: Arc<AtomicBool>,
+) -> Result<(), String> {
+    let mut downloads = active_downloads.lock().map_err(|e| {
+        log::error!("Failed to lock active downloads for inserting: {}", e);
+        "Failed to initialize download tracking".to_string()
+    })?;
+    if downloads.contains_key(model_name) {
+        return Err(format!(
+            "Download already in progress for model '{}'",
+            model_name
+        ));
+    }
+    downloads.insert(model_name.to_string(), cancel_flag);
+    Ok(())
+}
+
+fn clear_active_download(
+    active_downloads: &Arc<StdMutex<HashMap<String, Arc<AtomicBool>>>>,
+    model_name: &str,
+) {
+    match active_downloads.lock() {
+        Ok(mut downloads) => {
+            downloads.remove(model_name);
+        }
+        Err(e) => {
+            log::warn!("Failed to lock active downloads for cleanup: {}", e);
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ModelEngine {
     Whisper,
@@ -47,10 +81,21 @@ pub async fn download_model(
 ) -> Result<(), String> {
     let download_start = Instant::now();
 
-    let download_target =
-        identify_download_target(&model_name, &whisper_state, &parakeet_manager).await?;
-
     log::info!("Starting download for model: {}", model_name);
+
+    // Register before the first await so cancellation/delete cannot race the
+    // download startup path.
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    register_active_download(&active_downloads, &model_name, cancel_flag.clone())?;
+
+    let download_target =
+        match identify_download_target(&model_name, &whisper_state, &parakeet_manager).await {
+            Ok(target) => target,
+            Err(err) => {
+                clear_active_download(&active_downloads, &model_name);
+                return Err(err);
+            }
+        };
 
     // Monitor system resources at download start
     #[cfg(debug_assertions)]
@@ -63,20 +108,6 @@ pub async fn download_model(
     });
 
     let app_handle = app.clone();
-
-    // Create cancellation flag for this download
-    let cancel_flag = Arc::new(AtomicBool::new(false));
-    {
-        match active_downloads.lock() {
-            Ok(mut downloads) => {
-                downloads.insert(model_name.clone(), cancel_flag.clone());
-            }
-            Err(e) => {
-                log::error!("Failed to lock active downloads for inserting: {}", e);
-                return Err("Failed to initialize download tracking".to_string());
-            }
-        }
-    }
 
     let model_name_clone = model_name.clone();
 
@@ -147,18 +178,29 @@ pub async fn download_model(
         let progress_tx_clone = progress_tx.clone();
         let result = match download_target.engine {
             ModelEngine::Whisper => {
-                let manager = whisper_state.read().await;
-                let res = manager
-                    .download_model(
-                        &model_name,
-                        Some(cancel_flag.clone()),
-                        move |downloaded, total| {
-                            let _ = progress_tx_clone.send((downloaded, total));
-                        },
-                    )
-                    .await;
-                drop(manager);
-                res
+                let download_prep = {
+                    let manager = whisper_state.read().await;
+                    manager
+                        .get_model_info(&model_name)
+                        .map(|(model_info, output_path)| {
+                            (model_info, output_path, manager.models_dir())
+                        })
+                };
+                match download_prep {
+                    Err(e) => Err(e),
+                    Ok((model_info, output_path, models_dir)) => {
+                        WhisperManager::download_model_file(
+                            &model_info,
+                            &output_path,
+                            &models_dir,
+                            Some(cancel_flag.clone()),
+                            move |downloaded, total| {
+                                let _ = progress_tx_clone.send((downloaded, total));
+                            },
+                        )
+                        .await
+                    }
+                }
             }
             ModelEngine::Parakeet => {
                 parakeet_manager
@@ -201,21 +243,12 @@ pub async fn download_model(
     // Ensure progress handler completes
     let _ = progress_handle.await;
 
-    // Clean up the cancellation flag
-    {
-        match active_downloads.lock() {
-            Ok(mut downloads) => {
-                downloads.remove(&model_name);
-            }
-            Err(e) => {
-                log::warn!("Failed to lock active downloads for cleanup: {}", e);
-                // Continue despite cleanup failure
-            }
-        }
-    }
+    // Keep the active-download guard through verification and event emission so
+    // delete_model cannot remove the file while the downloader is still
+    // finalizing it.
 
     log::info!("Processing download result for model: {}", model_name);
-    match download_result {
+    let final_result = match download_result {
         Err(ref e) if e.contains("cancelled") => {
             log::info!("Download was cancelled");
             // Emit download-cancelled event
@@ -223,7 +256,7 @@ pub async fn download_model(
                 &app,
                 "download-cancelled",
                 serde_json::json!({
-                    "model": model_name,
+                    "model": &model_name,
                     "engine": download_target.engine.as_str()
                 }),
             ) {
@@ -247,11 +280,24 @@ pub async fn download_model(
                 logger.log_model_download_complete(&model_name, 0); // TODO: track actual duration
             });
 
-            // Refresh/verify downloaded status
-            match download_target.engine {
+            // Refresh/verify downloaded status before emitting success.
+            let verification_result = match download_target.engine {
                 ModelEngine::Whisper => {
                     let mut manager = whisper_state.write().await;
                     manager.refresh_downloaded_status();
+                    let verified = manager
+                        .get_models_status()
+                        .get(&model_name)
+                        .map(|info| info.downloaded)
+                        .unwrap_or(false);
+                    if verified {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Whisper manager did not confirm '{}' as downloaded. Please try again.",
+                            model_name
+                        ))
+                    }
                 }
                 ModelEngine::Parakeet => {
                     // Verify Parakeet reports the requested model as downloaded
@@ -260,48 +306,52 @@ pub async fn download_model(
                         .into_iter()
                         .any(|m| m.name == model_name && m.downloaded);
 
-                    if !verified {
-                        let msg = format!(
+                    if verified {
+                        Ok(())
+                    } else {
+                        Err(format!(
                             "Parakeet sidecar did not confirm '{}' as downloaded. Please try again.",
                             model_name
-                        );
-                        log::warn!("{}", msg);
-                        // Emit download-error event and return Err
-                        if let Err(emit_err) = emit_to_all(
-                            &app,
-                            "download-error",
-                            serde_json::json!({
-                                "model": model_name,
-                                "engine": download_target.engine.as_str(),
-                                "error": msg
-                            }),
-                        ) {
-                            log::warn!("Failed to emit download-error event: {}", emit_err);
-                        }
-                        return Err("verification_failed".to_string());
+                        ))
                     }
                 }
-            }
+            };
 
-            // Emit success event after verification
-            log::info!("Emitting model-downloaded event for {}", model_name);
-            if let Err(e) = emit_to_all(
-                &app,
-                "model-downloaded",
-                serde_json::json!({
-                    "model": model_name,
-                    "engine": download_target.engine.as_str()
-                }),
-            ) {
-                log::warn!("Failed to emit model-downloaded event: {}", e);
-            }
+            if let Err(msg) = verification_result {
+                log::warn!("{}", msg);
+                if let Err(emit_err) = emit_to_all(
+                    &app,
+                    "download-error",
+                    serde_json::json!({
+                        "model": &model_name,
+                        "engine": download_target.engine.as_str(),
+                        "error": msg
+                    }),
+                ) {
+                    log::warn!("Failed to emit download-error event: {}", emit_err);
+                }
+                Err("verification_failed".to_string())
+            } else {
+                // Emit success event after verification
+                log::info!("Emitting model-downloaded event for {}", model_name);
+                if let Err(e) = emit_to_all(
+                    &app,
+                    "model-downloaded",
+                    serde_json::json!({
+                        "model": &model_name,
+                        "engine": download_target.engine.as_str()
+                    }),
+                ) {
+                    log::warn!("Failed to emit model-downloaded event: {}", e);
+                }
 
-            // Refresh tray menu so the new model appears in the tray immediately
-            if let Err(e) = crate::commands::settings::update_tray_menu(app.clone()).await {
-                log::warn!("Failed to update tray menu after model download: {}", e);
-            }
+                // Refresh tray menu so the new model appears in the tray immediately
+                if let Err(e) = crate::commands::settings::update_tray_menu(app.clone()).await {
+                    log::warn!("Failed to update tray menu after model download: {}", e);
+                }
 
-            Ok(())
+                Ok(())
+            }
         }
         Err(e) => {
             log::error!("Download failed for model {}: {}", model_name, e);
@@ -316,7 +366,7 @@ pub async fn download_model(
                 &app,
                 "download-error",
                 serde_json::json!({
-                    "model": model_name,
+                    "model": &model_name,
                     "engine": download_target.engine.as_str(),
                     "error": e.to_string()
                 }),
@@ -328,7 +378,11 @@ pub async fn download_model(
 
             Err(e)
         }
-    }
+    };
+
+    clear_active_download(&active_downloads, &model_name);
+
+    final_result
 }
 
 #[derive(serde::Serialize)]
@@ -403,35 +457,44 @@ pub async fn delete_model(
     model_name: String,
     whisper_state: State<'_, RwLock<WhisperManager>>,
     parakeet_manager: State<'_, ParakeetManager>,
+    active_downloads: ActiveDownloadsState<'_>,
 ) -> Result<(), String> {
-    let engine = determine_model_engine(&model_name, &whisper_state, &parakeet_manager).await?;
+    let delete_guard = Arc::new(AtomicBool::new(false));
+    register_active_download(&active_downloads, &model_name, delete_guard)?;
 
-    match engine {
-        ModelEngine::Whisper => {
-            let mut manager = whisper_state.write().await;
-            manager.delete_model_file(&model_name)?;
+    let result = async {
+        let engine = determine_model_engine(&model_name, &whisper_state, &parakeet_manager).await?;
+
+        match engine {
+            ModelEngine::Whisper => {
+                let mut manager = whisper_state.write().await;
+                manager.delete_model_file(&model_name)?;
+            }
+            ModelEngine::Parakeet => {
+                parakeet_manager.delete_model(&app, &model_name).await?;
+            }
         }
-        ModelEngine::Parakeet => {
-            parakeet_manager.delete_model(&app, &model_name).await?;
+
+        // Emit model-deleted event
+        let _ = app.emit(
+            "model-deleted",
+            serde_json::json!({
+                "model": model_name.clone(),
+                "engine": engine.as_str()
+            }),
+        );
+
+        // Refresh tray menu so the deleted model is removed from tray selection
+        if let Err(e) = crate::commands::settings::update_tray_menu(app.clone()).await {
+            log::warn!("Failed to update tray menu after model deletion: {}", e);
         }
+
+        Ok(())
     }
+    .await;
 
-    // Emit model-deleted event
-    use tauri::Emitter;
-    let _ = app.emit(
-        "model-deleted",
-        serde_json::json!({
-            "model": model_name.clone(),
-            "engine": engine.as_str()
-        }),
-    );
-
-    // Refresh tray menu so the deleted model is removed from tray selection
-    if let Err(e) = crate::commands::settings::update_tray_menu(app.clone()).await {
-        log::warn!("Failed to update tray menu after model deletion: {}", e);
-    }
-
-    Ok(())
+    clear_active_download(&active_downloads, &model_name);
+    result
 }
 
 #[tauri::command]
@@ -566,23 +629,16 @@ pub async fn cancel_download(
 ) -> Result<(), String> {
     log::info!("Cancelling download for model: {}", model_name);
 
-    // Set the cancellation flag
-    {
-        match active_downloads.lock() {
-            Ok(downloads) => {
-                if let Some(cancel_flag) = downloads.get(&model_name) {
-                    cancel_flag.store(true, Ordering::Relaxed);
-                    log::info!("Set cancellation flag for model: {}", model_name);
-                } else {
-                    log::warn!("No active download found for model: {}", model_name);
-                    return Ok(()); // Not an error if download doesn't exist
-                }
-            }
-            Err(e) => {
-                log::error!("Failed to lock active downloads for cancellation: {}", e);
-                return Err("Failed to access download tracking".to_string());
-            }
-        }
+    let downloads = active_downloads.lock().map_err(|e| {
+        log::error!("Failed to lock active downloads for cancellation: {}", e);
+        "Failed to access download tracking".to_string()
+    })?;
+
+    if let Some(cancel_flag) = downloads.get(&model_name) {
+        cancel_flag.store(true, Ordering::Relaxed);
+        log::info!("Set cancellation flag for model: {}", model_name);
+    } else {
+        log::warn!("No active download found for model: {}", model_name);
     }
 
     Ok(())

--- a/src-tauri/src/parakeet/manager.rs
+++ b/src-tauri/src/parakeet/manager.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use log::{info, warn};
 use reqwest::Client;
@@ -36,6 +37,12 @@ pub struct ParakeetManager {
 const PARAKEET_UNAVAILABLE_EVENT: &str = "parakeet-unavailable";
 
 impl ParakeetManager {
+    async fn wait_for_cancel(cancel_flag: Arc<AtomicBool>) {
+        while !cancel_flag.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
     pub fn new(root_dir: PathBuf) -> Self {
         Self {
             client: ParakeetClient::new("parakeet-sidecar"),
@@ -140,7 +147,7 @@ impl ParakeetManager {
         &self,
         app: &AppHandle,
         model_name: &str,
-        _cancel_flag: Option<Arc<AtomicBool>>,
+        cancel_flag: Option<Arc<AtomicBool>>,
         progress_callback: impl Fn(u64, u64) + Send + 'static,
     ) -> Result<(), String> {
         let Some(definition) = self.get_model_definition(model_name) else {
@@ -165,8 +172,29 @@ impl ParakeetManager {
             eager_unload: Some(false),
         };
 
-        // Send to sidecar and let it handle the download
-        match self.send_command(app, &command).await {
+        if let Some(flag) = cancel_flag.as_ref() {
+            if flag.load(Ordering::Relaxed) {
+                return Err("Download cancelled by user".to_string());
+            }
+        }
+
+        // Send to sidecar and let it handle the download. FluidAudio does not
+        // expose per-download cancellation, so cancellation terminates the
+        // sidecar request instead of letting a cancelled download later emit
+        // success.
+        let response = if let Some(flag) = cancel_flag {
+            tokio::select! {
+                response = self.send_command(app, &command) => response,
+                () = Self::wait_for_cancel(flag) => {
+                    self.shutdown().await;
+                    return Err("Download cancelled by user".to_string());
+                }
+            }
+        } else {
+            self.send_command(app, &command).await
+        };
+
+        match response {
             Ok(ParakeetResponse::Status {
                 loaded_model: Some(id),
                 ..

--- a/src-tauri/src/tests/model_commands.rs
+++ b/src-tauri/src/tests/model_commands.rs
@@ -111,10 +111,52 @@ mod tests {
         // Create the models directory
         std::fs::create_dir_all(&models_dir).unwrap();
 
-        let _manager = WhisperManager::new(models_dir.clone());
+        let manager = WhisperManager::new(models_dir.clone());
 
-        // The manager should be created with the correct directory
         assert!(models_dir.exists());
+        assert_eq!(manager.models_dir(), models_dir);
+    }
+
+    #[test]
+    fn test_get_model_info_for_download_prep() {
+        let temp_dir = TempDir::new().unwrap();
+        let models_dir = temp_dir.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+
+        let manager = WhisperManager::new(models_dir.clone());
+        let (model_info, output_path) = manager.get_model_info("base.en").unwrap();
+
+        assert_eq!(model_info.name, "base.en");
+        assert_eq!(output_path, models_dir.join("base.en.bin"));
+        assert_eq!(manager.models_dir(), models_dir);
+    }
+
+    #[test]
+    fn test_active_download_guard_rejects_duplicate_operations() {
+        use crate::commands::model::register_active_download;
+        use std::collections::HashMap;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        let active_downloads = Arc::new(StdMutex::new(HashMap::<String, Arc<AtomicBool>>::new()));
+        let first_flag = Arc::new(AtomicBool::new(false));
+        let second_flag = Arc::new(AtomicBool::new(false));
+
+        register_active_download(&active_downloads, "base.en", first_flag.clone()).unwrap();
+
+        let err = register_active_download(&active_downloads, "base.en", second_flag.clone())
+            .unwrap_err();
+        assert!(err.contains("already in progress"));
+
+        let downloads = active_downloads.lock().unwrap();
+        assert!(std::ptr::eq(
+            downloads.get("base.en").unwrap().as_ref(),
+            first_flag.as_ref()
+        ));
+        assert!(!std::ptr::eq(
+            downloads.get("base.en").unwrap().as_ref(),
+            second_flag.as_ref()
+        ));
     }
 
     #[test]

--- a/src-tauri/src/whisper/manager.rs
+++ b/src-tauri/src/whisper/manager.rs
@@ -258,27 +258,6 @@ impl WhisperManager {
         }
     }
 
-    /// Download a model (wrapper that validates and delegates to download_model_file)
-    pub async fn download_model(
-        &self,
-        model_name: &str,
-        cancel_flag: Option<Arc<AtomicBool>>,
-        progress_callback: impl Fn(u64, u64),
-    ) -> Result<(), String> {
-        // Get model info with validation
-        let (model_info, output_path) = self.get_model_info(model_name)?;
-
-        // Download the model file
-        Self::download_model_file(
-            &model_info,
-            &output_path,
-            &self.models_dir,
-            cancel_flag,
-            progress_callback,
-        )
-        .await
-    }
-
     /// Get model info needed for download (doesn't hold lock during download)
     pub fn get_model_info(&self, model_name: &str) -> Result<(ModelInfo, PathBuf), String> {
         // Use centralized validation
@@ -297,6 +276,11 @@ impl WhisperManager {
         let output_path = self.models_dir.join(format!("{}.bin", model_name));
 
         Ok((model.clone(), output_path))
+    }
+
+    /// Returns a clone of the models directory path (read-only accessor).
+    pub fn models_dir(&self) -> PathBuf {
+        self.models_dir.clone()
     }
 
     /// Download a model file (should be called without holding the manager lock)

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -92,6 +92,7 @@ vi.mock('./tabs/TabContainer', () => ({
   TabContainer: ({ activeSection }: any) => (
     <div data-testid="tab-container">
       Current Tab: {activeSection}
+      <input aria-label="Editable model setting" />
     </div>
   )
 }));
@@ -114,6 +115,7 @@ describe('AppContainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSettings.onboarding_completed = true;
+    window.sessionStorage.clear();
     mockUnlisteners.length = 0;
     mockRegisterEvent.mockImplementation(() => {
       const unlisten = vi.fn();
@@ -178,6 +180,31 @@ describe('AppContainer', () => {
     act(() => handler());
 
     expect(screen.getByTestId('tab-container')).not.toHaveTextContent('Current Tab: overview');
+  });
+
+  it('restores the active section after a WebView refresh', () => {
+    window.sessionStorage.setItem('voicetypr:activeSection', 'models');
+
+    render(<AppContainer />);
+
+    expect(screen.getByTestId('tab-container')).toHaveTextContent('Current Tab: models');
+  });
+
+  it('persists section changes, blocks shell refresh, and preserves edit menus', () => {
+    render(<AppContainer />);
+
+    const settingsCall = mockRegisterEvent.mock.calls.find(
+      (call: any[]) => call[0] === 'navigate-to-settings'
+    );
+    expect(settingsCall).toBeDefined();
+
+    act(() => settingsCall![1]());
+    expect(window.sessionStorage.getItem('voicetypr:activeSection')).toBe('general');
+
+    const appShell = screen.getByTestId('sidebar').parentElement?.parentElement;
+    expect(appShell).toBeTruthy();
+    expect(fireEvent.contextMenu(appShell!)).toBe(false);
+    expect(fireEvent.contextMenu(screen.getByLabelText('Editable model setting'))).toBe(true);
   });
 
   it('registerEvent is called once per event type on mount', () => {

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { UnlistenFn } from "@tauri-apps/api/event";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Sparkles } from "lucide-react";
 import { AppErrorBoundary } from "./ErrorBoundary";
@@ -22,7 +22,71 @@ import { useSettings } from "@/contexts/SettingsContext";
 import { useEventCoordinator } from "@/hooks/useEventCoordinator";
 import { useModelManagementContext } from "@/contexts/ModelManagementContext";
 import { updateService } from "@/services/updateService";
-// Type for error event payloads from backend
+const ACTIVE_SECTION_STORAGE_KEY = "voicetypr:activeSection";
+
+const VALID_SECTIONS = new Set([
+  "overview",
+  "recordings",
+  "audio",
+  "general",
+  "models",
+  "formatting",
+  "advanced",
+  "license",
+  "about",
+  "help",
+]);
+
+function readStoredActiveSection(): string {
+  try {
+    const stored = sessionStorage.getItem(ACTIVE_SECTION_STORAGE_KEY);
+    if (stored && VALID_SECTIONS.has(stored)) {
+      return stored;
+    }
+  } catch {
+    // sessionStorage may be unavailable
+  }
+  return "overview";
+}
+
+function isEditableContextTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  const editable = target.closest(
+    'input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+  );
+  if (!editable) {
+    return false;
+  }
+
+  if (editable instanceof HTMLInputElement) {
+    switch (editable.type) {
+      case "button":
+      case "checkbox":
+      case "color":
+      case "file":
+      case "hidden":
+      case "image":
+      case "radio":
+      case "range":
+      case "reset":
+      case "submit":
+        return false;
+      default:
+        return true;
+    }
+  }
+
+  return true;
+}
+
+
 interface ErrorEventPayload {
   title?: string;
   message: string;
@@ -36,7 +100,15 @@ interface ErrorEventPayload {
 
 export function AppContainer() {
   const { registerEvent } = useEventCoordinator("main");
-  const [activeSection, setActiveSection] = useState<string>("overview");
+  const [activeSection, setActiveSectionState] = useState(readStoredActiveSection);
+  const setActiveSection = useCallback((section: string) => {
+    setActiveSectionState(section);
+    try {
+      sessionStorage.setItem(ACTIVE_SECTION_STORAGE_KEY, section);
+    } catch {
+      // sessionStorage may be unavailable
+    }
+  }, []);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [justUpdatedVersion, setJustUpdatedVersion] = useState<string | null>(null);
   const { settings, refreshSettings } = useSettings();
@@ -138,7 +210,7 @@ export function AppContainer() {
         unlisten();
       }
     };
-  }, [registerEvent]);
+  }, [registerEvent, setActiveSection]);
 
   // Settings-dependent initialization (onboarding check, cleanup, update service)
   useEffect(() => {
@@ -228,37 +300,46 @@ export function AppContainer() {
 
   // Main App Layout
   return (
-    <SidebarProvider>
-      <Sidebar
-        activeSection={activeSection}
-        onSectionChange={setActiveSection}
-      />
-      <SidebarInset>
-        <TabContainer activeSection={activeSection} />
-      </SidebarInset>
+    <div
+      className="h-full w-full"
+      onContextMenu={(event) => {
+        if (!isEditableContextTarget(event.target)) {
+          event.preventDefault();
+        }
+      }}
+    >
+      <SidebarProvider>
+        <Sidebar
+          activeSection={activeSection}
+          onSectionChange={setActiveSection}
+        />
+        <SidebarInset>
+          <TabContainer activeSection={activeSection} />
+        </SidebarInset>
 
-      {/* Post-update notification dialog */}
-      <Dialog
-        open={!!justUpdatedVersion}
-        onOpenChange={(open) => { if (!open) setJustUpdatedVersion(null); }}
-      >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-primary" />
-              VoiceTypr Updated
-            </DialogTitle>
-            <DialogDescription>
-              Successfully updated to version {justUpdatedVersion}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button onClick={() => setJustUpdatedVersion(null)}>
-              Dismiss
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </SidebarProvider>
+        {/* Post-update notification dialog */}
+        <Dialog
+          open={!!justUpdatedVersion}
+          onOpenChange={(open) => { if (!open) setJustUpdatedVersion(null); }}
+        >
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-primary" />
+                VoiceTypr Updated
+              </DialogTitle>
+              <DialogDescription>
+                Successfully updated to version {justUpdatedVersion}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button onClick={() => setJustUpdatedVersion(null)}>
+                Dismiss
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </SidebarProvider>
+    </div>
   );
 }

--- a/src/components/sections/ModelsSection.test.tsx
+++ b/src/components/sections/ModelsSection.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ModelsSection } from './ModelsSection';
+import type { LocalModelInfo } from '@/types';
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      current_model: '',
+      current_model_engine: 'whisper',
+      language: 'en',
+    },
+    updateSettings: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/components/LanguageSelection', () => ({
+  LanguageSelection: () => <div data-testid="language-selection" />,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+const noop = vi.fn();
+
+function whisperModel(overrides: Partial<LocalModelInfo> = {}): LocalModelInfo {
+  return {
+    name: 'base.en',
+    display_name: 'Base (English)',
+    engine: 'whisper',
+    kind: 'local',
+    downloaded: false,
+    requires_setup: false,
+    size: 147_964_211,
+    url: 'https://example.com/base.en.bin',
+    sha256: '137c40403d78fd54d454da0f9bd998f78703390c',
+    speed_score: 8,
+    accuracy_score: 5,
+    recommended: false,
+    ...overrides,
+  };
+}
+
+function renderModelsSection(props: Partial<Parameters<typeof ModelsSection>[0]> = {}) {
+  return render(
+    <ModelsSection
+      models={[]}
+      downloadProgress={{}}
+      verifyingModels={new Set()}
+      onDownload={noop}
+      onDelete={noop}
+      onCancelDownload={noop}
+      onSelect={noop}
+      refreshModels={async () => undefined}
+      {...props}
+    />
+  );
+}
+
+describe('ModelsSection', () => {
+  it('does not show a global downloading status in the header', () => {
+    renderModelsSection({
+      models: [['base.en', whisperModel()]],
+      downloadProgress: { 'base.en': 12 },
+    });
+
+    expect(screen.queryByText('Downloading...')).not.toBeInTheDocument();
+    expect(screen.getByText('12%')).toBeInTheDocument();
+  });
+
+  it('shows an initial loading state instead of an empty model-list message', () => {
+    renderModelsSection({ isLoading: true });
+
+    expect(screen.getByText('Loading models...')).toBeInTheDocument();
+    expect(screen.queryByText('No models available')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sections/ModelsSection.tsx
+++ b/src/components/sections/ModelsSection.tsx
@@ -8,7 +8,7 @@ import { useSettings } from "@/contexts/SettingsContext";
 import { getCloudProviderByModel } from "@/lib/cloudProviders";
 import { cn } from "@/lib/utils";
 import { ModelInfo, isCloudModel, isLocalModel } from "@/types";
-import { Bot, CheckCircle, Download, HardDrive, Star, Zap } from "lucide-react";
+import { Bot, CheckCircle, HardDrive, Loader2, Star, Zap } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Label } from "../ui/label";
@@ -24,6 +24,7 @@ interface ModelsSectionProps {
   onCancelDownload: (modelName: string) => Promise<void> | void;
   onSelect: (modelName: string) => Promise<void> | void;
   refreshModels: () => Promise<void>;
+  isLoading?: boolean;
 }
 
 type CloudModalMode = "connect" | "update";
@@ -43,6 +44,7 @@ export function ModelsSection({
   onCancelDownload,
   onSelect,
   refreshModels,
+  isLoading = false,
 }: ModelsSectionProps) {
   const { settings, updateSettings } = useSettings();
   const [cloudModal, setCloudModal] = useState<CloudModalState | null>(null);
@@ -120,12 +122,6 @@ export function ModelsSection({
       });
     }
   }, [isEnglishOnlyModel, settings, updateSettings]);
-
-  const hasDownloading = useMemo(
-    () => Object.keys(downloadProgress).length > 0,
-    [downloadProgress],
-  );
-  const hasVerifying = verifyingModels.size > 0;
 
   const openCloudModal = useCallback(
     (providerId: string, mode: CloudModalMode) => {
@@ -284,12 +280,6 @@ export function ModelsSection({
             </p>
           </div>
           <div className="flex items-center gap-3">
-            {(hasDownloading || hasVerifying) && (
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-blue-500/10 text-sm font-medium">
-                <Download className="h-3.5 w-3.5 text-blue-500" />
-                {hasDownloading ? "Downloading..." : "Verifying..."}
-              </div>
-            )}
             {activeModelLabel ? (
               <span className="text-sm text-muted-foreground">
                 Active:{" "}
@@ -414,17 +404,24 @@ export function ModelsSection({
             )}
 
             {availableToUse.length === 0 && availableToSetup.length === 0 && (
-              <div className="flex-1 flex items-center justify-center py-12">
-                <div className="text-center">
-                  <Bot className="w-12 h-12 text-muted-foreground/30 mx-auto mb-4" />
-                  <p className="text-sm text-muted-foreground">
-                    No models available
-                  </p>
-                  <p className="text-xs text-muted-foreground/70 mt-2">
-                    Models will appear here when they become available.
-                  </p>
+              isLoading && models.length === 0 ? (
+                <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Loading models...
                 </div>
-              </div>
+              ) : !isLoading ? (
+                <div className="flex-1 flex items-center justify-center py-12">
+                  <div className="text-center">
+                    <Bot className="w-12 h-12 text-muted-foreground/30 mx-auto mb-4" />
+                    <p className="text-sm text-muted-foreground">
+                      No models available
+                    </p>
+                    <p className="text-xs text-muted-foreground/70 mt-2">
+                      Models will appear here when they become available.
+                    </p>
+                  </div>
+                </div>
+              ) : null
             )}
           </div>
         </ScrollArea>

--- a/src/components/tabs/ModelsTab.test.tsx
+++ b/src/components/tabs/ModelsTab.test.tsx
@@ -1,16 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ModelsTab } from './ModelsTab';
 
-// Mock sonner
-vi.mock('sonner', () => ({
-  toast: {
-    info: vi.fn(),
-    warning: vi.fn(),
-    error: vi.fn(),
-    success: vi.fn()
-  }
-}));
+
+const mockUpdateSettings = vi.fn();
+const mockDeleteModel = vi.fn();
+
 
 // Mock contexts
 vi.mock('@/contexts/SettingsContext', () => ({
@@ -18,7 +13,8 @@ vi.mock('@/contexts/SettingsContext', () => ({
     settings: {
       current_model: 'base.en',
       current_model_engine: 'whisper'
-    }
+    },
+    updateSettings: mockUpdateSettings
   })
 }));
 
@@ -62,7 +58,7 @@ vi.mock('@/contexts/ModelManagementContext', () => ({
     verifyingModels: new Set(),
     sortedModels: Object.entries(mockModels),
     downloadModel: vi.fn(),
-    deleteModel: vi.fn(),
+    deleteModel: mockDeleteModel,
     cancelDownload: vi.fn(),
     retryDownload: vi.fn(),
     refreshModels: vi.fn(),
@@ -72,22 +68,14 @@ vi.mock('@/contexts/ModelManagementContext', () => ({
   })
 }));
 
-vi.mock('@/hooks/useEventCoordinator', () => ({
-  useEventCoordinator: () => ({
-    registerEvent: vi.fn((event: string, callback: any) => {
-      (window as any).__testEventCallbacks = (window as any).__testEventCallbacks || {};
-      (window as any).__testEventCallbacks[event] = callback;
-      return vi.fn();
-    })
-  })
-}));
 
 // Mock ModelsSection component
 vi.mock('@/components/sections/ModelsSection', () => ({
-  ModelsSection: ({ models, currentModel }: any) => (
+  ModelsSection: ({ models, currentModel, onDelete }: any) => (
     <div data-testid="models-section">
       <div>Current Model: {currentModel}</div>
       <div>Models Count: {models.length}</div>
+      <button onClick={() => onDelete(currentModel)}>Delete Current</button>
     </div>
   )
 }));
@@ -95,7 +83,8 @@ vi.mock('@/components/sections/ModelsSection', () => ({
 describe('ModelsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (window as any).__testEventCallbacks = {};
+    mockDeleteModel.mockResolvedValue(true);
+    mockUpdateSettings.mockResolvedValue(undefined);
   });
 
   it('displays current model and available models', () => {
@@ -104,18 +93,28 @@ describe('ModelsTab', () => {
     expect(screen.getByText('Models Count: 2')).toBeInTheDocument();
   });
 
-  it('shows error toast on download failure', async () => {
-    const { toast } = await import('sonner');
+  it('keeps current model when delete confirmation is cancelled', async () => {
+    mockDeleteModel.mockResolvedValue(false);
+
     render(<ModelsTab />);
+    fireEvent.click(screen.getByRole('button', { name: /delete current/i }));
 
-    const callback = (window as any).__testEventCallbacks['download-error'];
-    callback({ model: 'small.en', error: 'Network error' });
-
-    expect(toast.error).toHaveBeenCalledWith(
-      'Download Failed',
-      expect.objectContaining({
-        description: expect.stringContaining('small.en')
-      })
-    );
+    await waitFor(() => {
+      expect(mockDeleteModel).toHaveBeenCalledWith('base.en');
+    });
+    expect(mockUpdateSettings).not.toHaveBeenCalled();
   });
+
+  it('clears current model only after successful deletion', async () => {
+    render(<ModelsTab />);
+    fireEvent.click(screen.getByRole('button', { name: /delete current/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        current_model: '',
+        current_model_engine: 'whisper'
+      });
+    });
+  });
+
 });

--- a/src/components/tabs/ModelsTab.tsx
+++ b/src/components/tabs/ModelsTab.tsx
@@ -1,13 +1,11 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { toast } from "sonner";
 import { ModelsSection } from "../sections/ModelsSection";
 import { useSettings } from "@/contexts/SettingsContext";
-import { useEventCoordinator } from "@/hooks/useEventCoordinator";
 import { useModelManagementContext } from "@/contexts/ModelManagementContext";
 import { AppSettings } from "@/types";
 
 export function ModelsTab() {
-  const { registerEvent } = useEventCoordinator("main");
   const { settings, updateSettings } = useSettings();
 
   // Use the model management context
@@ -18,7 +16,8 @@ export function ModelsTab() {
     cancelDownload,
     deleteModel,
     loadModels,
-    sortedModels
+    sortedModels,
+    isLoading,
   } = useModelManagementContext();
 
   // Save settings
@@ -36,44 +35,23 @@ export function ModelsTab() {
   // Handle deleting a model with settings update
   const handleDeleteModel = useCallback(
     async (modelName: string) => {
-      await deleteModel(modelName);
+      try {
+        const deleted = await deleteModel(modelName);
+        if (!deleted) {
+          return;
+        }
 
-      // If deleted model was the current one, clear selection in settings
-      if (settings?.current_model === modelName) {
-        await saveSettings({ current_model: "", current_model_engine: 'whisper' });
+        // If deleted model was the current one, clear selection in settings
+        if (settings?.current_model === modelName) {
+          await saveSettings({ current_model: "", current_model_engine: 'whisper' });
+        }
+      } catch {
+        // deleteModel shows a toast and rethrows; keep current selection on failure
       }
     },
     [deleteModel, settings, saveSettings]
   );
 
-  // Initialize models tab
-  useEffect(() => {
-    const init = async () => {
-      try {
-        // Listen for download error events (when download fails)
-        registerEvent<{ model: string; engine?: string; error: string }>(
-          "download-error",
-          (errorData) => {
-            const { model, error } = errorData;
-            console.error("Download error:", errorData);
-
-            // Don't show error toast if it was cancelled - cancellation has its own toast
-            if (!error.toLowerCase().includes('cancel')) {
-              // Show user-friendly error message
-              toast.error(`Download Failed`, {
-                description: `Failed to download ${model}. Please try again.`,
-                duration: 5000
-              });
-            }
-          }
-        );
-      } catch (error) {
-        console.error("Failed to initialize models tab:", error);
-      }
-    };
-
-    init();
-  }, [registerEvent]);
 
   return (
     <ModelsSection
@@ -101,6 +79,7 @@ export function ModelsTab() {
       refreshModels={async () => {
         await loadModels();
       }}
+      isLoading={isLoading}
     />
   );
 }

--- a/src/hooks/useModelManagement.test.ts
+++ b/src/hooks/useModelManagement.test.ts
@@ -1,6 +1,39 @@
-import { describe, it, expect } from 'vitest';
-import { sortModels } from './useModelManagement';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { sortModels, useModelManagement } from './useModelManagement';
 import { LocalModelInfo } from '@/types';
+
+const mockTauri = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  ask: vi.fn(),
+  handlers: {} as Record<string, (payload: unknown) => void>,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mockTauri.invoke,
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  ask: mockTauri.ask,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('./useEventCoordinator', () => ({
+  useEventCoordinator: () => ({
+    registerEvent: vi.fn((event: string, callback: (payload: unknown) => void) => {
+      mockTauri.handlers[event] = callback;
+      return Promise.resolve(vi.fn());
+    }),
+  }),
+}));
+
 
 function whisperModel(
   name: string,
@@ -24,6 +57,23 @@ function whisperModel(
   };
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(mockTauri.handlers)) {
+    delete mockTauri.handlers[key];
+  }
+  mockTauri.ask.mockResolvedValue(true);
+  mockTauri.invoke.mockImplementation((command: string) => {
+    if (command === 'get_model_status') {
+      return Promise.resolve({
+        models: [whisperModel('base.en', 5, 8, 147_964_211)],
+      });
+    }
+    return Promise.resolve();
+  });
+});
+
+
 describe('sortModels', () => {
   it('orders whisper models by accuracy with medium after small', () => {
     const entries: [string, LocalModelInfo][] = [
@@ -41,5 +91,36 @@ describe('sortModels', () => {
       'medium',
       'large-v3-q5_0',
     ]);
+  });
+});
+
+describe('useModelManagement terminal download events', () => {
+  it('clears verifying state when post-download verification fails', async () => {
+    const { result } = renderHook(() => useModelManagement({ showToasts: false }));
+
+    await waitFor(() => {
+      expect(mockTauri.handlers['model-verifying']).toEqual(expect.any(Function));
+      expect(mockTauri.handlers['download-error']).toEqual(expect.any(Function));
+    });
+
+    act(() => {
+      mockTauri.handlers['model-verifying']({ model: 'base.en' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.verifyingModels.has('base.en')).toBe(true);
+    });
+
+    act(() => {
+      mockTauri.handlers['download-error']({
+        model: 'base.en',
+        error: 'verification_failed',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.verifyingModels.has('base.en')).toBe(false);
+    });
+    expect(result.current.downloadProgress['base.en']).toBeUndefined();
   });
 });

--- a/src/hooks/useModelManagement.ts
+++ b/src/hooks/useModelManagement.ts
@@ -66,7 +66,23 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
   const [verifyingModels, setVerifyingModels] = useState<Set<string>>(new Set());
 
   // Removed selectedModel state - now using settings.current_model directly
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const clearDownloadState = useCallback((modelName: string) => {
+    activeDownloads.current.delete(modelName);
+
+    setDownloadProgress((prev) => {
+      const newProgress = { ...prev };
+      delete newProgress[modelName];
+      return newProgress;
+    });
+
+    setVerifyingModels((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(modelName);
+      return newSet;
+    });
+  }, []);
 
   // Load models from backend
   const loadModels = useCallback(async () => {
@@ -128,42 +144,25 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       // Don't await - let it run async so progress events can update UI
       invoke("download_model", { modelName }).catch((error) => {
         console.error("[useModelManagement.downloadModel] Failed to download model:", error);
-        if (showToasts) {
-          toast.error(`Failed to download model: ${error}`);
+        const message = String(error);
+        if (showToasts && !message.toLowerCase().includes("cancel")) {
+          toast.error(`Failed to download model: ${message}`);
         }
-        // Remove from progress on error
-        setDownloadProgress((prev) => {
-          const newProgress = { ...prev };
-          delete newProgress[modelName];
-          return newProgress;
-        });
-        // Remove from active downloads
-        activeDownloads.current.delete(modelName);
+        clearDownloadState(modelName);
       });
     } catch (error) {
       console.error("[useModelManagement.downloadModel] Failed to start download:", error);
       if (showToasts) {
         toast.error(`Failed to start download: ${error}`);
       }
-      // Remove from active downloads
-      activeDownloads.current.delete(modelName);
+      clearDownloadState(modelName);
     }
-  }, [models, showToasts]);
+  }, [clearDownloadState, models, showToasts]);
 
   // Cancel download
   const cancelDownload = useCallback(async (modelName: string) => {
     try {
       await invoke("cancel_download", { modelName });
-
-      // Immediately remove from active downloads to allow retry
-      activeDownloads.current.delete(modelName);
-
-      // Remove from progress tracking
-      setDownloadProgress((prev) => {
-        const newProgress = { ...prev };
-        delete newProgress[modelName];
-        return newProgress;
-      });
     } catch (error) {
       console.error("Failed to cancel download:", error);
       if (showToasts) {
@@ -179,7 +178,7 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       if (showToasts) {
         toast.info(`${target.display_name} is a cloud model and cannot be deleted locally.`);
       }
-      return;
+      return false;
     }
 
     try {
@@ -189,7 +188,7 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       });
 
       if (!confirmed) {
-        return;
+        return false;
       }
 
       await invoke("delete_model", { modelName });
@@ -197,12 +196,13 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       // Refresh model status
       await loadModels();
 
-      // Model selection clearing is handled by the component via settings
+      return true;
     } catch (error) {
       console.error("Failed to delete model:", error);
       if (showToasts) {
         toast.error(`Failed to delete model: ${error}`);
       }
+      throw error;
     }
   }, [loadModels, models, showToasts]);
 
@@ -212,25 +212,9 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
     let unregisterVerifying: (() => void) | undefined;
     let unregisterComplete: (() => void) | undefined;
     let unregisterCancelled: (() => void) | undefined;
+    let unregisterError: (() => void) | undefined;
 
     const setupListeners = async () => {
-      // DEBUG: Add direct listener to verify events are reaching frontend
-      if (typeof window !== 'undefined') {
-        const { listen } = await import('@tauri-apps/api/event');
-
-        // Direct debug listener bypassing EventCoordinator
-        const debugUnlisten = await listen('download-progress', (event) => {
-          console.log('[DEBUG] Direct download-progress event received:', event);
-        });
-
-        // Clean up debug listener on unmount
-        const originalCleanup = () => {
-          debugUnlisten();
-        };
-
-        // Store for cleanup
-        (window as any).__debugUnlisten = originalCleanup;
-      }
       // Progress updates
       unregisterProgress = await registerEvent<{ model: string; engine?: string; downloaded: number; total: number; progress: number }>(
         "download-progress",
@@ -274,22 +258,7 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       unregisterComplete = await registerEvent<{ model: string; engine?: string }>("model-downloaded", async (event) => {
         const modelName = event.model;
 
-        // Remove from active downloads
-        activeDownloads.current.delete(modelName);
-
-        // Remove from progress tracking and verifying
-        setDownloadProgress((prev) => {
-          const newProgress = { ...prev };
-          delete newProgress[modelName];
-          return newProgress;
-        });
-        
-        // Remove from verifying set
-        setVerifyingModels((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(modelName);
-          return newSet;
-        });
+        clearDownloadState(modelName);
 
         // Refresh model list
         await loadModels();
@@ -302,19 +271,17 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
       // Download cancelled
       unregisterCancelled = await registerEvent<{ model: string; engine?: string }>("download-cancelled", (payload) => {
         const modelName = typeof payload === 'string' ? payload : payload.model;
-        // Remove from active downloads
-        activeDownloads.current.delete(modelName);
-
-        // Remove from progress tracking
-        setDownloadProgress((prev) => {
-          const newProgress = { ...prev };
-          delete newProgress[modelName];
-          return newProgress;
-        });
+        clearDownloadState(modelName);
 
         if (showToasts) {
           toast.info(`Download cancelled for ${modelName}`);
         }
+      });
+
+      // Download error
+      unregisterError = await registerEvent<{ model: string; engine?: string; error?: string }>("download-error", (payload) => {
+        const modelName = payload.model;
+        clearDownloadState(modelName);
       });
     };
 
@@ -322,17 +289,13 @@ export function useModelManagement(options: UseModelManagementOptions = {}) {
 
     // Cleanup
     return () => {
-      // Clean up debug listener
-      if ((window as any).__debugUnlisten) {
-        (window as any).__debugUnlisten();
-        delete (window as any).__debugUnlisten;
-      }
       unregisterProgress?.();
       unregisterVerifying?.();
       unregisterComplete?.();
       unregisterCancelled?.();
+      unregisterError?.();
     };
-  }, [registerEvent, loadModels, showToasts]);
+  }, [registerEvent, loadModels, showToasts, clearDownloadState]);
 
   // Load models on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep Whisper model downloads outside the manager lock so status/delete stay responsive
- serialize model download/delete/cancel per model and verify downloaded status before emitting success
- keep Models UI stable during loading/refresh and preserve the selected section across WebView refresh
- remove the global Models downloading banner while preserving per-model progress
- add macOS-safe Parakeet cancellation via sidecar shutdown

## Verification
- `pnpm quality-gate`

## Notes
- No release in this PR; release workflow should run only after merge and explicit approval.