### PR TITLE
fix(hotkey): let external tools (Stream Deck) trigger the hotkey via injected input

### DIFF
--- a/src-tauri/crates/keytrigger/src/backend/windows.rs
+++ b/src-tauri/crates/keytrigger/src/backend/windows.rs
@@ -122,6 +122,15 @@ impl KeyEventSource for WinKeyboardHook {
     }
 }
 
+/// Whether a hook event is one of VoiceTypr's OWN synthetic keystrokes: injected
+/// (`LLKHF_INJECTED`) AND carrying our [`crate::INJECTED_SIGNATURE`] in `dwExtraInfo`.
+/// External tools' injected input (Stream Deck, AutoHotkey, PowerToys) sets the
+/// injected flag but NOT our signature, so it returns false and is allowed through.
+#[inline]
+fn is_own_injection(flags: u32, extra_info: usize) -> bool {
+    (flags & LLKHF_INJECTED.0) != 0 && extra_info == crate::INJECTED_SIGNATURE
+}
+
 unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     if code == HC_ACTION as i32 {
         // A panic unwinding out of an `extern "system"` (Win32) callback is UB
@@ -130,15 +139,17 @@ unsafe extern "system" fn keyboard_hook_proc(code: i32, wparam: WPARAM, lparam: 
         // the key was consumed; a panic is treated as "not consumed" (pass through).
         let consumed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let kb = unsafe { &*(lparam.0 as *const KBDLLHOOKSTRUCT) };
-            // Ignore synthetic keystrokes (LLKHF_INJECTED). rdev's post-transcription
-            // paste is injected via SendInput, which sets this flag; forwarding it to
-            // the matcher could re-trigger a ModifierHold hotkey on Ctrl (the paste
-            // modifier), spuriously satisfy a DoubleTap/Chord, or wedge state if a
-            // synthetic key-up is missed. A WH_KEYBOARD_LL hook cannot see the
-            // injecting pid, so this also drops other tools' injected input (e.g.
-            // AutoHotkey firing the hotkey) — accepted: global hotkeys are physical
-            // input only. Still chain CallNextHookEx for pass-through.
-            if (kb.flags.0 & LLKHF_INJECTED.0) != 0 {
+            // Ignore only VoiceTypr's OWN synthetic keystrokes. The post-transcription
+            // paste (commands::text::paste_windows) injects Ctrl+V via SendInput stamped
+            // with crate::INJECTED_SIGNATURE in dwExtraInfo; forwarding it to the matcher
+            // could re-trigger a ModifierHold on Ctrl (the paste modifier), spuriously
+            // satisfy a DoubleTap/Chord, or wedge state if a synthetic key-up is missed. A
+            // WH_KEYBOARD_LL hook cannot see the injecting pid, so we distinguish by
+            // dwExtraInfo rather than a blanket LLKHF_INJECTED drop — that blanket drop
+            // regressed external tools (Stream Deck, AutoHotkey, PowerToys) that fire the
+            // hotkey via SendInput (which sets LLKHF_INJECTED). Their events carry a
+            // different dwExtraInfo and pass through. Still chain CallNextHookEx below.
+            if is_own_injection(kb.flags.0, kb.dwExtraInfo) {
                 return false;
             }
             let message = wparam.0 as u32;
@@ -363,4 +374,29 @@ fn modset_from_down(down: &HashSet<u32>) -> ModSet {
         m.insert(Modifier::Meta);
     }
     m
+}
+
+#[cfg(test)]
+mod injection_filter_tests {
+    use super::*;
+
+    #[test]
+    fn own_injection_is_ignored() {
+        // Injected flag + our signature => our own paste => ignored.
+        assert!(is_own_injection(LLKHF_INJECTED.0, crate::INJECTED_SIGNATURE));
+    }
+
+    #[test]
+    fn external_injection_passes_through() {
+        // Injected flag but NOT our signature (Stream Deck / AutoHotkey) => allowed.
+        assert!(!is_own_injection(LLKHF_INJECTED.0, 0));
+        assert!(!is_own_injection(LLKHF_INJECTED.0, 0xDEAD_BEEF));
+    }
+
+    #[test]
+    fn physical_key_passes_through() {
+        // No injected flag => physical key => allowed regardless of extra_info.
+        assert!(!is_own_injection(0, 0));
+        assert!(!is_own_injection(0, crate::INJECTED_SIGNATURE));
+    }
 }

--- a/src-tauri/crates/keytrigger/src/lib.rs
+++ b/src-tauri/crates/keytrigger/src/lib.rs
@@ -27,3 +27,12 @@ pub use types::{
     EngineError, KeyPhase, KeySpec, ModSet, Modifier, ModifierSpec, NamedKey, RawKeyEvent, Side,
     TapKey, Trigger, TriggerEvent, TriggerId,
 };
+
+/// Sentinel written to a synthetic keystroke's `dwExtraInfo` (Windows) to mark it
+/// as VoiceTypr's OWN injection — currently the post-transcription Ctrl+V paste in
+/// `commands::text::paste_windows`. The low-level keyboard hook ignores keystrokes
+/// carrying this value (so our paste can't re-trigger a hotkey), while external
+/// tools' injected input (Stream Deck, AutoHotkey, PowerToys) carries a different
+/// `dwExtraInfo` and passes through to trigger hotkeys normally. Value is arbitrary
+/// but must be non-zero; both the injector and the hook reference this one constant.
+pub const INJECTED_SIGNATURE: usize = 0x5654_5950; // "VTYP"

--- a/src-tauri/src/commands/text.rs
+++ b/src-tauri/src/commands/text.rs
@@ -701,7 +701,7 @@ fn paste_windows() -> Result<(), String> {
                         KEYBD_EVENT_FLAGS(0)
                     },
                     time: 0,
-                    dwExtraInfo: 0,
+                    dwExtraInfo: keytrigger::INJECTED_SIGNATURE,
                 },
             },
         }


### PR DESCRIPTION
## The bug

Reported on **2.0.4 (Windows)**: shortcuts triggered via **Stream Deck no longer start recording**. Same class affects AutoHotkey / PowerToys — any tool that fires the hotkey by *injecting* the keystroke.

## Root cause

A regression from the `global-shortcut → keytrigger` migration. The old Tauri `RegisterHotKey` path responded to injected keystrokes; the new `WH_KEYBOARD_LL` hook drops **every** injected keystroke (`LLKHF_INJECTED`). That blanket drop exists to stop VoiceTypr's own post-transcription Ctrl+V paste from re-triggering the hotkey — but it also eats legitimate external injected input. Stream Deck triggers the hotkey via `SendInput` (which sets `LLKHF_INJECTED`), so the hook silently swallowed it. The existing code comment even acknowledged it would drop "AutoHotkey firing the hotkey."

## The fix

Distinguish **our own** injection from everyone else's, instead of a blanket drop:

- **`keytrigger`**: add `pub const INJECTED_SIGNATURE` and an `is_own_injection(flags, extra_info)` helper.
- **`commands::text::paste_windows`**: stamp all four Ctrl+V `SendInput` events (and the retry path) with `dwExtraInfo = INJECTED_SIGNATURE`.
- **hook**: ignore an injected event only when it carries our signature. External tools' injected events use a different `dwExtraInfo` → they pass through to the matcher and fire the hotkey, exactly as before the migration. Our paste still never reaches the matcher (no feedback loop).
- **tests**: unit tests locking the own / external / physical classification so this can't silently regress again.

## Verification

- ✅ `cargo check --target x86_64-pc-windows-msvc -p keytrigger --tests` — clean
- ✅ `cargo clippy --target x86_64-pc-windows-msvc -p keytrigger --tests -- -D warnings` — zero warnings (note: CI only clippies macOS, so this Windows-target pass is not otherwise covered)
- ✅ Independent adversarial review — confirmed `paste_windows` is the **only** Win32 keyboard injection in the tree (rdev/enigo are Linux-only, CGEvent is macOS), so nothing else leaks into the matcher.

## Still required before merge/release

**Manual Windows smoke test** (behavior gate — cannot be run on the macOS dev box): confirm Stream Deck now triggers recording, and that normal typing / the transcription paste still behave. Build a test installer via the `release.yml` **dry-run** (`windows-x64` artifact).

Scope: hotfix branched off `main`, independent of the in-flight `integrate/perf-ux-2026-07` refactor branch. 3 files, +55/−10.
