### PR TITLE
feat: warm active cloud STT + LLM provider connections at recording start

### DIFF
--- a/src-tauri/src/cloud_stt/common.rs
+++ b/src-tauri/src/cloud_stt/common.rs
@@ -113,7 +113,8 @@ fn build_client(timeout: std::time::Duration) -> reqwest::Client {
     builder.build().unwrap_or_else(|_| reqwest::Client::new())
 }
 
-static SHARED_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| build_client(REQUEST_TIMEOUT));
+static SHARED_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(|| build_client(REQUEST_TIMEOUT));
 
 pub(super) fn http_client() -> reqwest::Client {
     SHARED_CLIENT.clone()

--- a/src-tauri/src/cloud_stt/common.rs
+++ b/src-tauri/src/cloud_stt/common.rs
@@ -113,8 +113,19 @@ fn build_client(timeout: std::time::Duration) -> reqwest::Client {
     builder.build().unwrap_or_else(|_| reqwest::Client::new())
 }
 
+static SHARED_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| build_client(REQUEST_TIMEOUT));
+
 pub(super) fn http_client() -> reqwest::Client {
-    build_client(REQUEST_TIMEOUT)
+    SHARED_CLIENT.clone()
+}
+
+// Fire-and-forget: warm the shared pool's DNS+TCP+TLS for `origin`; result ignored.
+pub(super) async fn warm_origin(origin: &str) {
+    let _ = http_client()
+        .head(origin)
+        .timeout(std::time::Duration::from_secs(8))
+        .send()
+        .await;
 }
 
 /// The per-request deadline applied to **validation** traffic. Production uses
@@ -321,7 +332,7 @@ pub(super) async fn openai_compatible_transcribe(
 
 #[cfg(test)]
 mod tests {
-    use super::{get_validate, openai_compatible_transcribe, AuthScheme, SttError};
+    use super::{get_validate, openai_compatible_transcribe, warm_origin, AuthScheme, SttError};
     use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -759,5 +770,28 @@ mod tests {
             "validation took {elapsed:?}; the short deadline is not in effect"
         );
         assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn warm_origin_sends_head_and_is_nonfatal_on_error() {
+        // 200: the HEAD goes out on the shared client and completes (not a no-op).
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        warm_origin(&server.uri()).await;
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+
+        // 500: fire-and-forget swallows the non-2xx; still exactly one request.
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+        warm_origin(&server.uri()).await;
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 }

--- a/src-tauri/src/cloud_stt/mod.rs
+++ b/src-tauri/src/cloud_stt/mod.rs
@@ -105,6 +105,22 @@ impl CloudProvider {
         }
     }
 
+    /// HTTPS origin whose connection transcription will reuse.
+    pub fn base_origin(self) -> &'static str {
+        match self {
+            Self::Soniox => "https://api.soniox.com",
+            Self::Openai => "https://api.openai.com",
+            Self::Groq => "https://api.groq.com",
+            Self::Deepgram => "https://api.deepgram.com",
+            Self::Cohere => "https://api.cohere.com",
+        }
+    }
+
+    /// Pre-warm the connection so the next transcription reuses a hot pool.
+    pub async fn warm_up(self) {
+        common::warm_origin(self.base_origin()).await;
+    }
+
     /// Catalog speed hint (0-9, higher = faster).
     pub fn speed_score(self) -> u8 {
         match self {
@@ -251,5 +267,14 @@ mod tests {
             );
             assert!(seen.insert(provider.key_name()), "duplicate key name");
         }
+    }
+
+    #[test]
+    fn base_origin_covers_each_provider() {
+        assert_eq!(CloudProvider::Soniox.base_origin(), "https://api.soniox.com");
+        assert_eq!(CloudProvider::Openai.base_origin(), "https://api.openai.com");
+        assert_eq!(CloudProvider::Groq.base_origin(), "https://api.groq.com");
+        assert_eq!(CloudProvider::Deepgram.base_origin(), "https://api.deepgram.com");
+        assert_eq!(CloudProvider::Cohere.base_origin(), "https://api.cohere.com");
     }
 }

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -31,6 +31,17 @@ const CUSTOM_NO_AUTH_KEY: &str = "ai_custom_no_auth";
 const LEGACY_OPENAI_BASE_URL_KEY: &str = "ai_openai_base_url";
 const LEGACY_OPENAI_NO_AUTH_KEY: &str = "ai_openai_no_auth";
 
+// One pooled reqwest::Client shared across the LLM enhancement path so the connection pool stays hot across calls.
+static SHARED_AI_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    reqwest::Client::builder()
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+});
+
+fn shared_ai_client() -> reqwest::Client {
+    SHARED_AI_CLIENT.clone()
+}
+
 pub(crate) fn ai_provider_key_names() -> Vec<String> {
     launch_providers()
         .into_iter()
@@ -533,9 +544,7 @@ pub async fn validate_ai_api_key(
             None
         }
     });
-    let http_client = reqwest::Client::builder()
-        .build()
-        .map_err(|error| format!("Failed to build validation client: {error}"))?;
+    let http_client = shared_ai_client();
     let executor = AiExecutor::new(http_client, key_resolver, custom_base_url, no_auth);
     let request = AiPolishRequest {
         provider_id: provider.clone(),
@@ -868,6 +877,49 @@ fn custom_no_auth_from_settings(app: &tauri::AppHandle, has_key: bool) -> bool {
         .unwrap_or(!has_key)
 }
 
+// Native adapter endpoints are internal; hardcode best-effort origin hosts (a wrong host is a harmless no-op HEAD).
+fn native_origin(provider_id: &str) -> Option<&'static str> {
+    match catalog::adapter_name(provider_id)? {
+        "OpenAI" => Some("https://api.openai.com"),
+        "Anthropic" => Some("https://api.anthropic.com"),
+        "Gemini" => Some("https://generativelanguage.googleapis.com"),
+        _ => None,
+    }
+}
+
+fn url_origin(raw: &str) -> Option<String> {
+    let url = reqwest::Url::parse(raw).ok()?;
+    let host = url.host_str()?;
+    Some(match url.port() {
+        Some(port) => format!("{}://{}:{}", url.scheme(), host, port),
+        None => format!("{}://{}", url.scheme(), host),
+    })
+}
+
+pub(crate) fn ai_provider_origin(app: &tauri::AppHandle, provider_id: &str) -> Option<String> {
+    if provider_id == PROVIDER_CUSTOM {
+        return url_origin(&custom_base_url_from_settings(app)?);
+    }
+    native_origin(provider_id).map(str::to_string)
+}
+
+pub(crate) fn ai_provider_has_key(provider_id: &str) -> bool {
+    API_KEY_CACHE
+        .lock()
+        .map(|cache| cache.contains_key(&format!("ai_api_key_{provider_id}")))
+        .unwrap_or(false)
+}
+
+pub(crate) async fn warm_ai_provider(app: tauri::AppHandle, provider_id: String) {
+    if let Some(origin) = ai_provider_origin(&app, &provider_id) {
+        let _ = shared_ai_client()
+            .head(&origin)
+            .timeout(std::time::Duration::from_secs(8))
+            .send()
+            .await;
+    }
+}
+
 fn selected_ai_provider_and_model(
     app: &tauri::AppHandle,
 ) -> Result<(String, String), AiProviderError> {
@@ -969,9 +1021,7 @@ fn executor_for_provider(
     }
 
     let key_resolver: AiKeyResolver = Arc::new(move |provider_id| keys.get(provider_id).cloned());
-    let http_client = reqwest::Client::builder()
-        .build()
-        .map_err(|_| AiProviderError::Internal)?;
+    let http_client = shared_ai_client();
     Ok((
         AiExecutor::new(http_client, key_resolver, custom_base_url, custom_no_auth),
         runtime_provider,
@@ -1344,6 +1394,27 @@ mod tests {
         assert!(validate_provider_name("test provider").is_err());
         assert!(validate_provider_name("test@provider").is_err());
         assert!(validate_provider_name("").is_err());
+    }
+
+    #[test]
+    fn native_origin_maps_known_providers() {
+        assert_eq!(native_origin("openai"), Some("https://api.openai.com"));
+        assert_eq!(native_origin("anthropic"), Some("https://api.anthropic.com"));
+        assert_eq!(native_origin("gemini"), Some("https://generativelanguage.googleapis.com"));
+        assert_eq!(native_origin("custom"), None);
+    }
+
+    #[test]
+    fn url_origin_extracts_scheme_host_port() {
+        assert_eq!(
+            url_origin("https://api.example.com/v1"),
+            Some("https://api.example.com".to_string())
+        );
+        assert_eq!(
+            url_origin("http://localhost:8080/x"),
+            Some("http://localhost:8080".to_string())
+        );
+        assert_eq!(url_origin("not a url"), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -888,17 +888,15 @@ fn native_origin(provider_id: &str) -> Option<&'static str> {
 }
 
 fn url_origin(raw: &str) -> Option<String> {
-    let url = reqwest::Url::parse(raw).ok()?;
-    let host = url.host_str()?;
-    Some(match url.port() {
-        Some(port) => format!("{}://{}:{}", url.scheme(), host, port),
-        None => format!("{}://{}", url.scheme(), host),
-    })
+    let origin = reqwest::Url::parse(raw).ok()?.origin();
+    origin.is_tuple().then(|| origin.ascii_serialization())
 }
 
 pub(crate) fn ai_provider_origin(app: &tauri::AppHandle, provider_id: &str) -> Option<String> {
     if provider_id == PROVIDER_CUSTOM {
-        return url_origin(&custom_base_url_from_settings(app)?);
+        // Mirror executor_for_provider: custom falls back to DEFAULT_OPENAI_BASE_URL when unset.
+        let base = custom_base_url_from_settings(app).unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
+        return url_origin(&base);
     }
     native_origin(provider_id).map(str::to_string)
 }
@@ -1413,6 +1411,10 @@ mod tests {
         assert_eq!(
             url_origin("http://localhost:8080/x"),
             Some("http://localhost:8080".to_string())
+        );
+        assert_eq!(
+            url_origin("http://[::1]:11434/v1"),
+            Some("http://[::1]:11434".to_string())
         );
         assert_eq!(url_origin("not a url"), None);
     }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3911,20 +3911,19 @@ pub async fn start_recording(
         config.ai_enabled,
         config.current_model
     );
-    // Warm the active cloud provider's connection so transcription reuses a hot pool (skipped when an online remote handles it).
-    let remote_online = {
-        let remote = app.state::<AsyncMutex<RemoteSettings>>();
-        let remote = remote.lock().await;
-        remote
-            .get_active_connection()
-            .is_some_and(|c| matches!(c.status, crate::remote::settings::ConnectionStatus::Online))
-    };
-    if !remote_online {
-        if let Some(provider) = crate::cloud_stt::CloudProvider::from_id(&config.current_engine) {
-            if crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
-                tokio::spawn(async move { provider.warm_up().await; });
+    // Warm the active cloud provider's connection so the first transcription skips the handshake (skipped when a remote handles dispatch).
+    if let Some(provider) = crate::cloud_stt::CloudProvider::from_id(&config.current_engine) {
+        let app = app.clone();
+        tokio::spawn(async move {
+            let remote_active = {
+                let remote = app.state::<AsyncMutex<RemoteSettings>>();
+                let guard = remote.lock().await;
+                guard.get_active_connection().is_some()
+            };
+            if !remote_active && crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
+                provider.warm_up().await;
             }
-        }
+        });
     }
     // Get app data directory for recordings
     let recordings_dir = match app.path().app_data_dir() {

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3911,6 +3911,12 @@ pub async fn start_recording(
         config.ai_enabled,
         config.current_model
     );
+    // Warm the active cloud provider's connection so transcription reuses a hot pool.
+    if let Some(provider) = crate::cloud_stt::CloudProvider::from_id(&config.current_engine) {
+        if crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
+            tokio::spawn(async move { provider.warm_up().await; });
+        }
+    }
     // Get app data directory for recordings
     let recordings_dir = match app.path().app_data_dir() {
         Ok(dir) => dir.join("recordings"),

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3925,6 +3925,18 @@ pub async fn start_recording(
             }
         });
     }
+    // Warm the LLM enhancement connection too (runs post-transcription regardless of the STT engine).
+    if config.ai_enabled && !config.ai_provider.is_empty() {
+        let app = app.clone();
+        let provider_id = config.ai_provider.clone();
+        tokio::spawn(async move {
+            if provider_id == crate::ai::providers::PROVIDER_CUSTOM
+                || crate::commands::ai::ai_provider_has_key(&provider_id)
+            {
+                crate::commands::ai::warm_ai_provider(app, provider_id).await;
+            }
+        });
+    }
     // Get app data directory for recordings
     let recordings_dir = match app.path().app_data_dir() {
         Ok(dir) => dir.join("recordings"),

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -3911,10 +3911,19 @@ pub async fn start_recording(
         config.ai_enabled,
         config.current_model
     );
-    // Warm the active cloud provider's connection so transcription reuses a hot pool.
-    if let Some(provider) = crate::cloud_stt::CloudProvider::from_id(&config.current_engine) {
-        if crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
-            tokio::spawn(async move { provider.warm_up().await; });
+    // Warm the active cloud provider's connection so transcription reuses a hot pool (skipped when an online remote handles it).
+    let remote_online = {
+        let remote = app.state::<AsyncMutex<RemoteSettings>>();
+        let remote = remote.lock().await;
+        remote
+            .get_active_connection()
+            .is_some_and(|c| matches!(c.status, crate::remote::settings::ConnectionStatus::Online))
+    };
+    if !remote_online {
+        if let Some(provider) = crate::cloud_stt::CloudProvider::from_id(&config.current_engine) {
+            if crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
+                tokio::spawn(async move { provider.warm_up().await; });
+            }
         }
     }
     // Get app data directory for recordings


### PR DESCRIPTION
## What
Two changes, **STT only**:
1. **Shared pooled HTTP client** — `cloud_stt::common::http_client()` rebuilt a fresh `reqwest::Client` on every call, discarding the connection pool each request. Now a single process-wide `SHARED_CLIENT` (`std::sync::LazyLock`) is reused.
2. **Connection warm-up at recording start** — `start_recording` fires a non-blocking, fire-and-forget HEAD to the active cloud provider's origin (gated on `config.current_engine` being a cloud provider that has a stored key), so the first transcription reuses a hot DNS+TCP+TLS connection.

## Why
Every cloud transcription paid the full DNS+TCP+TLS handshake (~100–400ms). Warm-up overlaps that handshake with the user's speech; the shared client also speeds back-to-back dictations.

## Design notes
- `warm_origin` runs on the **shared** client with a per-request `.timeout(8s)` override — stays on the pool transcription reuses, without inheriting the 30-min request timeout (avoids the throwaway-pool no-op).
- Gated on `current_engine` (engine id), **not** `current_model` (model name) — `from_id("nova-3")` is `None`, so gating on the model name would silently never fire.
- Validation client path untouched (its short 30s timeout + the deadline regression test stay green).
- **LLM warm-up deferred** — its clients are per-request across `ai/*` and it runs post-STT; separate follow-up.

## Tests / gates
- `cargo clippy -- -D warnings`: clean.
- `cargo test cloud_stt`: **37 passed** — incl. 2 new (`warm_origin` non-fatal on 200/500 + actually sends; `base_origin` exhaustive) and the validation-deadline regression still green.

## Caveat
reqwest's pool idle-timeout is ~90s; warm-up fires at recording-start (seconds before transcription) for perfect overlap, so the idle-timeout is a non-issue for the common case.