### PR TITLE
fix(telemetry): ship Windows debug symbols so crash reports symbolicate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,7 +450,9 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          RUSTFLAGS: -C target-feature=+crt-static
+          # /PDBALTPATH:%_PDB% records a RELATIVE pdb name in the PE so dbghelp
+          # resolves voicetypr.pdb next to the installed exe (not the CI build path).
+          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/PDBALTPATH:%_PDB%"
           VOICETYPR_REQUIRE_VULKAN_SIDECAR: "1"
         run: pnpm tauri build --target x86_64-pc-windows-msvc --ci --config src-tauri/tauri.windows.conf.json
 

--- a/scripts/stage-windows-pdb.cjs
+++ b/scripts/stage-windows-pdb.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Stage the Windows release PDB as a bundled resource.
+//
+// MSVC keeps debug symbols in a separate voicetypr.pdb (never embedded in the
+// .exe), so without it shipped, release crash stacks in Bugsink are all
+// `<unknown>`. The Sentry SDK resolves frames in-process at capture via dbghelp,
+// which finds symbols in the module's own directory — so the .pdb must end up
+// next to voicetypr.exe on the user's machine.
+//
+// Tauri does not auto-bundle the .pdb. This script (wired as the Windows-only
+// `build.beforeBundleCommand` in src-tauri/tauri.windows.conf.json) runs AFTER
+// cargo build and BEFORE the bundler collects resources, copying the freshly
+// built .pdb into src-tauri/windows/resources/ so it is bundled; the NSIS
+// installer hook then copies it beside the exe (see windows/installer-hooks.nsh).
+//
+// cwd is the project root (Tauri runs before-commands from there). Requires
+// `[profile.release] debug = "line-tables-only"` so MSVC emits the .pdb.
+
+const { copyFileSync, existsSync, mkdirSync } = require("node:fs");
+const { dirname, join, resolve } = require("node:path");
+
+const triple = process.env.TAURI_ENV_TARGET_TRIPLE || "x86_64-pc-windows-msvc";
+const targetDir = process.env.CARGO_TARGET_DIR || resolve("src-tauri", "target");
+
+// `--target <triple>` nests output under <triple>/release; a plain build uses release/.
+const candidates = [
+  join(targetDir, triple, "release", "voicetypr.pdb"),
+  join(targetDir, "release", "voicetypr.pdb"),
+];
+
+const src = candidates.find((p) => existsSync(p));
+if (!src) {
+  console.error(
+    "[stage-windows-pdb] voicetypr.pdb not found. Looked in:\n  " +
+      candidates.join("\n  ")
+  );
+  console.error(
+    '[stage-windows-pdb] Ensure [profile.release] debug = "line-tables-only" is set so MSVC emits a PDB.'
+  );
+  process.exit(1);
+}
+
+const dest = resolve("src-tauri", "windows", "resources", "voicetypr.pdb");
+mkdirSync(dirname(dest), { recursive: true });
+copyFileSync(src, dest);
+console.log(`[stage-windows-pdb] Copied ${src} -> ${dest}`);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -124,3 +124,11 @@ tauri-plugin-store = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-os = "2"
 tauri-plugin-single-instance = "2"
+[profile.release]
+# Client-side crash symbolication for Bugsink (which does NOT symbolicate native
+# server-side): line tables give function + file:line resolved in-process at
+# capture (sentry `backtrace`); strip = "none" keeps the symbol table so macOS
+# resolves names. Windows additionally emits voicetypr.pdb, shipped beside the
+# exe (see windows/installer-hooks.nsh) so dbghelp can resolve at runtime.
+debug = "line-tables-only"
+strip = "none"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -122,5 +122,23 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=../pnpm-workspace.yaml");
 
+    // Tauri validates `bundle.resources` paths at COMPILE time (generate_context!
+    // / tauri-build, which auto-merges tauri.windows.conf.json for the Windows
+    // target). We ship voicetypr.pdb (debug symbols) as a resource, but it is a
+    // BUILD OUTPUT of this very compile: scripts/stage-windows-pdb.cjs
+    // (beforeBundleCommand) copies the real PDB into place only at bundle time --
+    // too late for this validation, and absent entirely in a plain `cargo build`
+    // (the CI compile check). Create a placeholder now so validation passes; the
+    // real PDB overwrites it before bundling.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        let pdb_resource = Path::new("windows/resources/voicetypr.pdb");
+        if !pdb_resource.exists() {
+            if let Some(dir) = pdb_resource.parent() {
+                std::fs::create_dir_all(dir).ok();
+            }
+            std::fs::File::create(pdb_resource).ok();
+        }
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeBundleCommand": "node scripts/stage-windows-pdb.cjs"
+  },
   "bundle": {
     "resources": [
       "windows/resources/vc_redist.x64.exe",
-      "windows/resources/VulkanRT-Installer.exe"
+      "windows/resources/VulkanRT-Installer.exe",
+      "windows/resources/voicetypr.pdb"
     ],
     "externalBin": [
       "../sidecar/ffmpeg/dist/ffmpeg",

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -62,13 +62,29 @@
     ${EndIf}
 !macroend
 
+!macro InstallPdbSymbols
+    ; Place debug symbols (voicetypr.pdb) beside voicetypr.exe so the Sentry
+    ; backtrace integration (dbghelp) resolves function names + line numbers at
+    ; crash time. The bundler installs it under resources/; copy it next to the
+    ; exe where dbghelp's default per-module search looks. Best-effort: symbols
+    ; are a diagnostics aid and never required for the app to run.
+    ${If} ${FileExists} "$INSTDIR\resources\windows\resources\voicetypr.pdb"
+        DetailPrint "Installing debug symbols (voicetypr.pdb)..."
+        CopyFiles /SILENT "$INSTDIR\resources\windows\resources\voicetypr.pdb" "$INSTDIR\voicetypr.pdb"
+    ${Else}
+        DetailPrint "voicetypr.pdb not bundled, skipping debug symbol install"
+    ${EndIf}
+!macroend
+
 !macro NSIS_HOOK_PREINSTALL
 !macroend
 
 !macro NSIS_HOOK_POSTINSTALL
     !insertmacro InstallVcRedist
     !insertmacro InstallVulkanRuntime
+    !insertmacro InstallPdbSymbols
 !macroend
 
 !macro NSIS_HOOK_PREUNINSTALL
+    Delete "$INSTDIR\voicetypr.pdb"
 !macroend

--- a/src-tauri/windows/resources/.gitignore
+++ b/src-tauri/windows/resources/.gitignore
@@ -1,0 +1,5 @@
+# Runtime installers + debug symbols are fetched/generated at build time (CI),
+# never committed. Keep the directory tracked via .gitkeep only.
+*
+!.gitkeep
+!.gitignore


### PR DESCRIPTION
## Problem
Release crash reports in Bugsink show **all `<unknown>` frames on Windows**. Two causes:
1. The release profile carried no debug info (cargo default `debug = false`) → no line tables on any platform.
2. MSVC keeps symbols in a separate `voicetypr.pdb` we never shipped → dbghelp has nothing to resolve.

Bugsink does **not** symbolicate native crashes server-side (only JS source maps; dSYM/PDB support is [open upstream](https://github.com/bugsink/bugsink/issues/20)). So the only path is **client-side**: the Sentry Rust SDK (`backtrace` feature) resolves frames in-process *at capture* via dbghelp — which needs the `.pdb` on the user's machine, beside `voicetypr.exe`.

macOS is already better off (the symbol table stays in the binary → function names resolve; only line numbers are missing), so this is essentially a Windows fix.

## Changes
- **`[profile.release] debug = "line-tables-only"` + `strip = "none"`** — emit line tables (function + file:line) and keep the symbol table. Windows now produces `voicetypr.pdb`.
- **Ship the PDB beside the exe** — a Windows-only `beforeBundleCommand` (`scripts/stage-windows-pdb.cjs`) stages the freshly-built PDB into bundle resources after cargo build; the **NSIS installer hook** copies it from `resources/` to `$INSTDIR` next to the exe (where dbghelp's per-module search looks). Removed on uninstall.
- **`RUSTFLAGS … /PDBALTPATH:%_PDB%`** — records a *relative* pdb name in the PE so dbghelp resolves it next to the installed exe, not the CI build path.
- Generated `windows/resources/` artifacts are now gitignored (also clears the existing vc_redist/VulkanRT untracked noise).

`scrub_frame` already keeps `function`/`lineno`/`colno`/`in_app`, so resolved frames pass through `before_send` unchanged; addresses stay scrubbed (privacy posture intact). No `debug-images`/`debug_meta` — it would leak host paths and Bugsink can't use it.

## Verification (calibrated honesty)
**Verified on macOS (dev box):**
- ✅ Cargo accepts the profile; release build reports `[optimized + debuginfo]` (line tables active).
- ✅ `stage-windows-pdb.cjs` tested both paths: copies the PDB (happy), exits 1 with a clear error when missing.
- ✅ `tauri.windows.conf.json` valid JSON; `release.yml` valid YAML; script `node --check` clean.

**NOT yet runtime-proven (needs Windows):**
- ⚠️ The full pipeline (beforeBundleCommand → resource → NSIS hook → PDB beside exe → dbghelp resolves at crash) runs only in **`release.yml`** (manual dispatch), not in PR CI.
- ⚠️ The NSIS hook fragment compiles only during the Windows bundle (mirrors the existing vc_redist/Vulkan macros).

**Before merge/release:**
1. Run `release.yml` with **`dry_run: true`** → confirms the Windows runner builds the installer with the staging script + hook.
2. On the Windows laptop: install, force a crash, confirm Bugsink shows **named frames + line numbers** for `voicetypr::…` instead of `<unknown>`.

Draft until the Windows pipeline is confirmed green.