### PR TITLE
fix(tray): never crash on startup when the system tray fails (Windows E_FAIL)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,13 @@ fn show_main_window(app: &tauri::AppHandle) {
 
 /// Hide the main window and the macOS Dock icon — back to the menubar/tray.
 fn hide_main_window(app: &tauri::AppHandle) {
+    // If the system tray failed to create (e.g. the Windows shell notification
+    // area wasn't ready at startup), hiding the window would leave the app
+    // running with no way to bring it back. Keep the window visible instead.
+    if app.tray_by_id("main").is_none() {
+        log::warn!("No tray icon present; keeping main window visible instead of hiding to tray");
+        return;
+    }
     if let Some(window) = app.get_webview_window("main") {
         if let Err(e) = window.hide() {
             log::error!("Failed to hide main window: {}", e);
@@ -1629,9 +1636,16 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 // Only hide the window instead of closing it (except for pill)
                 if window.label() == "main" {
-                    api.prevent_close();
-                    hide_main_window(window.app_handle());
-                    log::info!("Main window hidden instead of closed");
+                    // Close-to-tray ONLY when a tray icon exists. If tray creation
+                    // failed at startup, prevent_close + hide would strand the app as a
+                    // background process with no way back -> let the close proceed (quit).
+                    if window.app_handle().tray_by_id("main").is_some() {
+                        api.prevent_close();
+                        hide_main_window(window.app_handle());
+                        log::info!("Main window hidden instead of closed");
+                    } else {
+                        log::warn!("No tray icon; allowing main window to close (quit) instead of hiding");
+                    }
                 }
             }
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,7 +813,9 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             // Build the tray menu using our helper function
             // Note: We need to block here since setup is sync
-            let menu = tauri::async_runtime::block_on(build_tray_menu(app.app_handle()))?;
+            let tray_app = app.app_handle().clone();
+            let try_build_tray = move || -> Result<(), Box<dyn std::error::Error>> {
+            let menu = tauri::async_runtime::block_on(build_tray_menu(&tray_app))?;
 
 
             // Bare-mark template icon for the menubar (no background; adapts to light/dark).
@@ -995,7 +997,43 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                         show_main_window(app);
                     }
                 })
-                .build(app)?;
+                .build(&tray_app)?;
+            Ok(())
+            };
+
+            // Tray creation can fail transiently on Windows (e.g. the shell's
+            // notification area isn't ready yet -> os error 0x80004005 / E_FAIL).
+            // This previously aborted the entire setup hook and stopped the app
+            // from launching at all. Retry a few times, then continue WITHOUT a
+            // tray instead of crashing -- a missing tray must never be fatal.
+            let mut tray_attempt: u32 = 0;
+            loop {
+                tray_attempt += 1;
+                match try_build_tray() {
+                    Ok(()) => {
+                        if tray_attempt > 1 {
+                            log::info!("Tray icon created on attempt {}", tray_attempt);
+                        }
+                        break;
+                    }
+                    Err(e) if tray_attempt < 5 => {
+                        log::warn!(
+                            "Tray icon creation failed (attempt {}/5): {} -- retrying in 400ms",
+                            tray_attempt,
+                            e
+                        );
+                        std::thread::sleep(std::time::Duration::from_millis(400));
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Tray icon creation failed after {} attempts; continuing without system tray: {}",
+                            tray_attempt,
+                            e
+                        );
+                        break;
+                    }
+                }
+            }
 
             // Load hotkey from settings store with graceful degradation
             log_start("HOTKEY_SETUP");


### PR DESCRIPTION
## Problem
2.0.1 Bugsink reported a **fatal startup panic** on Windows:

> Failed to setup app: error encountered during setup hook: tray icon error: Unbekannter Fehler (os error -2147467259)

`-2147467259` = `0x80004005` (E_FAIL). The Tauri setup hook built the system tray with `?`, so a **transient** tray failure (the Windows shell notification area not being ready yet at autostart) aborted the entire setup hook and **the app never launched**. Seen on a German-locale Windows laptop.

## Fix
- **Retry** menu + tray-icon creation 5×/400ms, then **continue WITHOUT a tray** instead of aborting startup — a missing tray must never be fatal (`0e5e5f7`).
- **Don't strand the app when there's no tray** (`a054500`): `hide_main_window` keeps the window visible if the tray is absent (covers the startup-hide-to-menubar path, which would otherwise launch an existing user *invisible*), and the main-window close handler lets the close **quit** instead of hiding — preventing a background zombie process holding the audio device with no way back.

## Verification
- ✅ `cargo check` on macOS (existing code intact; logic covers every hide-to-tray path)
- ⏳ Windows compile via CI
- ⏳ **Runtime smoke pending** on the Windows machine that hit the crash: app should launch *and* stay reachable even if the tray fails

Commits: `0e5e5f7`, `a054500`.