### PR TITLE
fix(cloud-stt): Deepgram key validation, Soniox v5, cloud model in UI

### DIFF
--- a/src-tauri/src/cloud_stt/common.rs
+++ b/src-tauri/src/cloud_stt/common.rs
@@ -26,7 +26,10 @@ impl SttError {
     pub(crate) fn message(&self, provider_name: &str) -> String {
         match self {
             Self::Auth => format!("Invalid {} API key", provider_name),
-            Self::ModelUnavailable => format!("{}: model unavailable for this key", provider_name),
+            Self::ModelUnavailable => format!(
+                "{}: model unavailable for this API key — check the key's scopes and your plan/credits",
+                provider_name
+            ),
             Self::RateLimited => {
                 format!("{} rate limit reached. Try again shortly.", provider_name)
             }
@@ -40,7 +43,9 @@ impl SttError {
 
 pub(super) fn classify_status(status: reqwest::StatusCode) -> SttError {
     match status {
-        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => SttError::Auth,
+        reqwest::StatusCode::UNAUTHORIZED => SttError::Auth,
+        // 403 = valid key lacking scope or model access, not a bad key.
+        reqwest::StatusCode::FORBIDDEN => SttError::ModelUnavailable,
         reqwest::StatusCode::NOT_FOUND => SttError::ModelUnavailable,
         reqwest::StatusCode::REQUEST_TIMEOUT => SttError::Timeout,
         reqwest::StatusCode::TOO_MANY_REQUESTS => SttError::RateLimited,
@@ -155,7 +160,14 @@ where
 pub(super) async fn log_http_body(resp: reqwest::Response, label: &str) -> SttError {
     let status = resp.status();
     let err = classify_status(status);
-    log::warn!("{label}: HTTP {status}; response body suppressed for authenticated request");
+    // Body holds err_msg + a request id, never the key — safe to log, needed to diagnose.
+    let body = resp.text().await.unwrap_or_default();
+    let snippet: String = body.chars().take(500).collect();
+    if snippet.trim().is_empty() {
+        log::warn!("{label}: HTTP {status} (empty response body)");
+    } else {
+        log::warn!("{label}: HTTP {status}; response body: {snippet}");
+    }
     err
 }
 

--- a/src-tauri/src/cloud_stt/deepgram.rs
+++ b/src-tauri/src/cloud_stt/deepgram.rs
@@ -10,9 +10,10 @@ use tauri::AppHandle;
 
 pub(super) const MODEL: &str = "nova-3";
 
+// /v1/auth/token validates any key; /v1/projects needs `project:read`, absent on default tokens.
 pub(super) async fn validate_key(key: &str) -> Result<(), String> {
     common::get_validate(
-        "https://api.deepgram.com/v1/projects",
+        "https://api.deepgram.com/v1/auth/token",
         AuthScheme::Token,
         key,
         "Deepgram",

--- a/src-tauri/src/cloud_stt/mod.rs
+++ b/src-tauri/src/cloud_stt/mod.rs
@@ -78,6 +78,16 @@ impl CloudProvider {
             Self::Cohere => "Cohere",
         }
     }
+    /// Underlying transcription model id used by this provider (single source of truth).
+    pub fn model_name(self) -> &'static str {
+        match self {
+            Self::Soniox => soniox::MODEL,
+            Self::Openai => openai::MODEL,
+            Self::Groq => groq::MODEL,
+            Self::Deepgram => deepgram::MODEL,
+            Self::Cohere => cohere::MODEL,
+        }
+    }
 
     /// Display label for menus/history, e.g. `Soniox (Cloud)`.
     pub fn cloud_label(self) -> String {

--- a/src-tauri/src/cloud_stt/soniox.rs
+++ b/src-tauri/src/cloud_stt/soniox.rs
@@ -4,7 +4,7 @@ use super::common::{self, AuthScheme};
 use std::path::Path;
 use tauri::AppHandle;
 
-pub(super) const MODEL: &str = "stt-async-v3";
+pub(super) const MODEL: &str = "stt-async-v5";
 
 const BASE: &str = "https://api.soniox.com/v1";
 
@@ -489,7 +489,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(payload["model"].as_str(), Some("stt-async-v3"));
+        assert_eq!(payload["model"].as_str(), Some("stt-async-v5"));
         assert_eq!(payload["file_id"].as_str(), Some("file_123"));
         assert_eq!(
             payload["language_hints"].as_array().unwrap()[0].as_str(),
@@ -518,7 +518,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(payload["model"].as_str(), Some("stt-async-v3"));
+        assert_eq!(payload["model"].as_str(), Some("stt-async-v5"));
         assert!(payload.get("language_hints").is_none());
         assert!(payload.get("context").is_none());
     }

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -417,6 +417,7 @@ pub struct UnifiedModelInfo {
     pub engine: String,
     pub kind: String,
     pub requires_setup: bool,
+    pub underlying_model: Option<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -747,6 +748,7 @@ fn convert_whisper_model(name: String, info: ModelInfo) -> UnifiedModelInfo {
         engine: ModelEngine::Whisper.as_str().to_string(),
         kind: "local".to_string(),
         requires_setup: false,
+        underlying_model: None,
     }
 }
 
@@ -764,6 +766,7 @@ fn convert_parakeet_model(status: ParakeetModelStatus) -> UnifiedModelInfo {
         engine: ModelEngine::Parakeet.as_str().to_string(),
         kind: "local".to_string(),
         requires_setup: false,
+        underlying_model: None,
     }
 }
 
@@ -793,6 +796,7 @@ fn collect_cloud_models(app: &AppHandle) -> Vec<UnifiedModelInfo> {
                 engine: provider.id().to_string(),
                 kind: "cloud".to_string(),
                 requires_setup: !has_key,
+                underlying_model: Some(provider.model_name().to_string()),
             }
         })
         .collect()

--- a/src/components/sections/ModelsSection.tsx
+++ b/src/components/sections/ModelsSection.tsx
@@ -589,6 +589,11 @@ export function ModelsSection({
                 <h3 className={cn("truncate text-sm font-semibold tracking-tight", isActive && "text-sage")}>
                   {provider?.displayName || provider?.providerName || getModelDisplayName(name, { [name]: model }) || name}
                 </h3>
+                {isCloudModel(model) && model.underlying_model && (
+                  <Badge variant="outline" className="gap-1 font-mono text-muted-foreground">
+                    {model.underlying_model}
+                  </Badge>
+                )}
                 {isActive && (
                   <Badge className="gap-1 bg-sage text-sage-foreground">
                     <CheckCircle className="size-3" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface LocalModelInfo extends BaseModelInfo {
 
 export interface CloudModelInfo extends BaseModelInfo {
   kind: 'cloud';
+  /** Backend-sourced transcription model id used by this cloud provider. */
+  underlying_model?: string | null;
 }
 
 export type ModelInfo = LocalModelInfo | CloudModelInfo;


### PR DESCRIPTION
## Why
User set up Deepgram, key is valid, but it failed with a "check your API key"-type error; also asked to surface which model each cloud provider uses, and whether models are current. Verified all 5 providers against live docs (Deepgram/Soniox/OpenAI/Groq/Cohere).

## Changes
**1. Deepgram key validation (the failure root cause)**
- `validate_key` now hits **`GET /v1/auth/token`** (Deepgram's documented key-check endpoint) instead of `/v1/projects`.
- `/v1/projects` requires the **`project:read`** scope, which default transcription tokens (`member` role / `usage:write`) **do not have** (it's behind "Advanced" when minting a key). So valid keys were rejected as "Invalid API key" before they could ever transcribe.

**2. Cloud STT error handling (`common.rs`)**
- HTTP **403 → `ModelUnavailable`** (not `Auth`): a key lacking scope/model access is no longer mislabeled "invalid key". 401 still → `Auth`.
- **Log the response body** on failure (provider `err_msg` + request id — never contains the key) so scope/entitlement/billing failures are diagnosable instead of opaque. (It was suppressed, which is why the log showed nothing.)

**3. Soniox model `stt-async-v3` → `stt-async-v5`**
- v4 retired 2026-06-30; **v5** is the current GA async model, API-compatible (model-name swap only). Tests updated.

**4. Show the model in the UI (single-sourced)**
- New `CloudProvider::model_name()` + `UnifiedModelInfo.underlying_model` expose each provider's `MODEL` const to the frontend; `ModelsSection` renders it as a mono badge on each cloud card. No model strings duplicated in TS — UI can't drift.

## Verification status (from doc cross-check)
- **Soniox / Groq / Cohere / Deepgram**: implementations correct & current (endpoint, auth, audio upload, model, response parsing all verified against current docs).
- **OpenAI** `gpt-4o-transcribe`: request/auth/parsing correct, but the model is flagged on a retirement track (Azure lifecycle). **Not changed** — `gpt-4o-mini-transcribe` is the cheaper model, not an upgrade; left for a deliberate decision.
- Minor (not changed): Deepgram `diarize=true` is deprecated in favor of `diarize_model` but works via back-compat.

## Gates
- Backend: `cargo clippy -D warnings` clean; `cargo test cloud_stt` 35 passed.
- Frontend: typecheck + lint clean; 582 tests pass.

## Note for the user
With the body now logged, reproducing the Deepgram failure will print Deepgram's exact reason. The likely fixes on the account side: ensure the key has the **`usage:write`** scope and the project/plan has **nova-3** access + credits.