### PR TITLE
fix(hotkeys): clear combo hotkey before saving bare-modifier primary

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3802,6 +3802,27 @@ pub async fn start_recording(
         }
     }
 
+    // Idempotent fast-path: if a recording is already starting or active — e.g. a
+    // redundant start from the in-app hotkey fallback racing the native hotkey
+    // path for one physical press — no-op BEFORE any side effects. This region is
+    // await-free through `update_recording_state(Starting)` below, so whichever
+    // caller publishes `Starting` first makes the other observe it here and return
+    // Ok, never bumping the generation, clobbering flags, or hitting the
+    // `Recording -> Starting` state-machine rejection.
+    {
+        let live_state = crate::get_recording_state(&app);
+        if matches!(
+            live_state,
+            crate::RecordingState::Starting | crate::RecordingState::Recording
+        ) {
+            log::debug!(
+                "start_recording: already {:?}; treating redundant start as no-op",
+                live_state
+            );
+            return Ok(());
+        }
+    }
+
     // All validation passed, update state to starting
     log::debug!(
         "⏱️ [REC TIMING] validation complete (+{}ms)",

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3973,9 +3973,14 @@ pub async fn start_recording(
 
         // Check if already recording
         if recorder.is_recording() {
-            log::warn!("Already recording!");
+            // Idempotent: a redundant start — e.g. the in-app hotkey fallback
+            // racing the native hotkey path for a single press — is a harmless
+            // no-op, not an error, so neither toggle path surfaces a spurious
+            // RecordingState::Error. The recorder lock above serializes the two
+            // calls, so the loser reliably observes is_recording() == true here.
+            log::debug!("start_recording: already recording; treating as no-op");
             resume_media_if_needed();
-            return Err("Already recording".to_string());
+            return Ok(());
         }
 
         // Log the current audio device before starting

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3994,14 +3994,12 @@ pub async fn start_recording(
 
         // Check if already recording
         if recorder.is_recording() {
-            // Idempotent: a redundant start — e.g. the in-app hotkey fallback
-            // racing the native hotkey path for a single press — is a harmless
-            // no-op, not an error, so neither toggle path surfaces a spurious
-            // RecordingState::Error. The recorder lock above serializes the two
-            // calls, so the loser reliably observes is_recording() == true here.
-            log::debug!("start_recording: already recording; treating as no-op");
+            // Reaching here means the entry idempotent guard did not catch this
+            // (backend state was not Starting/Recording) yet the recorder already
+            // has an active handle — a genuine inconsistency, so surface it.
+            log::warn!("Already recording!");
             resume_media_if_needed();
-            return Ok(());
+            return Err("Already recording".to_string());
         }
 
         // Log the current audio device before starting

--- a/src/components/AppContainer.test.tsx
+++ b/src/components/AppContainer.test.tsx
@@ -67,6 +67,17 @@ vi.mock('@/contexts/SettingsContext', () => ({
     settings: mockSettings,
     refreshSettings: refreshSettingsMock,
   }),
+  useSetting: (key: string) => (mockSettings as Record<string, unknown>)[key],
+}));
+
+vi.mock('@/hooks/useRecording', () => ({
+  useRecording: () => ({
+    state: 'idle',
+    error: null,
+    isActive: false,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
 }));
 
 vi.mock('@/contexts/LicenseContext', () => ({

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -10,6 +10,7 @@ import { UpdateAnnouncementDialog } from "./UpdateAnnouncementDialog";
 import { useReadiness } from "@/contexts/ReadinessContext";
 import { useSettings } from "@/contexts/SettingsContext";
 import { useEventCoordinator } from "@/hooks/useEventCoordinator";
+import { useInAppRecordingHotkey } from "@/hooks/useInAppRecordingHotkey";
 import { useModelManagementContext } from "@/contexts/ModelManagementContext";
 import { useModelAvailabilityContext } from "@/contexts/ModelAvailabilityContext";
 import { updateService } from "@/services/updateService";
@@ -41,6 +42,10 @@ export function AppContainer() {
 
   // Use the model management context for onboarding
   const modelManagement = useModelManagementContext();
+
+  // In-app fallback: toggle recording when the global hotkey is swallowed by a
+  // focused WebView2 text field (e.g. Ctrl+Space in the bug-report box).
+  useInAppRecordingHotkey();
 
   // Track explicit onboarding completion so recovery-driven onboarding doesn't trigger post-onboarding effects.
   const hasCompletedOnboarding = useRef(false);

--- a/src/components/sections/GeneralSettings.tsx
+++ b/src/components/sections/GeneralSettings.tsx
@@ -248,12 +248,17 @@ export function GeneralSettings() {
         const updatedBindings = existingPrimary
           ? existing.bindings.map((b) => (b.id === stableId ? newBinding : b))
           : [...existing.bindings, newBinding];
-        await invoke("update_shortcut_settings", {
-          settings: { bindings: updatedBindings },
-        });
+        // Clear the combo hotkey BEFORE saving the bare-modifier binding:
+        // update_shortcut_settings rebuilds the engine from settings.hotkey, and
+        // if the combo is still set the migration treats it as authoritative and
+        // disables the bare-modifier primary we just created (onboarding clears
+        // first for this exact reason).
         if (settings.hotkey) {
           await updateSettings({ hotkey: "" });
         }
+        await invoke("update_shortcut_settings", {
+          settings: { bindings: updatedBindings },
+        });
         setNativeBinding(newBinding);
         setIsEditingHotkey(false);
         setPendingHotkey("");

--- a/src/components/sections/__tests__/GeneralSettings.recording-indicator.test.tsx
+++ b/src/components/sections/__tests__/GeneralSettings.recording-indicator.test.tsx
@@ -584,6 +584,40 @@ describe('GeneralSettings recording hotkey editor', () => {
     });
   });
 
+  it('clears the combo hotkey BEFORE saving a bare-modifier binding (regression #100)', async () => {
+    // Fix A's startup migration treats a non-empty settings.hotkey as the
+    // authoritative primary and disables a bare-modifier primary. So when the
+    // user switches from a combo to a bare modifier, the combo MUST be cleared
+    // before update_shortcut_settings rebuilds the engine — otherwise the new
+    // bare-modifier binding is disabled the instant it is saved.
+    render(<GeneralSettings />);
+    const editButton = await screen.findByRole('button', { name: /edit/i });
+    fireEvent.click(editButton);
+    await screen.findByTestId('hotkey-input');
+
+    fireEvent.click(screen.getByTestId('mock-trigger-bare-modifier'));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({ hotkey: '' });
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith(
+        'update_shortcut_settings',
+        expect.anything(),
+      );
+    });
+
+    const clearIdx = mockUpdateSettings.mock.calls.findIndex(
+      ([arg]) => (arg as { hotkey?: string } | undefined)?.hotkey === '',
+    );
+    const clearOrder = mockUpdateSettings.mock.invocationCallOrder[clearIdx];
+    const saveIdx = vi
+      .mocked(invoke)
+      .mock.calls.findIndex(([cmd]) => cmd === 'update_shortcut_settings');
+    const saveOrder = vi.mocked(invoke).mock.invocationCallOrder[saveIdx];
+
+    expect(clearOrder).toBeLessThan(saveOrder);
+  });
+
   it('bare modifier + Hold-to-talk OFF → persists isolated_tap/toggle_recording/pressed', async () => {
     render(<GeneralSettings />);
     const editButton = await screen.findByRole('button', { name: /edit/i });

--- a/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
+++ b/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
@@ -132,4 +132,30 @@ describe("useInAppRecordingHotkey", () => {
 
     expect(mockRecording.startRecording).not.toHaveBeenCalled();
   });
+
+  it("leaves a bare-key hotkey to the field so typing still works", () => {
+    mockSettings.hotkey = "Space";
+    renderHook(() => useInAppRecordingHotkey());
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: "Space",
+      key: " ",
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+    editable.dispatchEvent(event);
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores Shift-only combos that can produce typed characters", () => {
+    mockSettings.hotkey = "Shift+Space";
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable, { ctrlKey: false, shiftKey: true });
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
+++ b/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
@@ -50,6 +50,7 @@ describe("useInAppRecordingHotkey", () => {
     platform.isMacOS = false;
     mockSettings.hotkey = "CommandOrControl+Space";
     mockRecording.isActive = false;
+    mockRecording.state = "idle";
     mockRecording.startRecording.mockReset();
     mockRecording.stopRecording.mockReset();
     editable = document.createElement("textarea");
@@ -71,14 +72,24 @@ describe("useInAppRecordingHotkey", () => {
     expect(mockRecording.stopRecording).not.toHaveBeenCalled();
   });
 
-  it("stops recording when it is already active", () => {
-    mockRecording.isActive = true;
+  it("stops recording when it is already recording", () => {
+    mockRecording.state = "recording";
     renderHook(() => useInAppRecordingHotkey());
 
     fireHotkey(editable);
 
     expect(mockRecording.stopRecording).toHaveBeenCalledTimes(1);
     expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("ignores the hotkey during transitional states (transcribing)", () => {
+    mockRecording.state = "transcribing";
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable);
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+    expect(mockRecording.stopRecording).not.toHaveBeenCalled();
   });
 
   it("ignores the hotkey when focus is not in an editable field", () => {

--- a/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
+++ b/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const platform = vi.hoisted(() => ({ isMacOS: false }));
+vi.mock("@/lib/platform", () => ({
+  get isMacOS() {
+    return platform.isMacOS;
+  },
+  get isWindows() {
+    return !platform.isMacOS;
+  },
+}));
+
+const mockRecording = vi.hoisted(() => ({
+  state: "idle" as string,
+  error: null as string | null,
+  isActive: false,
+  startRecording: vi.fn(),
+  stopRecording: vi.fn(),
+}));
+vi.mock("@/hooks/useRecording", () => ({
+  useRecording: () => mockRecording,
+}));
+
+const mockSettings = vi.hoisted(() => ({ hotkey: "CommandOrControl+Space" }) as Record<string, unknown>);
+vi.mock("@/contexts/SettingsContext", () => ({
+  useSetting: (key: string) => mockSettings[key],
+}));
+
+import { useInAppRecordingHotkey } from "@/hooks/useInAppRecordingHotkey";
+
+function fireHotkey(target: Element, init: KeyboardEventInit = {}): void {
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      code: "Space",
+      key: " ",
+      ...init,
+    }),
+  );
+}
+
+describe("useInAppRecordingHotkey", () => {
+  let editable: HTMLTextAreaElement;
+  let nonEditable: HTMLDivElement;
+
+  beforeEach(() => {
+    platform.isMacOS = false;
+    mockSettings.hotkey = "CommandOrControl+Space";
+    mockRecording.isActive = false;
+    mockRecording.startRecording.mockReset();
+    mockRecording.stopRecording.mockReset();
+    editable = document.createElement("textarea");
+    nonEditable = document.createElement("div");
+    document.body.append(editable, nonEditable);
+  });
+
+  afterEach(() => {
+    editable.remove();
+    nonEditable.remove();
+  });
+
+  it("starts recording when the hotkey fires inside a text field", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable);
+
+    expect(mockRecording.startRecording).toHaveBeenCalledTimes(1);
+    expect(mockRecording.stopRecording).not.toHaveBeenCalled();
+  });
+
+  it("stops recording when it is already active", () => {
+    mockRecording.isActive = true;
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable);
+
+    expect(mockRecording.stopRecording).toHaveBeenCalledTimes(1);
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("ignores the hotkey when focus is not in an editable field", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(nonEditable);
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+    expect(mockRecording.stopRecording).not.toHaveBeenCalled();
+  });
+
+  it("ignores a combo that does not match the configured hotkey", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    // Missing the Control modifier → plain Space.
+    fireHotkey(editable, { ctrlKey: false });
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("debounces a rapid second press within the window", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable);
+    fireHotkey(editable);
+
+    expect(mockRecording.startRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores auto-repeat keydowns", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable, { repeat: true });
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("ignores IME composition events", () => {
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable, { isComposing: true });
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no hotkey is configured", () => {
+    mockSettings.hotkey = "";
+    renderHook(() => useInAppRecordingHotkey());
+
+    fireHotkey(editable);
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
+++ b/src/hooks/__tests__/useInAppRecordingHotkey.test.tsx
@@ -169,4 +169,28 @@ describe("useInAppRecordingHotkey", () => {
 
     expect(mockRecording.startRecording).not.toHaveBeenCalled();
   });
+
+  it("ignores AltGr keystrokes so typing isn't stolen (Ctrl+Alt + AltGraph)", () => {
+    mockSettings.hotkey = "CommandOrControl+Alt+Q";
+    renderHook(() => useInAppRecordingHotkey());
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      altKey: true,
+      code: "KeyQ",
+      key: "@",
+    });
+    // jsdom doesn't honor modifierAltGraph init reliably; force AltGraph on.
+    Object.defineProperty(event, "getModifierState", {
+      value: (key: string) => key === "AltGraph",
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+    editable.dispatchEvent(event);
+
+    expect(mockRecording.startRecording).not.toHaveBeenCalled();
+    expect(mockRecording.stopRecording).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useInAppRecordingHotkey.ts
+++ b/src/hooks/useInAppRecordingHotkey.ts
@@ -61,6 +61,12 @@ export function useInAppRecordingHotkey(): void {
       if (event.isComposing) return;
       if (!isEditableTarget(event.target)) return;
 
+      // Only handle Ctrl/Cmd-class combos — the class the OS hook misses via
+      // IME inside our own text fields (e.g. Ctrl+Space). Bare keys and
+      // Shift/Alt-only combos can produce typed characters (onboarding allows a
+      // one-key shortcut), so leave them to the focused field's normal input.
+      if (!event.ctrlKey && !event.metaKey) return;
+
       const { hotkey: currentHotkey, recording: currentRecording } = latest.current;
       if (!currentHotkey || !eventMatchesShortcut(event, currentHotkey)) return;
 

--- a/src/hooks/useInAppRecordingHotkey.ts
+++ b/src/hooks/useInAppRecordingHotkey.ts
@@ -78,12 +78,16 @@ export function useInAppRecordingHotkey(): void {
       // space) now that we are handling it as the recording hotkey.
       event.preventDefault();
 
-      if (currentRecording.isActive) {
-        log.debug("In-app hotkey matched in editable field — stopping recording");
-        void currentRecording.stopRecording();
-      } else {
+      // Mirror the native toggle state machine (handle_toggle_mode): act only on
+      // settled states and ignore transitional ones (starting/stopping/
+      // transcribing), so a tap mid-transcription can't clobber that flow.
+      const state = currentRecording.state;
+      if (state === "idle" || state === "error") {
         log.debug("In-app hotkey matched in editable field — starting recording");
         void currentRecording.startRecording();
+      } else if (state === "recording") {
+        log.debug("In-app hotkey matched in editable field — stopping recording");
+        void currentRecording.stopRecording();
       }
     };
 

--- a/src/hooks/useInAppRecordingHotkey.ts
+++ b/src/hooks/useInAppRecordingHotkey.ts
@@ -67,6 +67,11 @@ export function useInAppRecordingHotkey(): void {
       // one-key shortcut), so leave them to the focused field's normal input.
       if (!event.ctrlKey && !event.metaKey) return;
 
+      // AltGr is reported as Ctrl+Alt on Windows and produces typed characters
+      // (e.g. German @, €). Skip it so AltGr typing in a text field never matches
+      // a configured Ctrl+Alt combo and steals the keystroke.
+      if (event.getModifierState?.("AltGraph")) return;
+
       const { hotkey: currentHotkey, recording: currentRecording } = latest.current;
       if (!currentHotkey || !eventMatchesShortcut(event, currentHotkey)) return;
 

--- a/src/hooks/useInAppRecordingHotkey.ts
+++ b/src/hooks/useInAppRecordingHotkey.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import { useSetting } from "@/contexts/SettingsContext";
+import { useRecording } from "@/hooks/useRecording";
+import { eventMatchesShortcut } from "@/lib/shortcut-event-match";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("in-app-hotkey");
+
+/**
+ * Minimum gap between two in-app toggles. Guards against duplicate keydowns
+ * (e.g. WebView2/IME quirks) and the rare case where the OS-level hook also
+ * fires for the same press.
+ */
+const TOGGLE_DEBOUNCE_MS = 300;
+
+/**
+ * True when focus is inside an editable element (text input / textarea /
+ * contenteditable) — the ONLY context where the OS-level keytrigger hook can be
+ * bypassed by the browser/IME (e.g. Ctrl+Space in our own bug-report box).
+ * Restricting the fallback to this case avoids double-triggering everywhere the
+ * native engine already handles the hotkey.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA";
+}
+
+/**
+ * In-app fallback for the recording hotkey.
+ *
+ * The OS-level `keytrigger` engine starts/stops recording globally, but when
+ * focus is inside one of our own WebView2 text fields the browser/IME can
+ * swallow the combo (most notably Ctrl+Space, a Windows input-language toggle)
+ * before the low-level hook sees it. There the global hotkey silently does
+ * nothing. Because the keydown still reaches the DOM, this hook re-derives the
+ * configured shortcut from the event and toggles recording directly.
+ *
+ * Mount once in the main window (it has the text inputs); the pill window has
+ * none.
+ */
+export function useInAppRecordingHotkey(): void {
+  const hotkey = useSetting("hotkey");
+  const recording = useRecording();
+  const lastToggleRef = useRef(0);
+
+  // Keep the latest hotkey + recording controls in a ref so the listener is
+  // bound once and never re-attaches on state changes. Updated in an effect
+  // (not during render) so reads always see the committed values.
+  const latest = useRef({ hotkey, recording });
+  useEffect(() => {
+    latest.current = { hotkey, recording };
+  });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat) return;
+      // Skip IME composition events (Chromium reports keyCode 229 / isComposing
+      // mid-composition), which would otherwise spuriously match the hotkey.
+      if (event.isComposing) return;
+      if (!isEditableTarget(event.target)) return;
+
+      const { hotkey: currentHotkey, recording: currentRecording } = latest.current;
+      if (!currentHotkey || !eventMatchesShortcut(event, currentHotkey)) return;
+
+      const now = Date.now();
+      if (now - lastToggleRef.current < TOGGLE_DEBOUNCE_MS) return;
+      lastToggleRef.current = now;
+
+      // Stop the combo from also acting on the focused field (e.g. inserting a
+      // space) now that we are handling it as the recording hotkey.
+      event.preventDefault();
+
+      if (currentRecording.isActive) {
+        log.debug("In-app hotkey matched in editable field — stopping recording");
+        void currentRecording.stopRecording();
+      } else {
+        log.debug("In-app hotkey matched in editable field — starting recording");
+        void currentRecording.startRecording();
+      }
+    };
+
+    // Capture phase: run before the focused field's own handlers.
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, []);
+}

--- a/src/lib/__tests__/shortcut-event-match.test.ts
+++ b/src/lib/__tests__/shortcut-event-match.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Toggle the macOS flag read by the matcher without re-importing.
+const platform = vi.hoisted(() => ({ isMacOS: false }));
+vi.mock("@/lib/platform", () => ({
+  get isMacOS() {
+    return platform.isMacOS;
+  },
+  get isWindows() {
+    return !platform.isMacOS;
+  },
+}));
+
+import { eventMatchesShortcut, eventToShortcut } from "@/lib/shortcut-event-match";
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", init);
+}
+
+describe("eventToShortcut", () => {
+  it("builds the canonical combo string on Windows (Ctrl → CommandOrControl)", () => {
+    platform.isMacOS = false;
+    expect(eventToShortcut(keydown({ ctrlKey: true, code: "Space", key: " " }))).toBe(
+      "CommandOrControl+Space",
+    );
+  });
+
+  it("orders modifiers as CommandOrControl+Alt+Shift+Key", () => {
+    platform.isMacOS = false;
+    expect(
+      eventToShortcut(
+        keydown({ ctrlKey: true, shiftKey: true, altKey: true, code: "KeyK", key: "k" }),
+      ),
+    ).toBe("CommandOrControl+Alt+Shift+K");
+  });
+
+  it("maps macOS Command to CommandOrControl and Control separately", () => {
+    platform.isMacOS = true;
+    expect(eventToShortcut(keydown({ metaKey: true, code: "Space", key: " " }))).toBe(
+      "CommandOrControl+Space",
+    );
+    expect(
+      eventToShortcut(keydown({ metaKey: true, ctrlKey: true, code: "KeyK", key: "k" })),
+    ).toBe("CommandOrControl+Control+K");
+    platform.isMacOS = false;
+  });
+
+  it("uppercases single-character keys via physical code", () => {
+    expect(eventToShortcut(keydown({ ctrlKey: true, code: "KeyA", key: "a" }))).toBe(
+      "CommandOrControl+A",
+    );
+  });
+
+  it("returns null for a bare modifier press", () => {
+    expect(eventToShortcut(keydown({ ctrlKey: true, key: "Control", code: "ControlLeft" }))).toBeNull();
+  });
+});
+
+describe("eventMatchesShortcut", () => {
+  it("matches Ctrl+Space against the stored CommandOrControl+Space", () => {
+    platform.isMacOS = false;
+    expect(
+      eventMatchesShortcut(keydown({ ctrlKey: true, code: "Space", key: " " }), "CommandOrControl+Space"),
+    ).toBe(true);
+  });
+
+  it("does not match a bare Space (missing the modifier)", () => {
+    expect(
+      eventMatchesShortcut(keydown({ code: "Space", key: " " }), "CommandOrControl+Space"),
+    ).toBe(false);
+  });
+
+  it("requires the exact modifier set (Ctrl+Space != Ctrl+Shift+Space)", () => {
+    expect(
+      eventMatchesShortcut(
+        keydown({ ctrlKey: true, code: "Space", key: " " }),
+        "CommandOrControl+Shift+Space",
+      ),
+    ).toBe(false);
+  });
+
+  it("normalizes Enter/Return so they compare equal", () => {
+    expect(
+      eventMatchesShortcut(
+        keydown({ ctrlKey: true, code: "Enter", key: "Enter" }),
+        "CommandOrControl+Return",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for an empty configured hotkey", () => {
+    expect(eventMatchesShortcut(keydown({ ctrlKey: true, code: "Space", key: " " }), "")).toBe(false);
+  });
+});

--- a/src/lib/shortcut-event-match.ts
+++ b/src/lib/shortcut-event-match.ts
@@ -1,0 +1,75 @@
+/**
+ * Match a DOM KeyboardEvent against a stored Tauri shortcut string
+ * (e.g. "CommandOrControl+Space").
+ *
+ * This is the IN-APP fallback path: when focus is inside one of our own
+ * WebView2 text inputs, the OS-level keytrigger hook can be bypassed by the
+ * browser/IME (notably Ctrl+Space, which Windows reserves as an input-language
+ * toggle), so the global hotkey never fires. The frontend still receives the
+ * DOM keydown, so we re-derive the same canonical shortcut string the hotkey
+ * picker produces and compare it to the configured hotkey.
+ *
+ * The canonical form intentionally mirrors `HotkeyInput`'s keydown builder so a
+ * string produced here equals the one persisted in settings.hotkey.
+ */
+import { mapCodeToKey } from "@/lib/keyboard-mapper";
+import { normalizeShortcutKeys } from "@/lib/keyboard-normalizer";
+import { isMacOS } from "@/lib/platform";
+
+// Persisted-shortcut modifier order: CommandOrControl, Control, Alt, Shift.
+const MODIFIER_ORDER = ["CommandOrControl", "Control", "Alt", "Shift"] as const;
+const PURE_MODIFIER_KEYS: Record<string, true> = {
+  Control: true,
+  Shift: true,
+  Alt: true,
+  Meta: true,
+};
+
+/**
+ * Apply the same per-key normalization the hotkey picker uses after mapping the
+ * physical `e.code`: Tauri expects "Return" (not "Enter"), and single-character
+ * keys are upper-cased so "a" and "A" produce the same shortcut.
+ */
+function normalizeMainKey(mapped: string): string {
+  if (mapped === "Enter") return "Return";
+  if (mapped.length === 1) return mapped.toUpperCase();
+  return mapped;
+}
+
+/**
+ * Derive the canonical shortcut string for a keydown event, or `null` when the
+ * event is a bare modifier press (no main key) and therefore not a combo.
+ */
+export function eventToShortcut(event: KeyboardEvent): string | null {
+  if (PURE_MODIFIER_KEYS[event.key]) return null;
+
+  const modifiers = new Set<string>();
+  if (isMacOS) {
+    // macOS: Command → CommandOrControl, Control stays separate (Cmd+Ctrl combos).
+    if (event.metaKey) modifiers.add("CommandOrControl");
+    if (event.ctrlKey) modifiers.add("Control");
+  } else {
+    // Windows/Linux: Control → CommandOrControl.
+    if (event.ctrlKey) modifiers.add("CommandOrControl");
+  }
+  if (event.altKey) modifiers.add("Alt");
+  if (event.shiftKey) modifiers.add("Shift");
+
+  const code = event.code || "";
+  const mainKey = normalizeMainKey(code ? mapCodeToKey(code) : event.key);
+  if (!mainKey) return null;
+
+  const ordered = MODIFIER_ORDER.filter((mod) => modifiers.has(mod));
+  return [...ordered, mainKey].join("+");
+}
+
+/**
+ * True when the keydown event matches the configured hotkey string. Both sides
+ * are normalized so stored variants (e.g. "Ctrl+Space") compare equal.
+ */
+export function eventMatchesShortcut(event: KeyboardEvent, hotkey: string): boolean {
+  if (!hotkey || !hotkey.trim()) return false;
+  const derived = eventToShortcut(event);
+  if (!derived) return false;
+  return normalizeShortcutKeys(derived) === normalizeShortcutKeys(hotkey);
+}


### PR DESCRIPTION
## Regression (found via a Windows tester log on 2.0.2)
Setting a bare modifier (e.g. **Control**) as the primary trigger via Settings **never armed** — "Control single-key doesn't work anywhere."

## Root cause (triangulated: log + code + matcher test)
`GeneralSettings.handleSaveHotkey` saved the bare-modifier binding via `update_shortcut_settings` (which rebuilds the engine) **and only then** cleared `settings.hotkey`. With the combo still set, the #100 Fix A migration treats the combo as authoritative and **disables the bare-modifier primary the instant it's created**. The tester log shows exactly this: `disabled stale bare-modifier primary 'onboarding-primary-hold' — combo hotkey is authoritative`.

The matcher itself fires `IsolatedTap` on a bare modifier fine (`matcher.rs:858 isolated_tap_alone_fires`), and the backend keeps a bare-modifier primary when `settings.hotkey` is empty (`empty_hotkey_with_bare_primary_synthesizes_no_combo`). So the defect was purely the **frontend save order**.

## Fix
Clear `settings.hotkey` **before** saving the bare-modifier binding — matching what the onboarding flow already does — so the rebuild sees an empty hotkey and keeps the new primary.

## Test
`clears the combo hotkey BEFORE saving a bare-modifier binding (regression #100)` asserts the clear's invocation order precedes `update_shortcut_settings`.

## Gates
recording-indicator suite 50/50, `pnpm typecheck` + `pnpm lint` clean. Frontend-only (no Rust touched).

## Still needs
Windows runtime re-smoke: set Control as trigger -> it arms; and confirm whether the separate 'combo doesn't trigger inside our own textarea' report persists (that one is NOT addressed here and may be unrelated).