### PR TITLE
fix(windows): guard tao monitor queries against stale-handle panic (Os 1461)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1170,13 +1170,14 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Calculate center-bottom position for pill/toast
                 let (pos_x, pos_y) = {
-                    let (screen_width, screen_height) = if let Ok(Some(monitor)) = app.primary_monitor() {
+                    let (screen_width, screen_height) = crate::utils::monitor::catch_monitor_panic(|| {
+                        let monitor = app.primary_monitor().ok().flatten()?;
                         let size = monitor.size();
                         let scale = monitor.scale_factor();
-                        (size.width as f64 / scale, size.height as f64 / scale)
-                    } else {
-                        (1440.0, 900.0) // Fallback
-                    };
+                        Some((size.width as f64 / scale, size.height as f64 / scale))
+                    })
+                    .flatten()
+                    .unwrap_or((1440.0, 900.0));
 
                     let pill_width = 80.0;  // Sized for 3-dot pill (active state with padding)
                     let pill_height = 40.0;

--- a/src-tauri/src/utils/display_watcher.rs
+++ b/src-tauri/src/utils/display_watcher.rs
@@ -118,15 +118,16 @@ impl DisplayWatcher {
 #[cfg(target_os = "windows")]
 fn get_windows_monitor_info(app: &AppHandle) -> (usize, u32, u32) {
     // Returns (monitor_count, primary_width, primary_height)
-    if let Ok(monitors) = app.available_monitors() {
-        let count = monitors.len();
-        if let Ok(Some(primary)) = app.primary_monitor() {
+    crate::utils::monitor::catch_monitor_panic(|| {
+        let count = app.available_monitors().map(|m| m.len()).unwrap_or(0);
+        if let Some(primary) = app.primary_monitor().ok().flatten() {
             let size = primary.size();
-            return (count, size.width, size.height);
+            (count, size.width, size.height)
+        } else {
+            (count, 0, 0)
         }
-        return (count, 0, 0);
-    }
-    (0, 0, 0)
+    })
+    .unwrap_or((0, 0, 0))
 }
 
 impl Drop for DisplayWatcher {

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -2,6 +2,7 @@
 pub mod diagnostics;
 pub mod display_watcher;
 pub mod logger;
+pub mod monitor;
 pub mod network_diagnostics;
 pub mod onboarding_logger;
 pub mod system_monitor;

--- a/src-tauri/src/utils/monitor.rs
+++ b/src-tauri/src/utils/monitor.rs
@@ -1,0 +1,16 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Run a monitor query and return `None` if it panics on a stale monitor handle.
+///
+/// tao 0.34.5 builds each `Monitor` by calling `GetMonitorInfoW().unwrap()`,
+/// which panics with `Os { code: 1461 }` (ERROR_INVALID_MONITOR_HANDLE) when a
+/// monitor handle goes stale mid display-change (dock / undock / sleep). tauri
+/// runs that conversion *inside* `current_monitor()` / `primary_monitor()` /
+/// `available_monitors()` (tauri-runtime-wry `From<MonitorHandleWrapper>`), so
+/// the panic surfaces during the query — not at `Monitor::size()`, which only
+/// returns an already-cached field. Wrapping the whole query + field read lets a
+/// transient stale handle fall back gracefully instead of crashing the app.
+/// (`profile.release` is `panic = "unwind"`, so the catch is effective.)
+pub fn catch_monitor_panic<T>(query: impl FnOnce() -> T) -> Option<T> {
+    catch_unwind(AssertUnwindSafe(query)).ok()
+}

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -634,18 +634,28 @@ impl WindowManager {
     fn get_screen_dimensions(&self) -> (f64, f64) {
         // Try to get monitor from main window
         if let Some(main_window) = self.get_main_window() {
-            if let Ok(Some(monitor)) = main_window.current_monitor() {
+            if let Some(dims) = crate::utils::monitor::catch_monitor_panic(|| {
+                let monitor = main_window.current_monitor().ok().flatten()?;
                 let size = monitor.size();
                 let scale = monitor.scale_factor();
-                return (size.width as f64 / scale, size.height as f64 / scale);
+                Some((size.width as f64 / scale, size.height as f64 / scale))
+            })
+            .flatten()
+            {
+                return dims;
             }
         }
 
         // Fallback to primary monitor
-        if let Ok(Some(monitor)) = self.app_handle.primary_monitor() {
+        if let Some(dims) = crate::utils::monitor::catch_monitor_panic(|| {
+            let monitor = self.app_handle.primary_monitor().ok().flatten()?;
             let size = monitor.size();
             let scale = monitor.scale_factor();
-            return (size.width as f64 / scale, size.height as f64 / scale);
+            Some((size.width as f64 / scale, size.height as f64 / scale))
+        })
+        .flatten()
+        {
+            return dims;
         }
 
         // Safe default for common screen sizes


### PR DESCRIPTION
## Problem
A real user on **2.0.1** reported a fatal panic:
```
called `Result::unwrap()` on an `Err` value:
Os { code: 1461, ... "Invalid monitor handle" }   (ERROR_INVALID_MONITOR_HANDLE)
```

## Root cause (confirmed in dependency source)
`tao 0.34.5` (`platform_impl/windows/monitor.rs`) builds monitor info with `get_monitor_info(self.hmonitor()).unwrap()` inside `MonitorHandle::size()`/`position()`. When a monitor handle goes **stale during a display change** (laptop dock/undock/sleep), `GetMonitorInfoW` returns `Err(1461)` and tao panics.

`tauri-runtime-wry` runs that tao conversion **inside** `current_monitor()` / `primary_monitor()` / `available_monitors()` (`From<MonitorHandleWrapper> for Monitor`, lib.rs:592-597) — so the panic surfaces **at monitor acquisition**, not at `Monitor::size()` (which just returns a cached field). Our own monitor code already used `if let Ok(Some(..))` guards, but those don't catch a *panic*. The most frequent hit point is `DisplayWatcher`'s 2 s poll that repositions floating windows on display changes — exactly when handles are stale.

## Fix
Add `crate::utils::monitor::catch_monitor_panic` (a `catch_unwind` wrapper) and wrap each monitor query (acquisition + field read) at all 4 sites:
- `window_manager.rs::get_screen_dimensions` (current + primary)
- `lib.rs` pill/toast startup positioning
- `utils/display_watcher.rs::get_windows_monitor_info` (the 2 s poll)

A transient stale handle now falls back to the **existing default dimensions** instead of crashing. `scale_factor()` and all fallback values are unchanged. `profile.release` is `panic = "unwind"`, so the catch is effective. Wrapping the *whole* query (not just `size()`) keeps it robust regardless of where tauri/tao computes the value.

## Honesty note
The 2.0.1 crash stack is unsymbolicated (PDBs ship in 2.0.2, #98), so "the crash fires via our monitor query" is a strong **inference** grounded in the tao/tauri source above — not a symbolicated proof. This guard covers the evidenced/most-likely path; **2.0.2's symbolication is what will confirm efficacy** (crashes stop = fixed; any continue = we get a real stack to diagnose a tao-internal path a userland guard can't reach).

## Testing
- `cargo clippy -- -D warnings`: clean (cross-platform sites + helper).
- `display_watcher.rs` is `#[cfg(windows)]` — validated by the Windows CI job (can't compile locally on macOS).
- Happy path unchanged: the `Some` branch computes dimensions exactly as before.