### PR TITLE
docs: scrub stale 'legacy global_shortcut' comments (internal-only)

### DIFF
--- a/src/lib/shortcut-display.ts
+++ b/src/lib/shortcut-display.ts
@@ -15,7 +15,7 @@ const BARE_MOD_ICONS: Record<string, string> = {
  * The primary is the onboarding hold binding, or — failing that — the first
  * enabled engine-kind binding (`modifier_hold` / `isolated_tap`)
  * that drives recording (`hold_to_record` / `toggle_recording`). Combo shortcuts
- * live in `settings.hotkey` (the `global_shortcut` path) and are intentionally
+ * live in `settings.hotkey` (the primary combo hotkey) and are intentionally
  * not considered here.
  *
  * Returns `null` when the active primary is a combo, or nothing is set.

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -32,7 +32,7 @@ export interface ShortcutBinding {
   trigger: ShortcutTrigger;
   enabled: boolean;
   allow_risky_combo: boolean;
-  /** Defaults to "combo" (legacy global_shortcut). Native kinds use the engine. */
+  /** Defaults to "combo" for combo hotkeys. Native kinds (modifier_hold / isolated_tap) use the keytrigger engine. */
   trigger_kind?: TriggerKind;
   /** Modifier target for "modifier_hold" / "isolated_tap" kinds. */
   modifier?: ModifierSpec | null;


### PR DESCRIPTION
Per request: keep the public surface the same, clean up internal references to the retired global-shortcut plugin.

The `tauri-plugin-global-shortcut` backend was retired in #99 (no dep / imports / capability remain). An audit found the cutover was already clean — nearly all `legacy` references in the tree are legitimate back-compat (settings migration, JSON deserialization, password migration) and were left untouched. The only genuine stale plugin mislabels were two internal comments that still described current combo-hotkey behavior as the "legacy global_shortcut" path:

- `src/types/shortcuts.ts` — `trigger_kind` doc said `(legacy global_shortcut)`.
- `src/lib/shortcut-display.ts` — referenced "the `global_shortcut` path".

Both reworded to describe the native keytrigger engine. **Comment-only — no API, type, or behavior change.** The `set_global_shortcut` command name and user-facing "global shortcut" copy are intentionally KEPT.

Backend `retired global-shortcut`/`retired OS shortcut registrar` comments are accurate history (not misleading) and overlap the #100 hotkey fix, so they're left as-is.

Gates: `pnpm typecheck` + `pnpm lint` clean.

Independent of #100 — mergeable in any order.