### PR TITLE
feat(audio): add shadow speech evidence telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ git add -A && git commit -m "feat: description"
 8. **Sidecar builds**: Parakeet Swift sidecar built via `build.rs` during `tauri build`
 
 9. **Windows CI is compile-only for Rust tests**: `cargo test --no-run` — Windows runtime behavior (hotkeys, Vulkan sidecar) needs manual smoke on a real machine.
+10. **Speech evidence is asymmetric**: live RMS/`SilenceDetector` and normalizer modulation are strong positive evidence that speech occurred, but failure to detect speech is not proof of silence (short/soft speech may miss thresholds). Instrument candidate pre-engine gates in shadow mode first; never reject uncertain audio or add a second full-buffer scan. Reuse recorder/normalizer aggregates and keep enforcement Beta-only until false negatives are ruled out.
 
 ## Key Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,8 @@ git add -A && git commit -m "feat: description"
 8. **Sidecar builds**: Parakeet Swift sidecar built via `build.rs` during `tauri build`
 
 9. **Windows CI is compile-only for Rust tests**: `cargo test --no-run` — Windows runtime behavior (hotkeys, Vulkan sidecar) needs manual smoke on a real machine.
-10. **Speech evidence is asymmetric**: live RMS/`SilenceDetector` and normalizer modulation are strong positive evidence that speech occurred, but failure to detect speech is not proof of silence (short/soft speech may miss thresholds). Instrument candidate pre-engine gates in shadow mode first; never reject uncertain audio or add a second full-buffer scan. Reuse recorder/normalizer aggregates and keep enforcement Beta-only until false negatives are ruled out.
-
 10. **Updater channels are a release contract, not only UI**: Stable stays on `releases/latest/download/latest.json`; Beta uses a separate fixed manifest and SemVer prereleases (`X.Y.Z-beta.N`). Betas must be published GitHub prereleases, never ordinary releases; Store/MSIX builds remain Store-managed. Switching Beta → Stable changes future checks and does not downgrade an installed beta.
+11. **Speech evidence is asymmetric**: live RMS/`SilenceDetector` and normalizer modulation are strong positive evidence that speech occurred, but failure to detect speech is not proof of silence (short/soft speech may miss thresholds). Instrument candidate pre-engine gates in shadow mode first; never reject uncertain audio or add a second full-buffer scan. Reuse recorder/normalizer aggregates and keep enforcement Beta-only until false negatives are ruled out.
 
 ## Key Files
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -6,6 +6,7 @@ pub mod recorder;
 pub mod recorder_watchdog;
 pub mod resampler;
 pub mod silence_detector;
+pub mod speech_evidence;
 
 #[cfg(test)]
 mod converter_tests;

--- a/src-tauri/src/audio/normalizer.rs
+++ b/src-tauri/src/audio/normalizer.rs
@@ -22,9 +22,41 @@ const MIN_TRAILING_SILENCE_TO_TRIM_WINDOWS: usize = 35; // 700ms
 const RETAIN_TRAILING_CONTEXT_WINDOWS: usize = 15; // keep 300ms after last speech
 const MIN_RETAINED_SAMPLES_AFTER_TRIM: usize = TARGET_RATE as usize / 2; // 0.5s floor
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NormalizationMetrics {
+    pub pre_gain_peak: f32,
+    pub speech_like_modulation: bool,
+    pub applied_gain: f32,
+    pub input_duration_ms: u64,
+    pub output_duration_ms: u64,
+    pub trimmed_duration_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct NormalizedAudio {
+    pub path: PathBuf,
+    pub metrics: NormalizationMetrics,
+}
+
+fn duration_ms(sample_count: usize) -> u64 {
+    (sample_count as u64)
+        .saturating_mul(1000)
+        .checked_div(u64::from(TARGET_RATE))
+        .unwrap_or(0)
+}
+
 /// Normalize any WAV (our recorder output) to the local engine contract:
 /// WAV PCM S16LE, mono, 16 kHz, peak-normalized with speech-gated quiet-clip gain and light dither.
 pub fn normalize_to_whisper_wav(input_wav: &Path, out_dir: &Path) -> Result<PathBuf, String> {
+    normalize_to_whisper_wav_with_metrics(input_wav, out_dir).map(|audio| audio.path)
+}
+
+/// Normalize audio and return evidence already computed while preparing the
+/// engine input. Metric collection adds no separate full-buffer traversal.
+pub fn normalize_to_whisper_wav_with_metrics(
+    input_wav: &Path,
+    out_dir: &Path,
+) -> Result<NormalizedAudio, String> {
     if !input_wav.exists() {
         return Err(format!("Input WAV does not exist: {:?}", input_wav));
     }
@@ -82,6 +114,7 @@ pub fn normalize_to_whisper_wav(input_wav: &Path, out_dir: &Path) -> Result<Path
     // (voiced energy AND genuine near-silent gaps); steady noise/tones stay at 10x.
     let peak = resampled.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
     let speech_like = has_speech_like_modulation(&resampled);
+    let input_duration_ms = duration_ms(resampled.len());
     let gain = peak_normalization_gain(peak, speech_like);
     let normalized: Vec<f32> = if (gain - 1.0).abs() > 1e-3 {
         resampled
@@ -93,6 +126,15 @@ pub fn normalize_to_whisper_wav(input_wav: &Path, out_dir: &Path) -> Result<Path
     };
 
     let trimmed = trim_trailing_silence_for_whisper(&normalized);
+    let output_duration_ms = duration_ms(trimmed.len());
+    let metrics = NormalizationMetrics {
+        pre_gain_peak: peak,
+        speech_like_modulation: speech_like,
+        applied_gain: gain,
+        input_duration_ms,
+        output_duration_ms,
+        trimmed_duration_ms: input_duration_ms.saturating_sub(output_duration_ms),
+    };
 
     // Quantize to i16 with TPDF dither
     let mut rng = rand::thread_rng();
@@ -124,7 +166,10 @@ pub fn normalize_to_whisper_wav(input_wav: &Path, out_dir: &Path) -> Result<Path
         .finalize()
         .map_err(|e| format!("WAV finalize failed: {}", e))?;
 
-    Ok(out_path)
+    Ok(NormalizedAudio {
+        path: out_path,
+        metrics,
+    })
 }
 
 pub(crate) fn peak_normalization_gain(peak: f32, speech_like: bool) -> f32 {

--- a/src-tauri/src/audio/normalizer_tests.rs
+++ b/src-tauri/src/audio/normalizer_tests.rs
@@ -1,4 +1,6 @@
-use super::normalizer::{normalize_to_whisper_wav, peak_normalization_gain};
+use super::normalizer::{
+    normalize_to_whisper_wav, normalize_to_whisper_wav_with_metrics, peak_normalization_gain,
+};
 use hound::{SampleFormat, WavSpec, WavWriter};
 use std::f32::consts::PI;
 use std::fs;
@@ -566,5 +568,71 @@ fn preserves_tail_above_silence_threshold() {
 
     let _ = fs::remove_file(&input);
     let _ = fs::remove_file(&out_path);
+    let _ = fs::remove_dir_all(&out_dir);
+}
+
+#[test]
+fn normalization_metrics_reuse_gapped_speech_decision_and_gain() {
+    let input = temp_file("metrics_gapped_speech_in.wav");
+    let out_dir = temp_file("metrics_gapped_speech_out_dir");
+    let _ = fs::create_dir_all(&out_dir);
+    write_gapped_tone_wav(&input, 16_000, 1.2, 0.03, 220.0, 200, 120);
+
+    let normalized =
+        normalize_to_whisper_wav_with_metrics(&input, &out_dir).expect("normalize with metrics");
+
+    assert!(normalized.metrics.speech_like_modulation);
+    assert!(normalized.metrics.pre_gain_peak > 0.02);
+    assert!(normalized.metrics.applied_gain > 10.0);
+    assert_eq!(normalized.metrics.input_duration_ms, 1200);
+    assert_eq!(normalized.metrics.output_duration_ms, 1200);
+    assert_eq!(normalized.metrics.trimmed_duration_ms, 0);
+
+    let _ = fs::remove_file(&input);
+    let _ = fs::remove_file(&normalized.path);
+    let _ = fs::remove_dir_all(&out_dir);
+}
+
+#[test]
+fn normalization_metrics_report_digital_silence_without_inventing_speech() {
+    let input = temp_file("metrics_silence_in.wav");
+    let out_dir = temp_file("metrics_silence_out_dir");
+    let _ = fs::create_dir_all(&out_dir);
+    write_silence_wav(&input, 16_000, 1.0);
+
+    let normalized =
+        normalize_to_whisper_wav_with_metrics(&input, &out_dir).expect("normalize with metrics");
+
+    assert_eq!(normalized.metrics.pre_gain_peak, 0.0);
+    assert!(!normalized.metrics.speech_like_modulation);
+    assert_eq!(normalized.metrics.applied_gain, 1.0);
+    assert_eq!(normalized.metrics.input_duration_ms, 1000);
+    assert_eq!(normalized.metrics.output_duration_ms, 1000);
+    assert_eq!(normalized.metrics.trimmed_duration_ms, 0);
+
+    let _ = fs::remove_file(&input);
+    let _ = fs::remove_file(&normalized.path);
+    let _ = fs::remove_dir_all(&out_dir);
+}
+
+#[test]
+fn normalization_metrics_account_for_trimmed_tail() {
+    let input = temp_file("metrics_trim_in.wav");
+    let out_dir = temp_file("metrics_trim_out_dir");
+    let _ = fs::create_dir_all(&out_dir);
+    write_speech_then_silence_wav(&input, 16_000, 1.0, 2.0, 0.5, 440.0);
+
+    let normalized =
+        normalize_to_whisper_wav_with_metrics(&input, &out_dir).expect("normalize with metrics");
+
+    assert_eq!(normalized.metrics.input_duration_ms, 3000);
+    assert!(normalized.metrics.trimmed_duration_ms >= 1500);
+    assert_eq!(
+        normalized.metrics.output_duration_ms + normalized.metrics.trimmed_duration_ms,
+        normalized.metrics.input_duration_ms
+    );
+
+    let _ = fs::remove_file(&input);
+    let _ = fs::remove_file(&normalized.path);
     let _ = fs::remove_dir_all(&out_dir);
 }

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -1,6 +1,6 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -178,10 +178,125 @@ fn chunk_capacity_for(max_frames: usize, channels: usize) -> usize {
     max_frames.saturating_mul(channels).max(CHUNK_CAPACITY_MIN)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CaptureAudioMetrics {
+    pub sample_count: u64,
+    pub duration_ms: u64,
+    pub rms: f64,
+    pub peak: f32,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub speech_detected: bool,
+}
+
+#[derive(Debug, Default)]
+struct CaptureMetricsAccumulator {
+    sample_count: AtomicU64,
+    sum_squares_bits: AtomicU64,
+    peak_bits: AtomicU32,
+}
+
+impl CaptureMetricsAccumulator {
+    /// Observe one CPAL callback buffer and return its RMS. This is the callback's
+    /// only sample traversal; the returned RMS feeds the existing level/silence path.
+    fn observe(&self, samples: &[f32]) -> f32 {
+        let mut callback_sum_squares = 0.0f32;
+        let mut aggregate_sum_squares = 0.0f64;
+        let mut peak = 0.0f32;
+        for &sample in samples {
+            callback_sum_squares += sample * sample;
+            let sample_f64 = sample as f64;
+            aggregate_sum_squares += sample_f64 * sample_f64;
+            peak = peak.max(sample.abs());
+        }
+
+        if !samples.is_empty() {
+            self.sample_count
+                .fetch_add(samples.len() as u64, Ordering::Relaxed);
+            atomic_add_f64(&self.sum_squares_bits, aggregate_sum_squares);
+            atomic_max_f32(&self.peak_bits, peak);
+        }
+        (callback_sum_squares / samples.len() as f32).sqrt()
+    }
+
+    fn snapshot(
+        &self,
+        sample_rate: u32,
+        channels: u16,
+        speech_detected: bool,
+    ) -> CaptureAudioMetrics {
+        let sample_count = self.sample_count.load(Ordering::Relaxed);
+        let sum_squares = f64::from_bits(self.sum_squares_bits.load(Ordering::Relaxed));
+        let frames = sample_count / u64::from(channels.max(1));
+        let duration_ms = frames
+            .saturating_mul(1000)
+            .checked_div(u64::from(sample_rate.max(1)))
+            .unwrap_or(0);
+        let rms = if sample_count == 0 {
+            0.0
+        } else {
+            (sum_squares / sample_count as f64).sqrt()
+        };
+
+        CaptureAudioMetrics {
+            sample_count,
+            duration_ms,
+            rms,
+            peak: f32::from_bits(self.peak_bits.load(Ordering::Relaxed)),
+            sample_rate,
+            channels,
+            speech_detected,
+        }
+    }
+}
+
+fn atomic_add_f64(target: &AtomicU64, value: f64) {
+    let mut current = target.load(Ordering::Relaxed);
+    loop {
+        let next = (f64::from_bits(current) + value).to_bits();
+        match target.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn atomic_max_f32(target: &AtomicU32, value: f32) {
+    let mut current = target.load(Ordering::Relaxed);
+    while value > f32::from_bits(current) {
+        match target.compare_exchange_weak(
+            current,
+            value.to_bits(),
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn finish_capture(
+    last_capture_metrics: &Mutex<Option<CaptureAudioMetrics>>,
+    metrics: CaptureAudioMetrics,
+    writer_result: Result<(), String>,
+    device_error: Option<String>,
+) -> Result<(), String> {
+    if let Ok(mut guard) = last_capture_metrics.lock() {
+        *guard = Some(metrics);
+    }
+    writer_result?;
+    if let Some(error) = device_error {
+        return Err(error);
+    }
+    Ok(())
+}
+
 pub struct AudioRecorder {
     recording_handle: Arc<Mutex<Option<RecordingHandle>>>,
     audio_level_receiver: Arc<Mutex<Option<mpsc::Receiver<f64>>>>,
     silence_event_receiver: Arc<Mutex<Option<mpsc::Receiver<SilenceDetectorEvent>>>>,
+    last_capture_metrics: Arc<Mutex<Option<CaptureAudioMetrics>>>,
 }
 
 impl Drop for AudioRecorder {
@@ -231,6 +346,7 @@ impl AudioRecorder {
             recording_handle: Arc::new(Mutex::new(None)),
             audio_level_receiver: Arc::new(Mutex::new(None)),
             silence_event_receiver: Arc::new(Mutex::new(None)),
+            last_capture_metrics: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -262,10 +378,15 @@ impl AudioRecorder {
         if let Ok(mut guard) = self.silence_event_receiver.lock() {
             guard.take();
         }
+        *self
+            .last_capture_metrics
+            .lock()
+            .map_err(|e| format!("Failed to acquire capture metrics lock: {e}"))? = None;
 
         let output_path = PathBuf::from(output_path);
         let (stop_tx, stop_rx) = mpsc::channel();
         let stop_tx_clone = stop_tx.clone();
+        let last_capture_metrics = self.last_capture_metrics.clone();
 
         // Create audio level channel (f64 for EBU R128 loudness values)
         let (audio_level_tx, audio_level_rx) = mpsc::channel::<f64>();
@@ -317,6 +438,7 @@ impl AudioRecorder {
 
             // Initialize silence detector and level meter
             let silence_detector = Arc::new(Mutex::new(SilenceDetector::new()));
+            let capture_metrics = Arc::new(CaptureMetricsAccumulator::default());
             let level_meter = Arc::new(Mutex::new(
                 AudioLevelMeter::new(
                     config.sample_rate().0,
@@ -469,6 +591,7 @@ impl AudioRecorder {
                 let level_meter_clone = level_meter.clone();
                 let stop_requested_clone = stop_requested.clone();
                 let callback_drained_clone = callback_drained.clone();
+                let capture_metrics_clone = capture_metrics.clone();
 
                 move |f32_samples: &[f32], i16_samples: &[i16]| {
                     // A panic in this real-time path would unwind into CPAL's
@@ -504,9 +627,8 @@ impl AudioRecorder {
                             }
                             return;
                         }
-                        // Calculate RMS for both level meter and silence detection
-                        let sum: f32 = f32_samples.iter().map(|x| x * x).sum();
-                        let rms = (sum / f32_samples.len() as f32).sqrt();
+                        // Reuse one traversal for callback RMS and recording-wide metrics.
+                        let rms = capture_metrics_clone.observe(f32_samples);
 
                         // Process with level meter
                         if let Ok(mut meter) = level_meter_clone.try_lock() {
@@ -701,16 +823,17 @@ impl AudioRecorder {
             // unfinalized-but-alive. See [`WRITER_JOIN_TIMEOUT`] and
             // [`join_writer_bounded`].
             let writer_result = join_writer_bounded(writer_handle, WRITER_JOIN_TIMEOUT);
-
-            writer_result?;
-
-            // Check if any errors occurred during recording after preserving writer integrity
-            // failures as the primary stop error.
-            if let Ok(guard) = error_occurred.lock() {
-                if let Some(error) = &*guard {
-                    return Err(error.clone());
-                }
-            }
+            let speech_detected = silence_detector
+                .lock()
+                .map(|detector| detector.speech_detected())
+                .unwrap_or(false);
+            let metrics = capture_metrics.snapshot(
+                config.sample_rate().0,
+                config.channels(),
+                speech_detected,
+            );
+            let device_error = error_occurred.lock().ok().and_then(|guard| guard.clone());
+            finish_capture(&last_capture_metrics, metrics, writer_result, device_error)?;
 
             // Return appropriate message based on stop reason
             match stop_reason {
@@ -787,6 +910,13 @@ impl AudioRecorder {
         } else {
             Err("Not recording".to_string())
         }
+    }
+
+    pub fn take_last_capture_metrics(&self) -> Option<CaptureAudioMetrics> {
+        self.last_capture_metrics
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
     }
 
     pub fn wait_for_recording_end(&mut self) -> Result<String, String> {
@@ -1264,5 +1394,86 @@ mod tests {
 
         assert!(!recorder.recording_thread_finished());
         drop(recorder);
+    }
+    #[test]
+    fn capture_metrics_accumulate_rms_peak_and_duration_in_callback_pass() {
+        let metrics = CaptureMetricsAccumulator::default();
+
+        assert!((metrics.observe(&[0.5, -0.5]) - 0.5).abs() < f32::EPSILON);
+        assert!((metrics.observe(&[0.25, -0.25]) - 0.25).abs() < f32::EPSILON);
+
+        let snapshot = metrics.snapshot(2, 1, true);
+        assert_eq!(snapshot.sample_count, 4);
+        assert_eq!(snapshot.duration_ms, 2000);
+        assert!((snapshot.rms - 0.395_284_707_521_047_44).abs() < 1e-12);
+        assert!((snapshot.peak - 0.5).abs() < f32::EPSILON);
+        assert!(snapshot.speech_detected);
+    }
+
+    #[test]
+    fn callback_rms_preserves_previous_f32_calculation_bits() {
+        fn legacy_callback_rms(samples: &[f32]) -> f32 {
+            let sum: f32 = samples.iter().map(|sample| sample * sample).sum();
+            (sum / samples.len() as f32).sqrt()
+        }
+
+        let near_threshold = [
+            crate::audio::silence_detector::VOICE_RMS_THRESHOLD - 0.000_001,
+            crate::audio::silence_detector::VOICE_RMS_THRESHOLD + 0.000_001,
+            -0.004_999,
+            0.005_001,
+        ];
+        let signed_zero = [0.0, -0.0];
+
+        for samples in [&[][..], &near_threshold[..], &signed_zero[..]] {
+            let metrics = CaptureMetricsAccumulator::default();
+            assert_eq!(
+                metrics.observe(samples).to_bits(),
+                legacy_callback_rms(samples).to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn capture_metrics_survive_writer_and_device_errors() {
+        let expected = CaptureAudioMetrics {
+            sample_count: 16_000,
+            duration_ms: 1000,
+            rms: 0.1,
+            peak: 0.2,
+            sample_rate: 16_000,
+            channels: 1,
+            speech_detected: true,
+        };
+
+        for (writer_result, device_error, expected_error) in [
+            (Err("writer failed".to_string()), None, "writer failed"),
+            (Ok(()), Some("device failed".to_string()), "device failed"),
+        ] {
+            let slot = Mutex::new(None);
+            let error = finish_capture(&slot, expected, writer_result, device_error).unwrap_err();
+            assert_eq!(error, expected_error);
+            assert_eq!(slot.lock().ok().and_then(|guard| *guard), Some(expected));
+        }
+    }
+
+    #[test]
+    fn take_last_capture_metrics_consumes_snapshot() {
+        let recorder = AudioRecorder::new();
+        let expected = CaptureAudioMetrics {
+            sample_count: 16_000,
+            duration_ms: 1000,
+            rms: 0.1,
+            peak: 0.2,
+            sample_rate: 16_000,
+            channels: 1,
+            speech_detected: false,
+        };
+        if let Ok(mut guard) = recorder.last_capture_metrics.lock() {
+            *guard = Some(expected);
+        }
+
+        assert_eq!(recorder.take_last_capture_metrics(), Some(expected));
+        assert_eq!(recorder.take_last_capture_metrics(), None);
     }
 }

--- a/src-tauri/src/audio/silence_detector.rs
+++ b/src-tauri/src/audio/silence_detector.rs
@@ -46,6 +46,10 @@ impl SilenceDetector {
         self.update_at(rms, Instant::now())
     }
 
+    pub fn speech_detected(&self) -> bool {
+        self.speech_detected
+    }
+
     fn new_at(now: Instant) -> Self {
         Self {
             started_at: now,
@@ -347,5 +351,15 @@ mod tests {
             ),
             None
         );
+    }
+    #[test]
+    fn speech_detected_remains_latched_after_trailing_silence() {
+        let start = t0();
+        let mut detector = SilenceDetector::new_at(start);
+        let voiced = confirm_speech(&mut detector, start + Duration::from_secs(1));
+        assert!(detector.speech_detected());
+
+        detector.update_at(SILENT, voiced + LONG_SILENCE_WARNING_AFTER);
+        assert!(detector.speech_detected());
     }
 }

--- a/src-tauri/src/audio/speech_evidence.rs
+++ b/src-tauri/src/audio/speech_evidence.rs
@@ -1,0 +1,393 @@
+use super::normalizer::NormalizationMetrics;
+use super::recorder::CaptureAudioMetrics;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpeechEvidenceClass {
+    SpeechPositive,
+    HighConfidenceNoInput,
+    Uncertain,
+}
+
+impl SpeechEvidenceClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SpeechPositive => "speech_positive",
+            Self::HighConfidenceNoInput => "high_confidence_no_input",
+            Self::Uncertain => "uncertain",
+        }
+    }
+
+    pub const fn would_skip_engine(self) -> bool {
+        matches!(self, Self::HighConfidenceNoInput)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpeechEvidenceOutcome {
+    AbortedBeforeResult,
+    CancelledBeforeEngine,
+    PreparationFailure,
+    RecordingTooShort,
+    EngineSuccess,
+    EngineFailure,
+}
+
+impl SpeechEvidenceOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::AbortedBeforeResult => "aborted_before_result",
+            Self::CancelledBeforeEngine => "cancelled_before_engine",
+            Self::PreparationFailure => "preparation_failure",
+            Self::RecordingTooShort => "recording_too_short",
+            Self::EngineSuccess => "success",
+            Self::EngineFailure => "failure",
+        }
+    }
+}
+
+/// Attempt-scoped evidence finalizer. Construct it before fallible preparation,
+/// then move it into the transcription future. `Drop` emits exactly one summary,
+/// including when Tokio aborts the future before its first poll or during an await.
+pub struct SpeechEvidenceAttempt {
+    engine: String,
+    route: &'static str,
+    capture: Option<CaptureAudioMetrics>,
+    prepared: Option<NormalizationMetrics>,
+    outcome: SpeechEvidenceOutcome,
+    #[cfg(test)]
+    drop_counter: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    #[cfg(test)]
+    emitted_lines: Option<std::sync::Arc<std::sync::Mutex<Vec<String>>>>,
+}
+
+impl SpeechEvidenceAttempt {
+    pub fn new(engine: String, route: &'static str, capture: Option<CaptureAudioMetrics>) -> Self {
+        Self {
+            engine,
+            route,
+            capture,
+            prepared: None,
+            outcome: SpeechEvidenceOutcome::AbortedBeforeResult,
+            #[cfg(test)]
+            drop_counter: None,
+            #[cfg(test)]
+            emitted_lines: None,
+        }
+    }
+
+    pub fn set_prepared(&mut self, prepared: Option<NormalizationMetrics>) {
+        self.prepared = prepared;
+    }
+
+    pub fn set_outcome(&mut self, outcome: SpeechEvidenceOutcome) {
+        self.outcome = outcome;
+    }
+
+    fn formatted_summary(&self) -> String {
+        let class = classify_speech_evidence(self.capture, self.prepared);
+        let capture = self.capture.map(|metrics| {
+            serde_json::json!({
+                "sample_count": metrics.sample_count,
+                "duration_ms": metrics.duration_ms,
+                "rms": finite_f64(metrics.rms),
+                "peak": finite_f32(metrics.peak),
+                "sample_rate": metrics.sample_rate,
+                "channels": metrics.channels,
+                "sustained_speech": metrics.speech_detected,
+            })
+        });
+        let prepared = self.prepared.map(|metrics| {
+            serde_json::json!({
+                "pre_gain_peak": finite_f32(metrics.pre_gain_peak),
+                "speech_like_modulation": metrics.speech_like_modulation,
+                "applied_gain": finite_f32(metrics.applied_gain),
+                "input_duration_ms": metrics.input_duration_ms,
+                "output_duration_ms": metrics.output_duration_ms,
+                "trimmed_duration_ms": metrics.trimmed_duration_ms,
+            })
+        });
+        let payload = serde_json::json!({
+            "engine": self.engine,
+            "route": self.route,
+            "engine_outcome": self.outcome.as_str(),
+            "class": class.as_str(),
+            "would_skip_engine": class.would_skip_engine(),
+            "capture": capture,
+            "prepared": prepared,
+        });
+        format!("SPEECH_EVIDENCE {payload}")
+    }
+}
+
+impl Drop for SpeechEvidenceAttempt {
+    fn drop(&mut self) {
+        let line = self.formatted_summary();
+        log::info!("{}", line);
+        #[cfg(test)]
+        {
+            if let Some(lines) = &self.emitted_lines {
+                if let Ok(mut lines) = lines.lock() {
+                    lines.push(line);
+                }
+            }
+            if let Some(counter) = &self.drop_counter {
+                counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    }
+}
+
+pub fn classify_speech_evidence(
+    capture: Option<CaptureAudioMetrics>,
+    prepared: Option<NormalizationMetrics>,
+) -> SpeechEvidenceClass {
+    let capture_speech = capture
+        .map(|metrics| metrics.speech_detected)
+        .unwrap_or(false);
+    let prepared_speech = prepared
+        .map(|metrics| metrics.speech_like_modulation)
+        .unwrap_or(false);
+    if capture_speech || prepared_speech {
+        return SpeechEvidenceClass::SpeechPositive;
+    }
+
+    if capture
+        .map(|metrics| {
+            metrics.sample_count > 0
+                && metrics.rms.is_finite()
+                && metrics.peak.is_finite()
+                && metrics.rms >= 0.0
+                && metrics.peak >= 0.0
+                && metrics.rms == 0.0
+                && metrics.peak == 0.0
+        })
+        .unwrap_or(false)
+    {
+        SpeechEvidenceClass::HighConfidenceNoInput
+    } else {
+        SpeechEvidenceClass::Uncertain
+    }
+}
+
+fn finite_f64(value: f64) -> Option<f64> {
+    value.is_finite().then_some(value)
+}
+
+fn finite_f32(value: f32) -> Option<f32> {
+    value.is_finite().then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capture(
+        sample_count: u64,
+        rms: f64,
+        peak: f32,
+        speech_detected: bool,
+    ) -> CaptureAudioMetrics {
+        CaptureAudioMetrics {
+            sample_count,
+            duration_ms: 1000,
+            rms,
+            peak,
+            sample_rate: 16_000,
+            channels: 1,
+            speech_detected,
+        }
+    }
+
+    fn prepared(speech_like_modulation: bool) -> NormalizationMetrics {
+        NormalizationMetrics {
+            pre_gain_peak: 0.02,
+            speech_like_modulation,
+            applied_gain: 10.0,
+            input_duration_ms: 1000,
+            output_duration_ms: 1000,
+            trimmed_duration_ms: 0,
+        }
+    }
+
+    #[test]
+    fn positive_capture_or_prepared_evidence_always_wins() {
+        assert_eq!(
+            classify_speech_evidence(Some(capture(16_000, 0.0, 0.0, true)), None),
+            SpeechEvidenceClass::SpeechPositive
+        );
+        assert_eq!(
+            classify_speech_evidence(Some(capture(16_000, 0.0, 0.0, false)), Some(prepared(true)),),
+            SpeechEvidenceClass::SpeechPositive
+        );
+        assert_eq!(
+            classify_speech_evidence(None, Some(prepared(true))),
+            SpeechEvidenceClass::SpeechPositive
+        );
+    }
+
+    #[test]
+    fn only_finite_nonempty_digital_zero_is_high_confidence_no_input() {
+        let class = classify_speech_evidence(Some(capture(16_000, 0.0, 0.0, false)), None);
+        assert_eq!(class, SpeechEvidenceClass::HighConfidenceNoInput);
+        assert!(class.would_skip_engine());
+
+        for metrics in [
+            capture(0, 0.0, 0.0, false),
+            capture(16_000, 1e-12, 0.0, false),
+            capture(16_000, 0.0, 1e-10, false),
+            capture(16_000, f64::NAN, 0.0, false),
+            capture(16_000, 0.0, f32::NAN, false),
+            capture(16_000, f64::INFINITY, 0.0, false),
+            capture(16_000, 0.0, f32::INFINITY, false),
+            capture(16_000, -0.1, 0.0, false),
+            capture(16_000, 0.0, -0.1, false),
+        ] {
+            assert_eq!(
+                classify_speech_evidence(Some(metrics), None),
+                SpeechEvidenceClass::Uncertain
+            );
+        }
+    }
+
+    #[test]
+    fn any_nonzero_or_missing_capture_evidence_remains_uncertain() {
+        assert_eq!(
+            classify_speech_evidence(Some(capture(16_000, 1e-12, 1e-10, false)), None,),
+            SpeechEvidenceClass::Uncertain
+        );
+        assert_eq!(
+            classify_speech_evidence(Some(capture(16_000, 0.000_01, 0.005, false)), None,),
+            SpeechEvidenceClass::Uncertain
+        );
+        assert_eq!(
+            classify_speech_evidence(None, Some(prepared(false))),
+            SpeechEvidenceClass::Uncertain
+        );
+    }
+
+    #[test]
+    fn structured_json_escapes_labels_and_marks_missing_metrics_null() {
+        let attempt = SpeechEvidenceAttempt {
+            engine: "remote \"lab\"\nserver".to_string(),
+            route: "remote",
+            capture: Some(capture(16_000, 0.1, 0.3, true)),
+            prepared: None,
+            outcome: SpeechEvidenceOutcome::EngineSuccess,
+            drop_counter: None,
+            emitted_lines: None,
+        };
+        let line = attempt.formatted_summary();
+        let payload = line.strip_prefix("SPEECH_EVIDENCE ").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(payload).unwrap();
+
+        assert_eq!(parsed["engine"], "remote \"lab\"\nserver");
+        assert_eq!(parsed["engine_outcome"], "success");
+        assert_eq!(parsed["class"], "speech_positive");
+        assert_eq!(parsed["would_skip_engine"], false);
+        assert_eq!(parsed["capture"]["rms"], 0.1);
+        assert!(parsed["prepared"].is_null());
+        assert_eq!(line.lines().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn abort_before_first_poll_emits_exactly_once() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut attempt = SpeechEvidenceAttempt::new("whisper".to_string(), "local", None);
+        attempt.drop_counter = Some(counter.clone());
+        attempt.emitted_lines = Some(lines.clone());
+        let future = async move {
+            let _attempt = attempt;
+            std::future::pending::<()>().await;
+        };
+
+        let handle = tokio::spawn(future);
+        handle.abort();
+        let _ = handle.await;
+
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let emitted = lines
+            .lock()
+            .ok()
+            .map(|lines| lines.clone())
+            .unwrap_or_default();
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].contains("\"engine_outcome\":\"aborted_before_result\""));
+    }
+
+    #[tokio::test]
+    async fn abort_during_await_emits_exactly_once() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut attempt = SpeechEvidenceAttempt::new("openai".to_string(), "cloud", None);
+        attempt.drop_counter = Some(counter.clone());
+        attempt.emitted_lines = Some(lines.clone());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _attempt = attempt;
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        let _ = started_rx.await;
+
+        handle.abort();
+        let _ = handle.await;
+
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(lines.lock().ok().map(|lines| lines.len()), Some(1));
+    }
+
+    #[tokio::test]
+    async fn task_panic_emits_aborted_outcome_exactly_once() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut attempt = SpeechEvidenceAttempt::new("remote".to_string(), "remote", None);
+        attempt.drop_counter = Some(counter.clone());
+        attempt.emitted_lines = Some(lines.clone());
+        let handle = tokio::spawn(async move {
+            let _attempt = attempt;
+            panic!("simulated task panic");
+        });
+
+        let error = handle.await.unwrap_err();
+
+        assert!(error.is_panic());
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let emitted = lines
+            .lock()
+            .ok()
+            .map(|lines| lines.clone())
+            .unwrap_or_default();
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].contains("\"engine_outcome\":\"aborted_before_result\""));
+    }
+
+    #[test]
+    fn every_explicit_terminal_outcome_emits_once() {
+        let lines = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let outcomes = [
+            SpeechEvidenceOutcome::CancelledBeforeEngine,
+            SpeechEvidenceOutcome::PreparationFailure,
+            SpeechEvidenceOutcome::RecordingTooShort,
+            SpeechEvidenceOutcome::EngineSuccess,
+            SpeechEvidenceOutcome::EngineFailure,
+        ];
+
+        for outcome in outcomes {
+            let mut attempt = SpeechEvidenceAttempt::new("whisper".to_string(), "local", None);
+            attempt.emitted_lines = Some(lines.clone());
+            attempt.set_outcome(outcome);
+            drop(attempt);
+        }
+
+        let emitted = lines
+            .lock()
+            .ok()
+            .map(|lines| lines.clone())
+            .unwrap_or_default();
+        assert_eq!(emitted.len(), outcomes.len());
+        for (line, outcome) in emitted.iter().zip(outcomes) {
+            assert!(line.contains(&format!("\"engine_outcome\":\"{}\"", outcome.as_str())));
+        }
+    }
+}

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -4,6 +4,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use crate::ai::error::{user_facing_message, AiProviderError};
 use crate::audio::recorder::AudioRecorder;
 use crate::audio::silence_detector::SilenceDetectorEvent;
+use crate::audio::speech_evidence::{SpeechEvidenceAttempt, SpeechEvidenceOutcome};
 use crate::commands::settings::{
     get_settings, normalize_final_text_language, normalize_speech_language_for_model,
     normalize_transcription_task, recording_retention_days_from_store, resolve_pill_indicator_mode,
@@ -1418,7 +1419,9 @@ where
                 }
                 Err(error) => {
                     preserve_gpu_status = true;
-                    log::warn!("GPU sidecar failed, unloading sidecar before CPU fallback: {error}");
+                    log::warn!(
+                        "GPU sidecar failed, unloading sidecar before CPU fallback: {error}"
+                    );
                     gpu_client.abort_active_process().await;
                     if mode == "gpu" {
                         pill_toast(app, "GPU unavailable, using CPU", 4000);
@@ -1506,9 +1509,10 @@ mod tests {
         set_in_flight_transcription_audio, should_hide_pill_when_idle, should_use_active_remote,
         silence_event_runs_in_state, silence_timeout_disposition, stop_should_reset_to_idle,
         sync_retranscription_failure_metadata, take_in_flight_transcription_audio,
-        toast_clear_is_current, transcription_watchdog_budget, LocalFailureKind,
-        NormalizedTempFile, PillToastEventPayload, RecordingLicenseState, SilenceDetectorEvent,
-        SilenceTimeoutDisposition, StopInFlightGuard, TranscriptionFailure, TranscriptionStatus,
+        toast_clear_is_current, transcription_watchdog_budget, ActiveEngineSelection,
+        LocalFailureKind, NormalizedTempFile, PillToastEventPayload, RecordingLicenseState,
+        SilenceDetectorEvent, SilenceTimeoutDisposition, StopInFlightGuard, TranscriptionFailure,
+        TranscriptionStatus,
     };
     use crate::commands::license::CachedLicense;
     use crate::license::{LicenseState, LicenseStatus};
@@ -2684,6 +2688,34 @@ mod tests {
             "spawned history task must recheck cancellation at the write site"
         );
     }
+    #[test]
+    fn active_engine_routes_are_stable_for_evidence_logs() {
+        let selections = [
+            ActiveEngineSelection::Whisper {
+                model_name: "base".to_string(),
+                model_path: std::path::PathBuf::new(),
+            },
+            ActiveEngineSelection::Parakeet {
+                model_name: "parakeet".to_string(),
+            },
+            ActiveEngineSelection::Cloud {
+                provider: crate::cloud_stt::CloudProvider::Openai,
+                model_name: "gpt-4o-mini-transcribe".to_string(),
+            },
+            ActiveEngineSelection::Remote {
+                server_id: "server".to_string(),
+                server_name: "Remote".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 47842,
+                password: None,
+            },
+        ];
+
+        assert_eq!(selections[0].route(), "local");
+        assert_eq!(selections[1].route(), "local");
+        assert_eq!(selections[2].route(), "cloud");
+        assert_eq!(selections[3].route(), "remote");
+    }
 }
 
 /// Play a system sound to confirm recording start (macOS only)
@@ -3182,6 +3214,16 @@ impl ActiveEngineSelection {
             ActiveEngineSelection::Whisper { .. } => "whisper",
             ActiveEngineSelection::Parakeet { .. } => "parakeet",
             ActiveEngineSelection::Cloud { provider, .. } => provider.id(),
+            ActiveEngineSelection::Remote { .. } => "remote",
+        }
+    }
+
+    pub(crate) const fn route(&self) -> &'static str {
+        match self {
+            ActiveEngineSelection::Whisper { .. } | ActiveEngineSelection::Parakeet { .. } => {
+                "local"
+            }
+            ActiveEngineSelection::Cloud { .. } => "cloud",
             ActiveEngineSelection::Remote { .. } => "remote",
         }
     }
@@ -3921,7 +3963,9 @@ pub async fn start_recording(
                 let guard = remote.lock().await;
                 guard.get_active_connection().is_some()
             };
-            if !remote_active && crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false) {
+            if !remote_active
+                && crate::secure_store::secure_has(&app, provider.key_name()).unwrap_or(false)
+            {
                 provider.warm_up().await;
             }
         });
@@ -4434,6 +4478,7 @@ pub async fn stop_recording(
     // DO NOT request cancellation here - we want transcription to complete!
     // Cancellation should only happen in cancel_recording command
 
+    let capture_metrics;
     let mut stop_unfinalized = false;
     let mut stop_integrity_failure = false;
     // Stop recording (lock only within this scope to stay Send)
@@ -4486,6 +4531,7 @@ pub async fn stop_recording(
                 format!("Recorder stop error: {}", e)
             }
         };
+        capture_metrics = recorder.take_last_capture_metrics();
         log::info!("{}", stop_message);
 
         // Play sound on recording end if enabled
@@ -4899,7 +4945,14 @@ pub async fn stop_recording(
             }
         }
     };
+    let engine_route = engine_selection.route();
+    let mut speech_evidence_attempt = SpeechEvidenceAttempt::new(
+        engine_selection.engine_name().to_string(),
+        engine_route,
+        capture_metrics,
+    );
 
+    let mut prepared_metrics = None;
     // For Whisper/Parakeet: normalize and duration gate; for Cloud/Remote: skip both
     let audio_path = match &engine_selection {
         ActiveEngineSelection::Cloud { provider, .. } => {
@@ -4928,11 +4981,14 @@ pub async fn stop_recording(
                 let a = audio_path.clone();
                 let d = parent_dir.clone();
                 let in_proc = tokio::task::spawn_blocking(move || {
-                    crate::audio::normalizer::normalize_to_whisper_wav(&a, &d)
+                    crate::audio::normalizer::normalize_to_whisper_wav_with_metrics(&a, &d)
                 })
                 .await;
                 match in_proc {
-                    Ok(Ok(path)) => path,
+                    Ok(Ok(normalized)) => {
+                        prepared_metrics = Some(normalized.metrics);
+                        normalized.path
+                    }
                     other => {
                         let other_err = match &other {
                             Ok(Ok(_)) => unreachable!(),
@@ -4948,6 +5004,8 @@ pub async fn stop_recording(
                         if let Err(e) =
                             crate::ffmpeg::normalize_streaming(&app, &audio_path, &out_path).await
                         {
+                            speech_evidence_attempt
+                                .set_outcome(SpeechEvidenceOutcome::PreparationFailure);
                             log::error!("Audio normalization (ffmpeg) failed: {}", e);
                             update_recording_state(
                                 &app,
@@ -4961,6 +5019,7 @@ pub async fn stop_recording(
                     }
                 }
             };
+            speech_evidence_attempt.set_prepared(prepared_metrics);
 
             // Remove raw capture after successful normalization
             if let Err(e) = std::fs::remove_file(&audio_path) {
@@ -5007,6 +5066,7 @@ pub async fn stop_recording(
             })();
 
             if matches!(duration_gate, Ok((true, _))) {
+                speech_evidence_attempt.set_outcome(SpeechEvidenceOutcome::RecordingTooShort);
                 // Emit friendly feedback and stop here
                 let _ = emit_to_window(
                     &app,
@@ -5091,9 +5151,11 @@ pub async fn stop_recording(
     let language_for_task = language.clone();
     let selected_model_name_for_task = selected_model_name.clone();
     let transcription_job_for_task = transcription_job.clone();
+    let speech_evidence_attempt_for_task = speech_evidence_attempt;
     // Spawn and track the transcription task
     let app_for_task = app.clone();
     let task_handle = tokio::spawn(async move {
+        let mut speech_evidence_attempt = speech_evidence_attempt_for_task;
         log::debug!("Transcription task started");
 
         // Update state to transcribing
@@ -5106,6 +5168,7 @@ pub async fn stop_recording(
         // Check for cancellation before loading model
         let app_state = app_for_task.state::<AppState>();
         if app_state.is_cancellation_requested() {
+            speech_evidence_attempt.set_outcome(SpeechEvidenceOutcome::CancelledBeforeEngine);
             log::info!("Transcription cancelled before model loading");
             // The task observed cancellation itself (cancel set the flag but
             // either did not, or could not, abort this handle in time). Remove
@@ -5230,6 +5293,12 @@ pub async fn stop_recording(
                     .await
                 }
             };
+
+        speech_evidence_attempt.set_outcome(if transcription_result.is_ok() {
+            SpeechEvidenceOutcome::EngineSuccess
+        } else {
+            SpeechEvidenceOutcome::EngineFailure
+        });
 
         // Decide persistence BEFORE touching the file. PRIVACY: a cancelled
         // dictation — or one whose recording generation has gone stale (a newer

--- a/src-tauri/src/tests/logging_performance_tests.rs
+++ b/src-tauri/src/tests/logging_performance_tests.rs
@@ -156,31 +156,6 @@ mod performance_tests {
     }
 
     #[test]
-    fn test_audio_metrics_logging_performance() {
-        log::info!("Testing audio metrics logging performance");
-
-        let benchmark = PerformanceBenchmark::new("audio_metrics", 2000, 400);
-
-        let result = benchmark.run(|i| {
-            let additional_metrics = log_context! {
-                "iteration" => &i.to_string(),
-                "model" => "test_model",
-                "sample_rate" => "16000"
-            };
-
-            log_audio_metrics(
-                "PERFORMANCE_TEST",
-                0.75 + (i as f64 * 0.001),  // Varying energy
-                0.85 + (i as f64 * 0.0001), // Varying peak
-                2.5 + (i as f32 * 0.01),    // Varying duration
-                Some(&additional_metrics),
-            );
-        });
-
-        result.assert_performance();
-    }
-
-    #[test]
     fn test_structured_logging_performance() {
         log::info!("Testing structured logging with multiple fields");
 
@@ -456,20 +431,10 @@ mod stress_tests {
         let mut operations = 0;
 
         while start.elapsed() < duration {
-            let context = log_context! {
-                "stress_test" => "sustained",
-                "operation" => &operations.to_string(),
-                "elapsed_ms" => &start.elapsed().as_millis().to_string()
-            };
-
             log_start("STRESS_TEST");
 
             if operations % 100 == 0 {
                 log_performance("STRESS_BATCH", operations, Some("sustained_test"));
-            }
-
-            if operations % 50 == 0 {
-                log_audio_metrics("STRESS_AUDIO", 0.5, 0.8, 1.0, Some(&context));
             }
 
             log_complete("STRESS_TEST", 1);

--- a/src-tauri/src/tests/panic_prevention_tests.rs
+++ b/src-tauri/src/tests/panic_prevention_tests.rs
@@ -372,19 +372,12 @@ mod performance_tests {
 
         let result = std::panic::catch_unwind(|| {
             for i in 0..iterations {
-                let context = log_context! {
-                    "iteration" => &i.to_string(),
-                    "operation" => "performance_test",
-                    "timestamp" => &chrono::Utc::now().to_rfc3339()
-                };
-
                 log_start("PERF_TEST");
                 log_performance("TEST_METRIC", i as u64, Some("test_data"));
                 log_complete("PERF_TEST", 1);
 
                 if i % 100 == 0 {
-                    log_audio_metrics("PERF_AUDIO", 0.5, 0.8, 2.5, Some(&context));
-                    log_model_operation("LOAD", "test-model", "READY", Some(&context));
+                    log_model_operation("LOAD", "test-model", "READY", None);
                 }
             }
 

--- a/src-tauri/src/utils/logger.rs
+++ b/src-tauri/src/utils/logger.rs
@@ -51,28 +51,6 @@ pub fn log_performance(operation: &str, duration_ms: u64, metadata: Option<&str>
 
 // REMOVED: HashMap-based wrappers - use log_start() with log_with_context() directly
 
-/// Log audio metrics in a structured way
-pub fn log_audio_metrics(
-    operation: &str,
-    energy: f64,
-    peak: f64,
-    duration: f32,
-    additional: Option<&HashMap<String, String>>,
-) {
-    log::info!(
-        "🔊 AUDIO {}: energy={:.4}, peak={:.4}, duration={:.2}s",
-        operation,
-        energy,
-        peak,
-        duration
-    );
-    if let Some(extra) = additional {
-        if !extra.is_empty() {
-            log::info!("   📊 Audio Metrics: {:?}", extra);
-        }
-    }
-}
-
 /// Log model operations with metadata
 pub fn log_model_operation(
     operation: &str,

--- a/src-tauri/src/whisper/transcriber.rs
+++ b/src-tauri/src/whisper/transcriber.rs
@@ -599,8 +599,6 @@ impl Transcriber {
             return Err(error);
         }
 
-        log_audio_metrics("WHISPER_INPUT", 0.0, 0.0, duration_seconds, None);
-
         let inference_start = Instant::now();
         log_start("WHISPER_INFERENCE");
         log_with_context(


### PR DESCRIPTION
## Summary
- aggregate real capture RMS, peak, duration, sample format, and sustained-speech evidence in the existing CPAL callback pass
- preserve the exact legacy `f32` callback RMS calculation while maintaining a separate `f64` recording-wide telemetry sum
- expose local prepared-audio peak, modulation, gain, duration, and trim metrics from work the normalizer already performs
- emit one compact JSON `SPEECH_EVIDENCE` line per live transcription attempt that reaches engine selection, through an abort-safe RAII finalizer across local, cloud, and remote routes
- remove the misleading hardcoded `WHISPER_INPUT energy=0.0000 peak=0.0000` log

Attempts that fail before engine selection (for example, no model configured or an unfinalized recorder stop) retain their existing dedicated error logs and do not claim an evidence summary, because a complete capture snapshot may not exist.

## Shadow-only policy
- sustained capture speech or prepared speech-like modulation => `speech_positive`
- nonempty exact digital-zero capture => `high_confidence_no_input`
- every nonzero, missing, invalid, or otherwise negative signal => `uncertain`
- `would_skip_engine` is **telemetry only**; this PR does not reject audio, skip an engine, or change user-visible behavior

## Real-time invariants
- no extra sample traversal
- no callback allocation, mutex, logging, or blocking
- capture metrics are published before writer/device errors propagate
- prepared metrics add no extra WAV read or full-buffer scan

## Verification
- `cargo check --lib` — passed
- `cargo test --lib` — 1201 passed before final hardening
- `cargo test --lib audio::` — 153 passed after final hardening
- `cargo clippy --release --lib -- -D warnings` — passed
- Windows, both macOS builds, frontend, Store MSIX, and `claude-review` — passed after merging current `main`
- independent merge-gate review — no P0/P1/P2 findings

No enforcement is enabled by this PR.