### PR TITLE
fix(release): allow safe beta pointer replay

### DIFF
--- a/.github/workflows/update-beta-channel.yml
+++ b/.github/workflows/update-beta-channel.yml
@@ -3,6 +3,12 @@ name: Update Beta Channel
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Published Stable/Beta release tag to replay'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,24 +21,37 @@ jobs:
   update-beta-manifest:
     # Creating the synthetic rolling `beta` release also emits `release.published`.
     # Ignore it or the pointer workflow would recursively trigger itself.
-    if: ${{ github.event.release.tag_name != 'beta' }}
+    if: ${{ (github.event_name == 'release' && github.event.release.tag_name != 'beta') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != 'beta') }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
-      RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
       REPOSITORY: ${{ github.repository }}
     steps:
       - name: Checkout channel tooling
         uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
 
-      - name: Download published updater manifest
+      - name: Load published updater manifest
         run: |
+          RELEASE_METADATA="$(gh release view \
+            --repo "$REPOSITORY" \
+            --json isDraft,isPrerelease \
+            -- "$RELEASE_TAG")"
+          if [[ "$(jq -r '.isDraft' <<< "$RELEASE_METADATA")" == "true" ]]; then
+            echo "::error::Release $RELEASE_TAG is still a draft"
+            exit 1
+          fi
+          echo "RELEASE_IS_PRERELEASE=$(jq -r '.isPrerelease' <<< "$RELEASE_METADATA")" >> "$GITHUB_ENV"
+
           mkdir -p candidate
-          gh release download "$RELEASE_TAG" \
+          gh release download \
             --repo "$REPOSITORY" \
             --pattern latest.json \
-            --dir candidate
+            --dir candidate \
+            -- "$RELEASE_TAG"
 
           CANDIDATE_VERSION="$(jq -r '.version' candidate/latest.json)"
           if [[ -z "$CANDIDATE_VERSION" || "$CANDIDATE_VERSION" == "null" ]]; then


### PR DESCRIPTION
## Problem
The first `v2.0.5-beta.1` publication executed the `release.published` workflow definition from the beta tag commit. That tag predates the merged manifest-prefix fix, so rerunning the event would repeat the old `vv2...` validation failure.

## Fix
- add a serialized `workflow_dispatch` replay path for an existing published release tag
- check out current channel tooling from `main`
- query actual GitHub release metadata and reject drafts
- derive prerelease status from GitHub rather than trusting manual input
- pass manual tags after `--` so option-like input cannot alter `gh` behavior
- disable checkout credential persistence
- retain the existing SemVer, signed immutable asset, and rolling-pointer safeguards

## Verification
- workflow YAML parses
- beta helper suite: 7 passed
- real `v2.0.5-beta.1` metadata query and manifest download succeed with the safe `--` syntax
- option-like input is treated as a nonexistent tag, not a `gh` flag
- independent final review: no P0/P1/P2/P3 findings

After merge, dispatch this workflow on `main` with `release_tag=v2.0.5-beta.1` to recover the live Beta pointer.