### PR TITLE
fix(release): normalize updater manifest tag prefix

### DIFF
--- a/.github/scripts/should-update-beta-manifest.mjs
+++ b/.github/scripts/should-update-beta-manifest.mjs
@@ -26,6 +26,11 @@ export function releaseChannelForVersion(input) {
   throw new Error(`Unsupported release version: ${input}`);
 }
 
+export function releaseTagForVersion(input) {
+  releaseChannelForVersion(input);
+  return `v${input.trim().replace(/^v/, "")}`;
+}
+
 export function compareSemver(leftInput, rightInput) {
   const left = parseSemver(leftInput);
   const right = parseSemver(rightInput);

--- a/.github/scripts/should-update-beta-manifest.node-test.mjs
+++ b/.github/scripts/should-update-beta-manifest.node-test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   compareSemver,
   releaseChannelForVersion,
+  releaseTagForVersion,
 } from "./should-update-beta-manifest.mjs";
 
 test("orders beta sequence numbers", () => {
@@ -33,6 +34,13 @@ test("accepts only stable and numbered beta release versions", () => {
     () => releaseChannelForVersion("2.0.5-rc.1"),
     /Unsupported release version/,
   );
+});
+
+test("normalizes updater manifest versions to one release tag prefix", () => {
+  assert.equal(releaseTagForVersion("2.0.5"), "v2.0.5");
+  assert.equal(releaseTagForVersion("v2.0.5"), "v2.0.5");
+  assert.equal(releaseTagForVersion("2.0.5-beta.1"), "v2.0.5-beta.1");
+  assert.equal(releaseTagForVersion("v2.0.5-beta.1"), "v2.0.5-beta.1");
 });
 
 test("rejects invalid versions", () => {

--- a/.github/workflows/update-beta-channel.yml
+++ b/.github/workflows/update-beta-channel.yml
@@ -43,7 +43,11 @@ jobs:
 
       - name: Validate release and immutable asset references
         run: |
-          if [[ "$RELEASE_TAG" != "v$candidate_version" ]]; then
+          EXPECTED_TAG="$(node --input-type=module -e '
+            import { releaseTagForVersion } from "./.github/scripts/should-update-beta-manifest.mjs";
+            process.stdout.write(releaseTagForVersion(process.env.candidate_version));
+          ')"
+          if [[ "$RELEASE_TAG" != "$EXPECTED_TAG" ]]; then
             echo "::error::Release tag $RELEASE_TAG does not match manifest version $candidate_version"
             exit 1
           fi


### PR DESCRIPTION
## Problem
The first real `2.0.5-beta.1` draft proved that Tauri writes updater manifest versions with a leading `v` (`v2.0.5-beta.1`). The rolling Beta workflow compared the GitHub tag against `v${candidate_version}`, so publication would expect `vv2.0.5-beta.1`, fail validation, and never create the Beta pointer.

## Fix
- validate the manifest version as Stable or `X.Y.Z-beta.N`
- canonicalize versions with or without one leading `v` to exactly one-`v` GitHub tag
- use the shared helper in the publication workflow
- add regression coverage for Stable/Beta with and without the prefix

## Verification
- `node --test .github/scripts/should-update-beta-manifest.node-test.mjs` — 7 passed
- real draft value `v2.0.5-beta.1` canonicalizes to `v2.0.5-beta.1`
- workflow YAML parses
- independent release-critical review — no P0/P1/P2 findings

The `v2.0.5-beta.1` release remains an unpublished draft until this lands.