### PR TITLE
fix(hotkeys): arm upgraded combo at startup; never consume bare modifiers on Windows

### DIFF
--- a/src-tauri/crates/keytrigger/src/backend/macos.rs
+++ b/src-tauri/crates/keytrigger/src/backend/macos.rs
@@ -1,6 +1,7 @@
-//! macOS backend: a listen-only `CGEventTap` on a dedicated CFRunLoop thread.
+//! macOS backend: an active (intercepting) `CGEventTap` on a dedicated CFRunLoop thread.
 //!
-//! - ListenOnly tap (never consumes); callback returns `None` (pass-through).
+//! - Default (intercepting) tap: the callback returns `None` to CONSUME a key
+//!   when the consume predicate matches; otherwise it returns the event to pass through.
 //! - `FlagsChanged` carries the changed modifier's keycode plus the post-change
 //!   aggregate flag mask. The keycode gives the side; the modifier's type bit in
 //!   the event flags gives authoritative down/up (`CGEventSourceKeyState` lags

--- a/src-tauri/crates/keytrigger/src/backend/mod.rs
+++ b/src-tauri/crates/keytrigger/src/backend/mod.rs
@@ -9,6 +9,13 @@
 mod macos;
 #[cfg(target_os = "windows")]
 mod windows;
+/// Pure, platform-neutral Windows virtual-key + consume-decision helpers.
+/// Compiled on Windows (the `cfg(windows)` hook, its sole non-test caller) and
+/// under `cfg(test)` on every target, so the consume logic unit-tests on macOS
+/// even though the hook itself cannot compile there. See `vk` for why a bare
+/// modifier VK is never consumed.
+#[cfg(any(target_os = "windows", test))]
+mod vk;
 
 use crate::engine::KeyEventSource;
 

--- a/src-tauri/crates/keytrigger/src/backend/vk.rs
+++ b/src-tauri/crates/keytrigger/src/backend/vk.rs
@@ -1,0 +1,222 @@
+//! Pure, platform-neutral helpers for the Windows `WH_KEYBOARD_LL` consume
+//! decision.
+//!
+//! The Windows backend funnels EVERY key — modifiers included — through one
+//! low-level hook, so the "swallow this key?" decision must explicitly avoid
+//! consuming bare modifiers. macOS needs no such guard: modifier transitions
+//! arrive as `FlagsChanged` events on a branch that ALWAYS passes through
+//! (`backend/macos.rs`). To keep that invariant unit-testable on macOS (the
+//! `cfg(windows)` hook itself cannot compile here), the consume decision and
+//! the raw-VK modifier predicate live in this ungated module, and the
+//! `cfg(windows)` hook is a thin caller.
+
+use crate::engine::ConsumeSet;
+use crate::types::{KeySpec, ModSet, Side};
+
+/// Whether a Windows virtual-key code is a modifier: the side-agnostic base
+/// codes (`VK_SHIFT`/`VK_CONTROL`/`VK_MENU`) plus the left/right and Windows
+/// (Meta) codes the low-level hook reports distinctly.
+///
+/// - `0x10` `VK_SHIFT`, `0x11` `VK_CONTROL`, `0x12` `VK_MENU` (Alt)
+/// - `0x5B` `VK_LWIN`, `0x5C` `VK_RWIN`
+/// - `0xA0..=0xA5` `VK_LSHIFT`/`VK_RSHIFT`/`VK_LCONTROL`/`VK_RCONTROL`/
+///   `VK_LMENU`/`VK_RMENU`
+pub(crate) fn is_modifier_vk(vk: u32) -> bool {
+    matches!(
+        vk,
+        0x10 | 0x11 | 0x12 | 0x5B | 0x5C | 0xA0 | 0xA1 | 0xA2 | 0xA3 | 0xA4 | 0xA5
+    )
+}
+
+/// Pure consume decision for a single key event.
+///
+/// Returns `true` (swallow via `LRESULT(1)`) ONLY for a non-repeat, non-modifier
+/// key-DOWN whose exact `(mods, key)` is registered in `consume`. Key-ups,
+/// auto-repeats, and — critically — ANY modifier virtual-key always pass through
+/// (`false`). The raw event is still forwarded to the matcher upstream of this
+/// call, so a modifier-hold / isolated-tap / double-tap trigger still observes
+/// modifier presses even though they are never consumed.
+///
+/// Consuming a bare modifier (Control/Shift/Alt/Win) would globally swallow it
+/// and break system shortcuts like Ctrl+C/Ctrl+V. `is_modifier_vk` is the
+/// primary guard; `side.is_none()` (modifier events carry a side) is a
+/// redundant secondary guard kept for robustness — it does NOT alone suffice,
+/// because the generic `VK_SHIFT`/`VK_CONTROL`/`VK_MENU` codes (0x10/0x11/0x12)
+/// are not side-specific and fall through `map_vk` with `side = None`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn should_consume_keydown(
+    vk: u32,
+    key: KeySpec,
+    side: Option<Side>,
+    down: bool,
+    is_repeat: bool,
+    mods: ModSet,
+    consume: &ConsumeSet,
+) -> bool {
+    down
+        && !is_repeat
+        && !is_modifier_vk(vk)
+        && side.is_none()
+        && consume.consumes(key, mods)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Modifier, NamedKey};
+
+    /// A consume set containing exactly one bare single key, bypassing
+    /// `ConsumeSet::from_bindings` (which now filters bare modifiers) so we can
+    /// prove the VK-level guard saves us even if a bare-modifier `SingleKey`
+    /// somehow entered the live consume set.
+    fn single(key: NamedKey) -> ConsumeSet {
+        ConsumeSet {
+            singles: vec![KeySpec::Named(key)],
+            combos: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn modifier_vks_are_recognized() {
+        // side-agnostic base codes
+        for vk in [0x10u32, 0x11, 0x12] {
+            assert!(is_modifier_vk(vk), "0x{:X} should be a modifier", vk);
+        }
+        // Windows / Meta keys
+        for vk in [0x5Bu32, 0x5C] {
+            assert!(is_modifier_vk(vk), "0x{:X} should be a modifier", vk);
+        }
+        // side-specific L/R modifiers
+        for vk in [0xA0u32, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5] {
+            assert!(is_modifier_vk(vk), "0x{:X} should be a modifier", vk);
+        }
+    }
+
+    #[test]
+    fn non_modifier_vks_are_not_recognized() {
+        for vk in [
+            0x41u32, // 'A'
+            0x30,    // '0'
+            0x77,    // VK_F8
+            0x1B,    // VK_ESCAPE
+            0x0D,    // VK_RETURN
+            0x20,    // VK_SPACE
+        ] {
+            assert!(!is_modifier_vk(vk), "0x{:X} should NOT be a modifier", vk);
+        }
+    }
+
+    #[test]
+    fn modifier_vks_are_never_consumed_even_when_bound() {
+        // The generic base codes (0x10/0x11/0x12) are the ones `side.is_none()`
+        // alone would miss: prove the VK guard catches them too.
+        for vk in [0x10u32, 0x11, 0x12] {
+            assert!(
+                !should_consume_keydown(
+                    vk,
+                    KeySpec::Raw(vk),
+                    None,
+                    true,
+                    false,
+                    ModSet::empty(),
+                    &ConsumeSet {
+                        singles: vec![KeySpec::Raw(vk)],
+                        combos: Vec::new(),
+                    },
+                ),
+                "generic modifier 0x{:X} must NEVER be consumed",
+                vk
+            );
+        }
+        // Every side-specific modifier family, each with a matching bare-modifier
+        // SingleKey bound (the worst case the guard must defeat).
+        for (vk, key, side) in [
+            (0xA0u32, NamedKey::ShiftLeft, Side::Left),
+            (0xA1, NamedKey::ShiftRight, Side::Right),
+            (0xA2, NamedKey::ControlLeft, Side::Left),
+            (0xA3, NamedKey::ControlRight, Side::Right),
+            (0xA4, NamedKey::AltLeft, Side::Left),
+            (0xA5, NamedKey::AltRight, Side::Right),
+            (0x5B, NamedKey::MetaLeft, Side::Left),
+            (0x5C, NamedKey::MetaRight, Side::Right),
+        ] {
+            assert!(
+                !should_consume_keydown(
+                    vk,
+                    KeySpec::Named(key),
+                    Some(side),
+                    true,
+                    false,
+                    ModSet::empty(),
+                    &single(key),
+                ),
+                "modifier 0x{:X} must NEVER be consumed even when bound",
+                vk
+            );
+        }
+    }
+
+    #[test]
+    fn non_modifier_single_keys_still_consume_when_bound() {
+        // VK_F8 (0x77), bound as a SingleKey with no mods held → consume.
+        assert!(should_consume_keydown(
+            0x77,
+            KeySpec::Named(NamedKey::F8),
+            None,
+            true,
+            false,
+            ModSet::empty(),
+            &single(NamedKey::F8),
+        ));
+        // VK_ESCAPE (0x1B) → consume.
+        assert!(should_consume_keydown(
+            0x1B,
+            KeySpec::Named(NamedKey::Escape),
+            None,
+            true,
+            false,
+            ModSet::empty(),
+            &single(NamedKey::Escape),
+        ));
+    }
+
+    #[test]
+    fn keyups_and_repeats_never_consume() {
+        let set = single(NamedKey::F8);
+        // key-up (down = false) → pass through.
+        assert!(!should_consume_keydown(
+            0x77,
+            KeySpec::Named(NamedKey::F8),
+            None,
+            false,
+            false,
+            ModSet::empty(),
+            &set,
+        ));
+        // auto-repeat → pass through.
+        assert!(!should_consume_keydown(
+            0x77,
+            KeySpec::Named(NamedKey::F8),
+            None,
+            true,
+            true,
+            ModSet::empty(),
+            &set,
+        ));
+    }
+
+    #[test]
+    fn single_key_with_modifier_held_does_not_consume() {
+        // A bound single key pressed while a modifier is held passes through
+        // (mirrors `ConsumeSet::consumes`: singles require zero mods).
+        assert!(!should_consume_keydown(
+            0x77,
+            KeySpec::Named(NamedKey::F8),
+            None,
+            true,
+            false,
+            ModSet::empty().with(Modifier::Shift),
+            &single(NamedKey::F8),
+        ));
+    }
+}

--- a/src-tauri/crates/keytrigger/src/backend/windows.rs
+++ b/src-tauri/crates/keytrigger/src/backend/windows.rs
@@ -34,6 +34,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 
 use crate::engine::{ConsumeSet, KeyEventSource, Msg, ReadySignal};
 use crate::types::{KeySpec, ModSet, Modifier, NamedKey, RawKeyEvent, Side};
+use super::vk::should_consume_keydown;
 
 struct HookState {
     tx: Sender<Msg>,
@@ -158,15 +159,23 @@ unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: 
                         down,
                         is_repeat,
                     }));
-                    // Consume ONLY a non-repeat, non-modifier key-down whose exact
-                    // (mods, key) is a registered combo/single — mirrors the macOS
-                    // tap. Modifiers, key-ups, and auto-repeats pass through.
-                    down && !is_repeat
-                        && side.is_none()
-                        && state
-                            .consume
-                            .load()
-                            .consumes(key, modset_from_down(&state.down))
+                    // Forward EVERY event to the matcher for observation, but
+                    // swallow (consume) only a non-repeat, non-modifier key-down
+                    // whose exact (mods, key) is a registered combo/single. A bare
+                    // modifier VK is NEVER consumed — swallowing Control/Shift/Alt/
+                    // Win would globally break shortcuts like Ctrl+C/V. macOS routes
+                    // modifier changes through a FlagsChanged branch that always
+                    // passes through; `should_consume_keydown` enforces the same
+                    // invariant here (pure + unit-tested in `backend::vk`).
+                    should_consume_keydown(
+                        vk,
+                        key,
+                        side,
+                        down,
+                        is_repeat,
+                        modset_from_down(&state.down),
+                        &state.consume.load(),
+                    )
                 } else {
                     false
                 }

--- a/src-tauri/crates/keytrigger/src/engine.rs
+++ b/src-tauri/crates/keytrigger/src/engine.rs
@@ -93,15 +93,13 @@ impl ConsumeSet {
         for (_, trig) in bindings {
             match trig {
                 Trigger::ComboExact { mods, key } => combos.push((*mods, *key)),
-                Trigger::SingleKey { key } => {
-                    // Belt-and-suspenders: a bare-modifier SingleKey never enters
-                    // the consume set. Consuming Control/Shift/Alt/Win would
-                    // globally break Ctrl+C/V etc.; the OS backends also guard
-                    // modifier VKs at the hook, but filtering here means a stray
-                    // bare-modifier binding can't be swallowed even transiently.
-                    if !is_modifier_key(*key) {
-                        singles.push(*key);
-                    }
+                // Belt-and-suspenders: a bare-modifier SingleKey never enters
+                // the consume set. Consuming Control/Shift/Alt/Win would
+                // globally break Ctrl+C/V etc.; the OS backends also guard
+                // modifier VKs at the hook, but filtering here means a stray
+                // bare-modifier binding can't be swallowed even transiently.
+                Trigger::SingleKey { key } if !is_modifier_key(*key) => {
+                    singles.push(*key);
                 }
                 _ => {}
             }

--- a/src-tauri/crates/keytrigger/src/engine.rs
+++ b/src-tauri/crates/keytrigger/src/engine.rs
@@ -14,7 +14,7 @@ use parking_lot::Mutex;
 
 use crate::backend::platform_source;
 use crate::matcher::Matcher;
-use crate::types::{EngineError, KeySpec, ModSet, RawKeyEvent, Trigger, TriggerEvent, TriggerId};
+use crate::types::{EngineError, KeySpec, ModSet, NamedKey, RawKeyEvent, Trigger, TriggerEvent, TriggerId};
 
 /// Messages flowing to the dispatcher thread. Raw events and control messages
 /// share one channel so they are processed in order.
@@ -65,6 +65,25 @@ pub struct ConsumeSet {
     /// Bare keys consumed only when NO modifiers are held.
     pub singles: Vec<KeySpec>,
 }
+/// Whether `key` is a bare (side-specific) modifier key. Such keys must NEVER be
+/// swallowed at the OS level: consuming Control/Shift/Alt/Win would globally
+/// break shortcuts like Ctrl+C/V. The OS backends additionally guard modifier
+/// virtual-key codes at the hook, but excluding bare-modifier `SingleKey`
+/// bindings here ensures the matcher's own consume set cannot resurrect the bug
+/// via a stray binding.
+fn is_modifier_key(key: KeySpec) -> bool {
+    matches!(
+        key,
+        KeySpec::Named(NamedKey::AltLeft)
+            | KeySpec::Named(NamedKey::AltRight)
+            | KeySpec::Named(NamedKey::ControlLeft)
+            | KeySpec::Named(NamedKey::ControlRight)
+            | KeySpec::Named(NamedKey::MetaLeft)
+            | KeySpec::Named(NamedKey::MetaRight)
+            | KeySpec::Named(NamedKey::ShiftLeft)
+            | KeySpec::Named(NamedKey::ShiftRight)
+    )
+}
 
 impl ConsumeSet {
     /// Build the consume set from a binding list (ignores non-consuming triggers).
@@ -74,7 +93,16 @@ impl ConsumeSet {
         for (_, trig) in bindings {
             match trig {
                 Trigger::ComboExact { mods, key } => combos.push((*mods, *key)),
-                Trigger::SingleKey { key } => singles.push(*key),
+                Trigger::SingleKey { key } => {
+                    // Belt-and-suspenders: a bare-modifier SingleKey never enters
+                    // the consume set. Consuming Control/Shift/Alt/Win would
+                    // globally break Ctrl+C/V etc.; the OS backends also guard
+                    // modifier VKs at the hook, but filtering here means a stray
+                    // bare-modifier binding can't be swallowed even transiently.
+                    if !is_modifier_key(*key) {
+                        singles.push(*key);
+                    }
+                }
                 _ => {}
             }
         }
@@ -528,5 +556,51 @@ mod tests {
         let set = ConsumeSet::default();
         assert!(!set.consumes(j(), ModSet::empty()));
         assert!(!set.consumes(j(), ModSet::empty().with(Modifier::Meta)));
+    }
+    #[test]
+    fn consume_set_filters_bare_modifier_single_keys() {
+        // Bare-modifier SingleKeys must NOT enter the consume set: consuming a
+        // modifier would globally swallow Control/Shift/Alt/Win (Ctrl+C/V etc.).
+        let set = ConsumeSet::from_bindings(&[
+            (
+                "blocked-ctrl".into(),
+                Trigger::SingleKey {
+                    key: KeySpec::Named(NamedKey::ControlLeft),
+                },
+            ),
+            (
+                "blocked-alt".into(),
+                Trigger::SingleKey {
+                    key: KeySpec::Named(NamedKey::AltLeft),
+                },
+            ),
+            (
+                "blocked-shift".into(),
+                Trigger::SingleKey {
+                    key: KeySpec::Named(NamedKey::ShiftRight),
+                },
+            ),
+            (
+                "blocked-meta".into(),
+                Trigger::SingleKey {
+                    key: KeySpec::Named(NamedKey::MetaLeft),
+                },
+            ),
+            (
+                "kept".into(),
+                Trigger::SingleKey {
+                    key: KeySpec::Named(NamedKey::F8),
+                },
+            ),
+        ]);
+        // Only the non-modifier single survives into the set.
+        assert_eq!(set.singles, vec![KeySpec::Named(NamedKey::F8)]);
+        // The filtered modifier is not consumed even with zero mods held.
+        assert!(!set.consumes(
+            KeySpec::Named(NamedKey::ControlLeft),
+            ModSet::empty()
+        ));
+        // The non-modifier single is consumed as before.
+        assert!(set.consumes(KeySpec::Named(NamedKey::F8), ModSet::empty()));
     }
 }

--- a/src-tauri/src/commands/shortcuts.rs
+++ b/src-tauri/src/commands/shortcuts.rs
@@ -509,7 +509,7 @@ fn migrate_legacy_tap_bindings(value: &mut serde_json::Value) -> bool {
     changed
 }
 
-fn save_shortcut_settings(app: &AppHandle, settings: &ShortcutSettings) -> Result<(), String> {
+pub(crate) fn save_shortcut_settings(app: &AppHandle, settings: &ShortcutSettings) -> Result<(), String> {
     let store = app.store("settings").map_err(|e| e.to_string())?;
     store.set(
         SHORTCUT_BINDINGS_KEY,

--- a/src-tauri/src/trigger/engine_host.rs
+++ b/src-tauri/src/trigger/engine_host.rs
@@ -153,11 +153,8 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
     // longer see an enabled binding that would suppress combo synthesis.
     if let Some(id) = stale_id {
         let mut repaired = settings;
-        let mutated = repaired
-            .bindings
-            .iter_mut()
-            .any(|b| if b.id == id { b.enabled = false; true } else { false });
-        if mutated {
+        if let Some(binding) = repaired.bindings.iter_mut().find(|b| b.id == id) {
+            binding.enabled = false;
             match crate::commands::shortcuts::save_shortcut_settings(app, &repaired) {
                 Ok(()) => log::info!(
                     "keytrigger: disabled stale bare-modifier primary '{}' — combo hotkey is authoritative",
@@ -306,6 +303,10 @@ fn plan_engine_bindings(
                 trigger_kind: TriggerKind::Combo,
                 modifier: None,
             });
+        } else {
+            log::warn!(
+                "keytrigger: push-to-talk is set to use a different PTT key, but ptt_hotkey is empty — PTT will not arm"
+            );
         }
     }
 

--- a/src-tauri/src/trigger/engine_host.rs
+++ b/src-tauri/src/trigger/engine_host.rs
@@ -27,13 +27,26 @@ pub fn apply_engine_bindings(app: &AppHandle, bindings: &[ShortcutBinding]) {
         .iter()
         .filter(|b| b.enabled && mapping::is_engine_kind(b))
     {
-        if let Some(trigger) = mapping::to_trigger(binding) {
-            new_bindings.push(EngineBinding {
-                id: binding.id.clone(),
-                action: binding.action,
-                trigger: binding.trigger,
-            });
-            triggers.push((binding.id.clone(), trigger));
+        match mapping::to_trigger(binding) {
+            Some(trigger) => {
+                new_bindings.push(EngineBinding {
+                    id: binding.id.clone(),
+                    action: binding.action,
+                    trigger: binding.trigger,
+                });
+                triggers.push((binding.id.clone(), trigger));
+            }
+            None => {
+                // A binding that survived validation/rebuild but still resolves
+                // to no trigger is a silent failure waiting to happen — its id
+                // would vanish from the engine with no signal. Surface it.
+                log::warn!(
+                    "keytrigger: dropping binding '{}' ({:?}, shortcut={:?}) — no resolvable trigger; not installed",
+                    binding.id,
+                    binding.trigger_kind,
+                    binding.shortcut,
+                );
+            }
         }
     }
 
@@ -85,6 +98,10 @@ fn bindings_needing_release(old: &[EngineBinding], new: &[EngineBinding]) -> Vec
 }
 
 /// Rebuild the complete native-engine binding list from persisted settings and runtime state.
+///
+/// Decision logic lives in [`plan_engine_bindings`] (pure, unit-tested). This
+/// wrapper loads persisted state, runs the plan, performs the one-time durable
+/// bare-modifier-primary migration it requests, and applies the result.
 pub fn rebuild_engine_bindings(app: &AppHandle) {
     let settings = match crate::commands::shortcuts::load_shortcut_settings(app) {
         Ok(settings) => settings,
@@ -94,6 +111,93 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
         }
     };
 
+    let store = app.store("settings").ok();
+    let hotkey = store
+        .as_ref()
+        .and_then(|store| store.get("hotkey"))
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| "CommandOrControl+Shift+Space".to_string());
+    let recording_mode_str = store
+        .as_ref()
+        .and_then(|store| store.get("recording_mode"))
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| "toggle".to_string());
+    let recording_mode = if recording_mode_str == "push_to_talk" {
+        RecordingMode::PushToTalk
+    } else {
+        RecordingMode::Toggle
+    };
+    let use_different_ptt_key = store
+        .as_ref()
+        .and_then(|store| store.get("use_different_ptt_key"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let ptt_hotkey = store
+        .as_ref()
+        .and_then(|store| store.get("ptt_hotkey"))
+        .and_then(|value| value.as_str().map(str::to_string));
+    let is_recording = matches!(crate::get_recording_state(app), RecordingState::Recording);
+
+    let (bindings, stale_id) = plan_engine_bindings(
+        &settings.bindings,
+        &hotkey,
+        recording_mode,
+        use_different_ptt_key,
+        ptt_hotkey.as_deref(),
+        is_recording,
+    );
+
+    // One-time durable migration (Issue A): when the combo hotkey is
+    // authoritative, persist-disable the single stale bare-modifier recording
+    // primary it superseded, so the next rebuild (and the Settings UI) no
+    // longer see an enabled binding that would suppress combo synthesis.
+    if let Some(id) = stale_id {
+        let mut repaired = settings;
+        let mutated = repaired
+            .bindings
+            .iter_mut()
+            .any(|b| if b.id == id { b.enabled = false; true } else { false });
+        if mutated {
+            match crate::commands::shortcuts::save_shortcut_settings(app, &repaired) {
+                Ok(()) => log::info!(
+                    "keytrigger: disabled stale bare-modifier primary '{}' — combo hotkey is authoritative",
+                    id
+                ),
+                Err(error) => log::warn!(
+                    "keytrigger: failed to persist bare-modifier primary migration for '{}': {}",
+                    id,
+                    error
+                ),
+            }
+        }
+    }
+
+    apply_engine_bindings(app, &bindings);
+}
+
+/// Pure decision core for [`rebuild_engine_bindings`]. Given the persisted
+/// bindings and runtime state, returns:
+///   * the final engine binding list to install, and
+///   * the id of a SINGLE stale bare-modifier recording primary to
+///     persist-disable as a one-time migration, or `None`.
+///
+/// When the combo `hotkey` is non-empty it is authoritative: the combo
+/// `primary` always wins, and a stale enabled bare-modifier recording binding
+/// (left by an older migration) is repaired by removing that single primary
+/// candidate from this rebuild and flagging it for persistence. When `hotkey`
+/// is empty, a remaining bare-modifier primary owns recording and no combo is
+/// synthesized (default-combo fallback otherwise). Other bare-modifier bindings
+/// the user added as additional shortcuts are never touched.
+///
+/// Pure (no app handle) so the migration decision can be unit-tested directly.
+fn plan_engine_bindings(
+    persisted: &[ShortcutBinding],
+    hotkey: &str,
+    recording_mode: RecordingMode,
+    use_different_ptt_key: bool,
+    ptt_hotkey: Option<&str>,
+    is_recording: bool,
+) -> (Vec<ShortcutBinding>, Option<String>) {
     // Persisted bindings may predate current validation rules; the update/save
     // path rejects them, but at startup we read straight from the store. Skip
     // (and warn) any enabled binding that fails per-binding validation so it is
@@ -101,8 +205,7 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
     // that resolves to bare `SingleKey(Escape)` — Escape is reserved for the
     // synthesized `escape-cancel`. The synthesized escape-cancel/primary/ptt
     // ids are appended below and bypass this gate.
-    let mut bindings: Vec<ShortcutBinding> = settings
-        .bindings
+    let mut bindings: Vec<ShortcutBinding> = persisted
         .iter()
         .filter(|binding| {
             if !binding.enabled {
@@ -131,38 +234,23 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
         .cloned()
         .collect();
 
-    let store = app.store("settings").ok();
-    let hotkey = store
-        .as_ref()
-        .and_then(|store| store.get("hotkey"))
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| "CommandOrControl+Shift+Space".to_string());
-    let recording_mode_str = store
-        .as_ref()
-        .and_then(|store| store.get("recording_mode"))
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| "toggle".to_string());
-    let recording_mode = if recording_mode_str == "push_to_talk" {
-        RecordingMode::PushToTalk
-    } else {
-        RecordingMode::Toggle
-    };
-    let use_different_ptt_key = store
-        .as_ref()
-        .and_then(|store| store.get("use_different_ptt_key"))
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    let ptt_hotkey = store
-        .as_ref()
-        .and_then(|store| store.get("ptt_hotkey"))
-        .and_then(|value| value.as_str().map(str::to_string));
+    // Issue A: a non-empty combo hotkey makes the combo `primary` authoritative.
+    // A stale enabled bare-modifier recording binding left by an older migration
+    // would otherwise suppress combo synthesis below; repair it by removing the
+    // SINGLE active-primary candidate from this rebuild and flagging it for a
+    // durable disable. Additional bare-modifier shortcuts are preserved.
+    let stale_id = stale_primary_candidate(&bindings, hotkey);
+    if let Some(id) = &stale_id {
+        bindings.retain(|b| b.id != *id);
+    }
 
-    // A bare-modifier primary is any enabled recording-action binding triggered
-    // by a modifier hold or an isolated tap — the frontend's notion of "primary"
-    // (GeneralSettings.tsx / shortcut-display.ts), not just the literal
-    // "onboarding-primary-hold" id. When one exists we must NOT also synthesize
-    // the combo `primary`, or a phantom consuming combo coexists with the
-    // pass-through bare-modifier primary and breaks it.
+    // Synthesize the combo `primary` when the combo owns recording. With a
+    // non-empty hotkey the combo always wins (the repair above removed any
+    // stale bare-modifier primary). With an empty hotkey, a remaining
+    // bare-modifier primary owns recording and we synthesize no combo; otherwise
+    // fall back to the default combo so the user always has a way to start
+    // recording.
+    let combo_owns_primary = !hotkey.trim().is_empty();
     let has_bare_modifier_primary = bindings.iter().any(|binding| {
         binding.enabled
             && matches!(
@@ -174,16 +262,16 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
                 TriggerKind::ModifierHold | TriggerKind::IsolatedTap
             )
     });
-
-    if !has_bare_modifier_primary {
-        // Default-combo fallback: if the stored hotkey is empty/blank and there is
-        // no bare-modifier primary either, the user would otherwise be left with NO
-        // way to start recording by hotkey. The retired global-shortcut startup
-        // fell back to this same default for that inconsistent state.
-        let hotkey = if hotkey.trim().is_empty() {
+    if combo_owns_primary || !has_bare_modifier_primary {
+        // Default-combo fallback: if the stored hotkey is empty/blank and there
+        // is no bare-modifier primary either, the user would otherwise be left
+        // with NO way to start recording by hotkey. The retired
+        // global-shortcut startup fell back to this same default for that
+        // inconsistent state.
+        let combo_hotkey = if hotkey.trim().is_empty() {
             "CommandOrControl+Shift+Space".to_string()
         } else {
-            hotkey
+            hotkey.to_string()
         };
         let hold_to_record = recording_mode == RecordingMode::PushToTalk;
         bindings.push(ShortcutBinding {
@@ -193,7 +281,7 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
             } else {
                 ShortcutAction::ToggleRecording
             },
-            shortcut: hotkey,
+            shortcut: combo_hotkey,
             trigger: if hold_to_record {
                 ShortcutTrigger::Hold
             } else {
@@ -211,7 +299,7 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
             bindings.push(ShortcutBinding {
                 id: "ptt".to_string(),
                 action: ShortcutAction::HoldToRecord,
-                shortcut: ptt_hotkey,
+                shortcut: ptt_hotkey.to_string(),
                 trigger: ShortcutTrigger::Hold,
                 enabled: true,
                 allow_risky_combo: false,
@@ -221,7 +309,7 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
         }
     }
 
-    if matches!(crate::get_recording_state(app), RecordingState::Recording) {
+    if is_recording {
         bindings.push(ShortcutBinding {
             id: "escape-cancel".to_string(),
             action: ShortcutAction::CancelRecording,
@@ -234,7 +322,39 @@ pub fn rebuild_engine_bindings(app: &AppHandle) {
         });
     }
 
-    apply_engine_bindings(app, &bindings);
+    (bindings, stale_id)
+}
+
+/// Identify the single stale bare-modifier recording primary to disable so a
+/// non-empty combo `hotkey` can own recording. Returns its id, or `None` when
+/// the combo is not authoritative (empty hotkey) or no enabled recording
+/// bare-modifier binding exists.
+///
+/// Precedence mirrors the frontend's primary selection (GeneralSettings.tsx /
+/// shortcut-display.ts): prefer the binding whose id is `onboarding-primary-hold`,
+/// else the FIRST enabled recording bare-modifier binding. Only this single
+/// candidate is ever returned; any additional bare-modifier recording bindings
+/// the user added as separate shortcuts are preserved. Pure (no app state).
+fn stale_primary_candidate(bindings: &[ShortcutBinding], hotkey: &str) -> Option<String> {
+    if hotkey.trim().is_empty() {
+        return None;
+    }
+    let is_primary_candidate = |b: &ShortcutBinding| {
+        b.enabled
+            && matches!(
+                b.action,
+                ShortcutAction::HoldToRecord | ShortcutAction::ToggleRecording
+            )
+            && matches!(
+                b.trigger_kind,
+                TriggerKind::ModifierHold | TriggerKind::IsolatedTap
+            )
+    };
+    bindings
+        .iter()
+        .find(|b| b.id == "onboarding-primary-hold" && is_primary_candidate(b))
+        .or_else(|| bindings.iter().find(|b| is_primary_candidate(b)))
+        .map(|b| b.id.clone())
 }
 
 /// Attempt to start the native trigger engine. On macOS without Accessibility
@@ -260,9 +380,13 @@ pub fn start_engine(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::bindings_needing_release;
-    use crate::commands::shortcuts::{ShortcutAction, ShortcutTrigger};
+    use super::{bindings_needing_release, plan_engine_bindings, stale_primary_candidate};
+    use crate::commands::shortcuts::{
+        ModifierKind, ModifierSpec, ShortcutAction, ShortcutBinding, ShortcutTrigger, SideKind,
+        TriggerKind,
+    };
     use crate::trigger::EngineBinding;
+    use crate::RecordingMode;
 
     fn binding(id: &str, action: ShortcutAction, trigger: ShortcutTrigger) -> EngineBinding {
         EngineBinding {
@@ -356,5 +480,162 @@ mod tests {
             ShortcutTrigger::Hold,
         )];
         assert_eq!(bindings_needing_release(&old, &new).len(), 1);
+    }
+
+    fn modifier_hold_binding(id: &str) -> ShortcutBinding {
+        ShortcutBinding {
+            id: id.to_string(),
+            action: ShortcutAction::HoldToRecord,
+            shortcut: String::new(),
+            trigger: ShortcutTrigger::Hold,
+            enabled: true,
+            allow_risky_combo: false,
+            trigger_kind: TriggerKind::ModifierHold,
+            modifier: Some(ModifierSpec {
+                modifier: ModifierKind::Alt,
+                side: SideKind::Right,
+            }),
+        }
+    }
+
+    /// Issue A: on upgrade a saved combo hotkey must arm even when a stale
+    /// enabled bare-modifier recording primary is present. The stale primary is
+    /// flagged for a durable disable and removed from the runtime rebuild; the
+    /// combo `primary` is synthesized from settings.hotkey.
+    #[test]
+    fn nonempty_hotkey_disables_stale_bare_primary_and_synthesizes_combo() {
+        let stale = modifier_hold_binding("onboarding-primary-hold");
+        let (bindings, stale_id) = plan_engine_bindings(
+            &[stale],
+            "CommandOrControl+Space",
+            RecordingMode::Toggle,
+            false,
+            None,
+            false,
+        );
+
+        assert_eq!(stale_id.as_deref(), Some("onboarding-primary-hold"));
+        assert!(
+            !bindings
+                .iter()
+                .any(|b| b.id == "onboarding-primary-hold"),
+            "stale bare primary must not be installed"
+        );
+
+        let primary = bindings
+            .iter()
+            .find(|b| b.id == "primary")
+            .expect("combo primary must be synthesized when hotkey is non-empty");
+        assert_eq!(primary.trigger_kind, TriggerKind::Combo);
+        assert_eq!(primary.shortcut, "CommandOrControl+Space");
+        assert!(primary.enabled);
+    }
+
+    /// Empty hotkey + a valid bare-modifier primary: the bare primary owns
+    /// recording, no combo is synthesized, and nothing is migrated (unchanged
+    /// behavior).
+    #[test]
+    fn empty_hotkey_with_bare_primary_synthesizes_no_combo() {
+        let bare = modifier_hold_binding("onboarding-primary-hold");
+        let (bindings, stale_id) = plan_engine_bindings(
+            &[bare],
+            "",
+            RecordingMode::Toggle,
+            false,
+            None,
+            false,
+        );
+
+        assert!(stale_id.is_none(), "empty hotkey must not trigger migration");
+        assert!(
+            bindings
+                .iter()
+                .any(|b| b.id == "onboarding-primary-hold" && b.enabled),
+            "bare primary must stay enabled"
+        );
+        assert!(
+            !bindings.iter().any(|b| b.id == "primary"),
+            "no combo primary when a bare primary owns recording"
+        );
+    }
+
+    /// A non-empty combo hotkey with both the stale primary and an extra
+    /// user-added bare-modifier shortcut: only the single primary candidate is
+    /// disabled; the additional shortcut is preserved and stays enabled.
+    #[test]
+    fn additional_bare_modifier_shortcut_is_not_disabled() {
+        let stale = modifier_hold_binding("onboarding-primary-hold");
+        let mut extra = modifier_hold_binding("my-extra-mod");
+        extra.modifier = Some(ModifierSpec {
+            modifier: ModifierKind::Control,
+            side: SideKind::Left,
+        });
+        let (bindings, stale_id) = plan_engine_bindings(
+            &[stale, extra],
+            "CommandOrControl+Space",
+            RecordingMode::Toggle,
+            false,
+            None,
+            false,
+        );
+
+        assert_eq!(stale_id.as_deref(), Some("onboarding-primary-hold"));
+        let extra_installed = bindings
+            .iter()
+            .find(|b| b.id == "my-extra-mod")
+            .expect("additional bare-modifier shortcut must stay installed");
+        assert!(
+            extra_installed.enabled,
+            "additional shortcut must stay enabled"
+        );
+        assert!(bindings
+            .iter()
+            .any(|b| b.id == "primary" && b.trigger_kind == TriggerKind::Combo));
+        assert!(!bindings.iter().any(|b| b.id == "onboarding-primary-hold"));
+    }
+
+    /// Precedence: without an `onboarding-primary-hold` id, the FIRST enabled
+    /// recording bare-modifier binding is the primary candidate; a second one is
+    /// an additional shortcut and is preserved.
+    #[test]
+    fn stale_primary_falls_back_to_first_bare_modifier_binding() {
+        let first = modifier_hold_binding("legacy-hold");
+        let mut second = modifier_hold_binding("legacy-hold-2");
+        second.modifier = Some(ModifierSpec {
+            modifier: ModifierKind::Control,
+            side: SideKind::Left,
+        });
+        let (bindings, stale_id) = plan_engine_bindings(
+            &[first, second],
+            "CommandOrControl+Space",
+            RecordingMode::Toggle,
+            false,
+            None,
+            false,
+        );
+
+        assert_eq!(stale_id.as_deref(), Some("legacy-hold"));
+        assert!(!bindings.iter().any(|b| b.id == "legacy-hold"));
+        assert!(bindings
+            .iter()
+            .any(|b| b.id == "legacy-hold-2" && b.enabled));
+        assert!(bindings
+            .iter()
+            .any(|b| b.id == "primary" && b.trigger_kind == TriggerKind::Combo));
+    }
+
+    /// `stale_primary_candidate` is a pure no-op for an empty hotkey even when a
+    /// bare-modifier recording binding exists.
+    #[test]
+    fn stale_primary_candidate_returns_none_for_empty_hotkey() {
+        assert_eq!(
+            stale_primary_candidate(&[modifier_hold_binding("onboarding-primary-hold")], ""),
+            None
+        );
+        assert_eq!(
+            stale_primary_candidate(&[modifier_hold_binding("onboarding-primary-hold")], "   "),
+            None,
+            "whitespace-only hotkey is treated as empty"
+        );
     }
 }

--- a/src-tauri/src/trigger/engine_host.rs
+++ b/src-tauri/src/trigger/engine_host.rs
@@ -532,6 +532,50 @@ mod tests {
         assert!(primary.enabled);
     }
 
+    fn isolated_tap_binding(id: &str) -> ShortcutBinding {
+        ShortcutBinding {
+            id: id.to_string(),
+            action: ShortcutAction::ToggleRecording,
+            shortcut: String::new(),
+            trigger: ShortcutTrigger::Pressed,
+            enabled: true,
+            allow_risky_combo: false,
+            trigger_kind: TriggerKind::IsolatedTap,
+            modifier: Some(ModifierSpec {
+                modifier: ModifierKind::Alt,
+                side: SideKind::Right,
+            }),
+        }
+    }
+
+    /// Issue A migration also covers an `IsolatedTap` stale primary
+    /// (`stale_primary_candidate` matches both ModifierHold and IsolatedTap):
+    /// a non-empty combo hotkey disables the tap primary and synthesizes the combo.
+    #[test]
+    fn nonempty_hotkey_disables_stale_isolated_tap_primary() {
+        let stale = isolated_tap_binding("onboarding-primary-hold");
+        let (bindings, stale_id) = plan_engine_bindings(
+            &[stale],
+            "CommandOrControl+Space",
+            RecordingMode::Toggle,
+            false,
+            None,
+            false,
+        );
+
+        assert_eq!(stale_id.as_deref(), Some("onboarding-primary-hold"));
+        assert!(
+            !bindings.iter().any(|b| b.id == "onboarding-primary-hold"),
+            "stale isolated-tap primary must not be installed"
+        );
+        assert!(
+            bindings
+                .iter()
+                .any(|b| b.id == "primary" && b.trigger_kind == TriggerKind::Combo),
+            "combo primary must be synthesized over a stale isolated-tap primary"
+        );
+    }
+
     /// Empty hotkey + a valid bare-modifier primary: the bare primary owns
     /// recording, no combo is synthesized, and nothing is migrated (unchanged
     /// behavior).


### PR DESCRIPTION
Two independent regressions found during the Windows smoke of the 2.0.2 bundle (oracle root-caused, both confirmed against the real 2.0.2 code).

## Issue A — upgraded combo hotkey shown but dead until re-recorded
`rebuild_engine_bindings` treated ANY enabled bare-modifier recording binding as the primary and skipped synthesizing the combo from `settings.hotkey`, even when non-empty. A stale bare-modifier binding left by the 2.0.1->2.0.2 cutover suppressed the combo the UI still displayed; it only armed after the Settings UI separately disabled it. Now a non-empty `settings.hotkey` is AUTHORITATIVE: the combo primary always installs, and the SINGLE stale bare-modifier primary (precedence: `onboarding-primary-hold`, else first enabled recording bare-modifier) is durably disabled via a one-time, idempotent migration. Empty-hotkey + bare-primary path unchanged; additional user shortcuts untouched. `apply_engine_bindings` now warns instead of silently dropping an unresolved synthesized primary/ptt.

## Issue B — Windows-only: lone modifier set as trigger globally consumed (breaks Ctrl+C/V)
The `WH_KEYBOARD_LL` hook only guarded consume with `side.is_none()`, which misses the generic `VK_CONTROL/SHIFT/MENU` (0x10/0x11/0x12, side=None). New `backend/vk.rs` `is_modifier_vk` + `should_consume_keydown` make modifier VKs NEVER consumed (matching macOS `FlagsChanged` pass-through); `ConsumeSet::from_bindings` also drops bare-modifier `SingleKey`s. The modifier is still forwarded to the matcher, so isolated-tap / modifier-hold triggers still fire.

## Tests / gates
- +5 engine_host unit tests, +7 keytrigger unit tests
- `cargo test` 1180 passed; `clippy --all-targets -D warnings` clean; `cargo check --target x86_64-pc-windows-msvc -p keytrigger` clean
- Windows RUNTIME re-smoke (upgrade arms hotkey w/o re-record; Control-as-trigger keeps Ctrl+C/V working) happens on the re-cut 2.0.2 release draft.