### PR TITLE
fix: preserve paid licenses through transient outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **tray:** recover from transient system-tray startup failures, keep the dashboard reachable, expose retry help, and attach tray diagnostics to support reports
 * **uploads:** constrain long speaker timelines so Copy and Save remain reachable
+* **licensing:** preserve paid access through temporary verification outages, retry validation three times, repair stale device activation automatically, and show a revalidation warning instead of `Trial expired`.
 
 ## [2.0.4](https://github.com/moinulmoin/voicetypr/compare/v2.0.3...v2.0.4) (2026-07-01)
 

--- a/plans/041-license-validation-resilience.md
+++ b/plans/041-license-validation-resilience.md
@@ -1,0 +1,24 @@
+# 041 — Paid-license validation resilience
+
+**Status: IN PROGRESS — claimed Main 2026-07-24**
+
+## Problem
+
+A paid user successfully activates Voicetypr, then later sees `Trial expired` and must enter the same license key again. A transient network or server failure must not erase or downgrade a paid entitlement, and must never be presented as a definitive trial/license expiration.
+
+## Locked behavior
+
+1. Only a definitive entitlement response from the licensing service may mark a paid license invalid or expired.
+2. Transport errors, timeouts, and server-unavailable responses keep the last verified paid entitlement through its existing offline-grace contract.
+3. Validation uses bounded retries and records consecutive scheduled verification failures without retrying indefinitely.
+4. Repeated transient failures escalate to a verification warning, not `Trial expired`; the UI offers an explicit revalidation action.
+5. Activation and validation never delete a stored paid key solely because the service was unreachable.
+
+## Acceptance
+
+- A paid cached license remains usable through transient validation failures.
+- A fresh paid activation survives restart and a simulated unavailable licensing service.
+- Three consecutive scheduled verification failures produce a truthful verification warning while preserving entitlement.
+- A definitive invalid/expired server response still revokes paid status immediately.
+- Focused Rust and frontend behavioral tests cover the state transitions.
+- No license key, device identifier, or raw server response is added to logs or telemetry.

--- a/plans/041-license-validation-resilience.md
+++ b/plans/041-license-validation-resilience.md
@@ -1,6 +1,6 @@
 # 041 — Paid-license validation resilience
 
-**Status: IN PROGRESS — claimed Main 2026-07-24**
+**Status: DONE — independent reviewer PASS 2026-07-24**
 
 ## Problem
 
@@ -22,3 +22,29 @@ A paid user successfully activates Voicetypr, then later sees `Trial expired` an
 - A definitive invalid/expired server response still revokes paid status immediately.
 - Focused Rust and frontend behavioral tests cover the state transitions.
 - No license key, device identifier, or raw server response is added to logs or telemetry.
+
+## Implementation
+
+- Startup clears only the short-lived status cache; the last successful validation timestamp now survives restarts.
+- License validation retries transport, malformed-response, `408`, `429`, and `5xx` failures up to three times with bounded backoff. Other `4xx` responses are not retried and retain a structured rejection outcome so definitive revocations cannot be mistaken for outages.
+- A stored key preserves `Licensed` status through the exact persisted 90-day grace deadline. Verified and offline runtime states both require online revalidation at that boundary; failures 1–2 use `offline_grace`, while failure 3+ uses `needs_revalidation`.
+- The 2.0.4 migration path seeds grace once from a stored key. A durable initialization marker prevents cache invalidation or failed keychain deletion from replaying that migration.
+- Explicit invalid/not-found/expired/revoked responses delete the stored key whether returned as a successful validation payload or a non-retryable `4xx`. Device mismatch attempts a five-second, server-enforced activation repair and otherwise preserves bounded offline access.
+- Account UI keeps `Pro Licensed` visible, explains that the license has not expired, and keeps revalidation reachable from both verified and warning states. License commands use a 60-second UI deadline.
+- Activation no longer transmits the machine hostname.
+- A shared async lock serializes checks, revalidation, activation, restoration, and deactivation so cache and failure-counter transitions cannot race. Transient restore also refreshes the runtime recording gate.
+
+## Validation
+
+- `cargo test license:: --lib` — 9 passed.
+- `cargo test` — 1,240 passed, 7 ignored.
+- `cargo test recording_license_state_requires_verification_after_offline_deadline --lib` — 1 passed.
+- `cargo clippy --lib -- -D warnings` — passed.
+- `cargo check --lib` — passed.
+- Touched Rust files formatted with `rustfmt`.
+- `LicenseContext.test.tsx` + `AccountSection.test.tsx` — 4 passed.
+- `pnpm test` — 584 passed, 1 skipped.
+- `pnpm typecheck` — passed.
+- `pnpm lint` — passed.
+- Independent final current-source review — **PASS**, no remaining P0/P1/P2 findings after the public cache-invalidation race was corrected.
+- Browser smoke rendered the real Account section in verified state, confirmed `Revalidate License` was reachable, exercised it, and observed the non-expiry `needs_revalidation` warning with `Revalidate now`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -39,7 +39,7 @@ Verification commands used across all plans: `pnpm typecheck`, `pnpm lint`,
 | 027  | Formatting & recording-pill UI/UX pass (naming, guidance, pill state legibility, app-category UI) | P2 | M | 016, 017 | TODO — captured 2026-06-19; backlog for post-2.0.0-smoke UAUX phase (notes only, not yet claimed) |
 | 028  | Transcription latency + streaming ("fast af" dictation) — investigation + phased design | P2 | XL | 015/020 smoke | TODO — drafted 2026-06-20; design/index only, not claimed. Phase 0 (insert-path plumbing tail + ffmpeg normalize) is S/LOW-risk and shippable alone; Phases 1–5 (decode-ahead, Parakeet/Whisper/cloud streaming, partial UX) graduate to 029+ |
 | 031  | GlitchTip observability — errors, symbols, curated logs, sampled traces | P0 | M | — | IN PROGRESS — claimed Main 2026-07-14; user approved stages 1–4 for next Beta |
-| 041  | Paid-license validation resilience | P0 | M | — | IN PROGRESS — claimed Main 2026-07-24; repeated paid-user `Trial expired` report |
+| 041  | Paid-license validation resilience | P0 | M | — | DONE — reviewer PASS; focused/full gates + local Account UI smoke passed 2026-07-24 |
 
 ## Code-done, awaiting batched manual smoke (`plans/SMOKE.md`)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -39,6 +39,7 @@ Verification commands used across all plans: `pnpm typecheck`, `pnpm lint`,
 | 027  | Formatting & recording-pill UI/UX pass (naming, guidance, pill state legibility, app-category UI) | P2 | M | 016, 017 | TODO — captured 2026-06-19; backlog for post-2.0.0-smoke UAUX phase (notes only, not yet claimed) |
 | 028  | Transcription latency + streaming ("fast af" dictation) — investigation + phased design | P2 | XL | 015/020 smoke | TODO — drafted 2026-06-20; design/index only, not claimed. Phase 0 (insert-path plumbing tail + ffmpeg normalize) is S/LOW-risk and shippable alone; Phases 1–5 (decode-ahead, Parakeet/Whisper/cloud streaming, partial UX) graduate to 029+ |
 | 031  | GlitchTip observability — errors, symbols, curated logs, sampled traces | P0 | M | — | IN PROGRESS — claimed Main 2026-07-14; user approved stages 1–4 for next Beta |
+| 041  | Paid-license validation resilience | P0 | M | — | IN PROGRESS — claimed Main 2026-07-24; repeated paid-user `Trial expired` report |
 
 ## Code-done, awaiting batched manual smoke (`plans/SMOKE.md`)
 

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1665,6 +1665,8 @@ mod tests {
             license_type: None,
             license_key: None,
             expires_at: None,
+            verification_state: None,
+            verification_expires_at: None,
         })
     }
 
@@ -2202,6 +2204,18 @@ mod tests {
         assert_eq!(
             recording_license_state(Some(&cached)),
             RecordingLicenseState::Blocked
+        );
+    }
+
+    #[test]
+    fn recording_license_state_requires_verification_after_offline_deadline() {
+        let mut cached = cached_license(LicenseState::Licensed);
+        cached.status.verification_state = Some(crate::license::LicenseVerificationState::Verified);
+        cached.status.verification_expires_at =
+            Some(chrono::Utc::now() - chrono::Duration::seconds(1));
+        assert_eq!(
+            recording_license_state(Some(&cached)),
+            RecordingLicenseState::VerificationRequired
         );
     }
 
@@ -3582,12 +3596,20 @@ enum RecordingLicenseState {
     Ready,
     Loading,
     Blocked,
+    VerificationRequired,
 }
 
 fn recording_license_state(
     cache: Option<&crate::commands::license::CachedLicense>,
 ) -> RecordingLicenseState {
     match cache {
+        Some(cached)
+            if cached
+                .status
+                .verification_window_expired(chrono::Utc::now()) =>
+        {
+            RecordingLicenseState::VerificationRequired
+        }
         Some(cached)
             if matches!(
                 cached.status.status,
@@ -3656,6 +3678,20 @@ async fn validate_recording_requirements(app: &AppHandle) -> Result<(), String> 
     let cache = app_state.license_cache.read().await;
 
     match recording_license_state(cache.as_ref()) {
+        RecordingLicenseState::VerificationRequired => {
+            log::warn!("Recording blocked: offline license verification window has ended");
+            let _ = crate::commands::window::focus_main_window(app.clone()).await;
+            let _ = emit_to_all(
+                app,
+                "license-required",
+                serde_json::json!({
+                    "title": "License Verification Required",
+                    "message": "Connect to the internet and revalidate your license to continue recording.",
+                    "action": "revalidate"
+                }),
+            );
+            return Err("License verification required to record".to_string());
+        }
         RecordingLicenseState::Blocked => {
             if let Some(cached) = cache.as_ref() {
                 log::warn!("Recording blocked: license is {:?}", cached.status.status);

--- a/src-tauri/src/commands/license.rs
+++ b/src-tauri/src/commands/license.rs
@@ -1,4 +1,7 @@
-use crate::license::{api_client::LicenseApiClient, device, keychain, LicenseState, LicenseStatus};
+use crate::license::{
+    api_client::{LicenseApiClient, LicenseValidationFailureKind},
+    device, keychain, LicenseState, LicenseStatus, LicenseVerificationState,
+};
 use crate::simple_cache::{self as scache, SetItemOptions};
 use crate::AppState;
 use chrono::{DateTime, Duration, Utc};
@@ -54,8 +57,11 @@ const TRIAL_OFFLINE_GRACE_PERIOD_DAYS: i64 = 1; // 1 day offline grace for trial
 const CACHE_TTL_HOURS: u64 = 8; // 8-hour cache TTL for both licensed and trial users
 const LICENSE_CACHE_KEY: &str = "license_status";
 const LAST_VALIDATION_KEY: &str = "last_license_validation";
+const VALIDATION_ANCHOR_INITIALIZED_KEY: &str = "license_validation_anchor_initialized";
 const LAST_TRIAL_VALIDATION_KEY: &str = "last_trial_validation"; // Tracks when trial was last validated online
 const TRIAL_EXPIRES_KEY: &str = "trial_expires_at"; // Cache key for trial expiry date
+const VALIDATION_FAILURES_KEY: &str = "license_validation_failures";
+const REVALIDATION_WARNING_THRESHOLD: u32 = 3;
 
 // Error message constants for consistency
 const ERR_INVALID_LICENSE: &str = "Invalid license key format";
@@ -80,32 +86,19 @@ fn hours_to_days(hours: i64) -> i32 {
     (hours as f64 / 24.0).ceil() as i32
 }
 
-// Check if we're within the grace period for offline access
-fn is_within_grace_period(app: &AppHandle) -> Option<i64> {
-    // Use store-backed cache helper
-    // let cache = app.cache();
-
-    if let Ok(Some(timestamp_json)) = scache::get(app, LAST_VALIDATION_KEY) {
-        if let Ok(last_validation) = serde_json::from_value::<DateTime<Utc>>(timestamp_json) {
-            let elapsed = Utc::now().signed_duration_since(last_validation);
-            let days_elapsed = elapsed.num_days();
-
-            if days_elapsed < OFFLINE_GRACE_PERIOD_DAYS {
-                return Some(OFFLINE_GRACE_PERIOD_DAYS - days_elapsed);
-            }
-        }
-    }
-
-    None
-}
-
-// Check if grace period timestamp exists (regardless of whether it's valid)
-fn has_grace_period_timestamp(app: &AppHandle) -> bool {
-    // let cache = app.cache();
+fn last_successful_validation(app: &AppHandle) -> Option<DateTime<Utc>> {
     scache::get(app, LAST_VALIDATION_KEY)
         .ok()
         .flatten()
-        .is_some()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn validation_anchor_initialized(app: &AppHandle) -> bool {
+    scache::get(app, VALIDATION_ANCHOR_INITIALIZED_KEY)
+        .ok()
+        .flatten()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or(false)
 }
 
 // Check if we're within the trial grace period
@@ -138,6 +131,47 @@ fn should_delete_invalid_license(error_msg: &str) -> bool {
         || msg_lower.contains("license revoked")
 }
 
+fn consecutive_validation_failures(app: &AppHandle) -> u32 {
+    scache::get(app, VALIDATION_FAILURES_KEY)
+        .ok()
+        .flatten()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or(0)
+}
+
+fn record_validation_failure(app: &AppHandle) -> u32 {
+    let failures = consecutive_validation_failures(app).saturating_add(1);
+    if let Err(error) = scache::set(
+        app,
+        VALIDATION_FAILURES_KEY,
+        serde_json::to_value(failures).unwrap_or_default(),
+        None,
+    ) {
+        log::warn!(
+            "Failed to persist license validation failure count: {}",
+            error
+        );
+    }
+    failures
+}
+
+fn reset_validation_failures(app: &AppHandle) {
+    if let Err(error) = scache::remove(app, VALIDATION_FAILURES_KEY) {
+        log::warn!(
+            "Failed to reset license validation failure count: {}",
+            error
+        );
+    }
+}
+
+fn verification_state_for_failures(failures: u32) -> LicenseVerificationState {
+    if failures >= REVALIDATION_WARNING_THRESHOLD {
+        LicenseVerificationState::NeedsRevalidation
+    } else {
+        LicenseVerificationState::OfflineGrace
+    }
+}
+
 /// Check the current license status
 /// This checks license first (if stored), then falls back to trial
 /// Forces fresh check on app start, then uses cache during session
@@ -147,12 +181,164 @@ async fn seed_runtime_license_cache(app: &AppHandle, status: &LicenseStatus) {
     *perf_cache = Some(CachedLicense::new(status.clone()));
 }
 
+fn cache_license_status(app: &AppHandle, status: &LicenseStatus) {
+    let wrapped_status = CachedLicenseStatus {
+        status: status.clone(),
+        cached_at: Utc::now(),
+    };
+    let cache_options = Some(SetItemOptions {
+        ttl: Some(CACHE_TTL_HOURS * 60 * 60),
+        compress: None,
+        compression_method: None,
+    });
+    if let Err(error) = scache::set(
+        app,
+        LICENSE_CACHE_KEY,
+        serde_json::to_value(wrapped_status).unwrap_or_default(),
+        cache_options,
+    ) {
+        log::warn!("Failed to cache license status: {}", error);
+    }
+}
+
+fn licensed_status(
+    license_key: String,
+    verification_state: LicenseVerificationState,
+    expires_at: Option<String>,
+    verification_expires_at: Option<DateTime<Utc>>,
+) -> LicenseStatus {
+    LicenseStatus {
+        status: LicenseState::Licensed,
+        trial_days_left: None,
+        license_type: Some("pro".to_string()),
+        license_key: Some(license_key),
+        expires_at,
+        verification_state: Some(verification_state),
+        verification_expires_at,
+    }
+}
+
+fn record_successful_validation(app: &AppHandle) -> DateTime<Utc> {
+    let validation_time = Utc::now();
+    if let Err(error) = scache::set(
+        app,
+        LAST_VALIDATION_KEY,
+        serde_json::to_value(validation_time).unwrap_or_default(),
+        None,
+    ) {
+        log::warn!("Failed to persist successful license validation: {}", error);
+    }
+    if let Err(error) = scache::set(
+        app,
+        VALIDATION_ANCHOR_INITIALIZED_KEY,
+        serde_json::json!(true),
+        None,
+    ) {
+        log::warn!(
+            "Failed to persist license validation anchor state: {}",
+            error
+        );
+    }
+    reset_validation_failures(app);
+    validation_time + Duration::days(OFFLINE_GRACE_PERIOD_DAYS)
+}
+
+fn preserve_paid_entitlement(
+    app: &AppHandle,
+    license_key: String,
+) -> Result<LicenseStatus, String> {
+    let now = Utc::now();
+    let validation_time = match last_successful_validation(app) {
+        Some(validation_time) => validation_time,
+        None if validation_anchor_initialized(app) => {
+            return Err(
+                "Couldn't verify the license because its validation history is unavailable. Connect to the internet and revalidate."
+                    .to_string(),
+            );
+        }
+        None => {
+            // Versions through 2.0.4 deleted this timestamp during every startup.
+            // A stored key is only written after successful activation, so seed the
+            // existing entitlement once instead of locking that paid user out.
+            scache::set(
+                app,
+                LAST_VALIDATION_KEY,
+                serde_json::to_value(now).unwrap_or_default(),
+                None,
+            )
+            .map_err(|error| {
+                format!(
+                    "Couldn't preserve offline license access after verification failed: {}",
+                    error
+                )
+            })?;
+            scache::set(
+                app,
+                VALIDATION_ANCHOR_INITIALIZED_KEY,
+                serde_json::json!(true),
+                None,
+            )
+            .map_err(|error| {
+                format!(
+                    "Couldn't preserve the license validation boundary after verification failed: {}",
+                    error
+                )
+            })?;
+            now
+        }
+    };
+    let verification_expires_at = validation_time + Duration::days(OFFLINE_GRACE_PERIOD_DAYS);
+    if now >= verification_expires_at {
+        return Err(
+            "Couldn't verify the license and the offline grace period has ended. Connect to the internet and revalidate."
+                .to_string(),
+        );
+    }
+
+    let seconds_remaining = (verification_expires_at - now).num_seconds();
+    let days_remaining = ((seconds_remaining + 86_399) / 86_400).max(1);
+    let failures = record_validation_failure(app);
+    let status = licensed_status(
+        license_key,
+        verification_state_for_failures(failures),
+        Some(format!("{} days offline remaining", days_remaining)),
+        Some(verification_expires_at),
+    );
+    cache_license_status(app, &status);
+    Ok(status)
+}
+
+async fn revoke_paid_entitlement(app: &AppHandle) {
+    if keychain::delete_license(app).is_err() {
+        log::warn!("Failed to remove a definitively rejected license from secure storage");
+    }
+    if scache::set(
+        app,
+        VALIDATION_ANCHOR_INITIALIZED_KEY,
+        serde_json::json!(true),
+        None,
+    )
+    .is_err()
+    {
+        log::warn!("Failed to persist the rejected license boundary");
+    }
+    let _ = scache::remove(app, LAST_VALIDATION_KEY);
+    reset_validation_failures(app);
+    clear_license_status_cache(app).await;
+}
+
 #[tauri::command]
 pub async fn check_license_status(app: AppHandle) -> Result<LicenseStatus, String> {
-    log::info!("Checking license status");
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
+    perform_license_status_check(&app).await
+}
 
-    // Directly call the implementation - Tauri handles concurrent command execution
-    check_license_status_impl(app).await
+async fn perform_license_status_check(app: &AppHandle) -> Result<LicenseStatus, String> {
+    log::info!("Checking license status");
+    let status = check_license_status_impl(app.clone()).await?;
+    seed_runtime_license_cache(app, &status).await;
+    Ok(status)
 }
 
 /// Internal implementation of license status check
@@ -163,7 +349,6 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
     match scache::get(&app, LICENSE_CACHE_KEY) {
         Ok(Some(cached_json)) => {
             log::info!("📦 Cache hit: Found cached license status");
-            log::debug!("Raw cached data: {:?}", cached_json);
 
             // Try to deserialize as new format first (with metadata)
             match serde_json::from_value::<CachedLicenseStatus>(cached_json.clone()) {
@@ -196,8 +381,11 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                                 return Ok(status);
                             }
                         }
+                    } else if status.verification_window_expired(Utc::now()) {
+                        log::warn!(
+                            "Cached offline grace has ended - performing fresh license check"
+                        );
                     } else {
-                        // Not a trial, return cached status
                         return Ok(status);
                     }
                 }
@@ -223,8 +411,11 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                                 } else {
                                     return Ok(cached_status);
                                 }
+                            } else if cached_status.verification_window_expired(Utc::now()) {
+                                log::warn!(
+                                    "Cached offline grace has ended - performing fresh license check"
+                                );
                             } else {
-                                // Not a trial, return cached status
                                 return Ok(cached_status);
                             }
                         }
@@ -258,128 +449,65 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
             .validate_license(&license_key, &device_hash, Some(&app_version))
             .await
         {
+            Ok(response) if response.data.valid => {
+                log::info!("License is valid");
+                let verification_expires_at = record_successful_validation(&app);
+                let status = licensed_status(
+                    license_key,
+                    LicenseVerificationState::Verified,
+                    None,
+                    Some(verification_expires_at),
+                );
+                cache_license_status(&app, &status);
+                return Ok(status);
+            }
             Ok(response) => {
-                if response.data.valid {
-                    log::info!("License is valid");
-                    let status = LicenseStatus {
-                        status: LicenseState::Licensed,
-                        trial_days_left: None,
-                        license_type: Some("pro".to_string()), // You might want to get this from the API
-                        license_key: Some(license_key),
-                        expires_at: None,
-                    };
-
-                    // Store last successful validation timestamp
-                    let validation_time = Utc::now();
-                    let _ = scache::set(
-                        &app,
-                        LAST_VALIDATION_KEY,
-                        serde_json::to_value(validation_time).unwrap_or_default(),
-                        None,
+                let message = response.message.as_deref().unwrap_or_default();
+                if should_delete_invalid_license(message) {
+                    log::warn!("License service definitively rejected the stored license");
+                    revoke_paid_entitlement(&app).await;
+                } else {
+                    log::warn!(
+                        "License could not be verified definitively; preserving paid entitlement"
                     );
 
-                    // Cache for 24 hours for licensed users
-                    let wrapped_status = CachedLicenseStatus {
-                        status: status.clone(),
-                        cached_at: validation_time,
-                    };
-
-                    let cache_options = Some(SetItemOptions {
-                        ttl: Some(CACHE_TTL_HOURS * 60 * 60), // 8 hours in seconds
-                        compress: None,
-                        compression_method: None,
-                    });
-                    match scache::set(
-                        &app,
-                        LICENSE_CACHE_KEY,
-                        serde_json::to_value(&wrapped_status).unwrap_or_default(),
-                        cache_options,
-                    ) {
-                        Ok(_) => log::info!(
-                            "Cached licensed status for {} hours with metadata",
-                            CACHE_TTL_HOURS
-                        ),
-                        Err(e) => log::error!("Failed to cache licensed status: {}", e),
-                    }
-
-                    return Ok(status);
-                } else {
-                    log::warn!("Stored license is invalid: {:?}", response.message);
-                    // Only delete if we're certain the license is invalid
-                    if let Some(ref msg) = response.message {
-                        if should_delete_invalid_license(msg) {
-                            log::info!("Removing invalid license from keychain");
-                            let _ = keychain::delete_license(&app);
-                        } else {
-                            log::warn!("License validation failed but keeping stored license (error might be temporary)");
+                    if message.to_lowercase().contains("different device") {
+                        log::info!("Attempting to repair the device activation");
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            activate_license_internal(license_key.clone(), app.clone()),
+                        )
+                        .await
+                        {
+                            Ok(Ok(status)) => return Ok(status),
+                            Ok(Err(_)) => {
+                                log::warn!(
+                                    "Automatic device activation repair failed; preserving offline access"
+                                );
+                            }
+                            Err(_) => {
+                                log::warn!(
+                                    "Automatic device activation repair timed out; preserving offline access"
+                                );
+                            }
                         }
                     }
+
+                    return preserve_paid_entitlement(&app, license_key);
                 }
             }
-            Err(e) => {
-                log::error!("Failed to validate license: {}", e);
-
-                // Check if we're within the offline grace period
-                if let Some(days_remaining) = is_within_grace_period(&app) {
-                    log::info!(
-                        "API unavailable but within {}-day grace period. {} days remaining",
-                        OFFLINE_GRACE_PERIOD_DAYS,
-                        days_remaining
-                    );
-
-                    // Warn if approaching limit
-                    if days_remaining <= 7 {
-                        log::warn!("⚠️ Only {} days of offline access remaining. Please connect to internet soon.",
-                                 days_remaining);
-                    }
-
-                    let status = LicenseStatus {
-                        status: LicenseState::Licensed,
-                        trial_days_left: None,
-                        license_type: Some("pro".to_string()),
-                        license_key: Some(license_key),
-                        expires_at: Some(format!("{} days offline remaining", days_remaining)),
-                    };
-
-                    // Cache with 8-hour TTL during grace period
-                    let wrapped_status = CachedLicenseStatus {
-                        status: status.clone(),
-                        cached_at: Utc::now(),
-                    };
-
-                    let cache_options = Some(SetItemOptions {
-                        ttl: Some(CACHE_TTL_HOURS * 60 * 60), // 8 hours
-                        compress: None,
-                        compression_method: None,
-                    });
-                    let _ = scache::set(
-                        &app,
-                        LICENSE_CACHE_KEY,
-                        serde_json::to_value(&wrapped_status).unwrap_or_default(),
-                        cache_options,
-                    );
-
-                    return Ok(status);
-                } else {
-                    // Check if we have a timestamp at all before assuming grace period expired
-                    if has_grace_period_timestamp(&app) {
-                        // Timestamp exists and grace period expired
-                        log::error!("Grace period of {} days has expired. License requires online validation.",
-                                  OFFLINE_GRACE_PERIOD_DAYS);
-                        // DO NOT DELETE THE LICENSE! User paid for it and might just be offline temporarily
-                        // Clear the timestamp so next successful validation starts fresh grace period
-                        let _ = scache::remove(&app, LAST_VALIDATION_KEY);
-                        return Err("Grace period expired. Please connect to internet to revalidate your license.".to_string());
-                    } else {
-                        // No timestamp exists - this is the first offline attempt
-                        log::warn!("No previous online validation found. Initial online validation required.");
-                        // DON'T delete the license - it may still be valid
-                        return Err(
-                            "Initial online validation required. Please connect to internet."
-                                .to_string(),
-                        );
-                    }
-                }
+            Err(error)
+                if error.kind == LicenseValidationFailureKind::Rejected
+                    && should_delete_invalid_license(&error.message) =>
+            {
+                log::warn!("License service definitively rejected the stored license");
+                revoke_paid_entitlement(&app).await;
+            }
+            Err(_) => {
+                log::warn!(
+                    "License verification unavailable after bounded retries; preserving offline access"
+                );
+                return preserve_paid_entitlement(&app, license_key);
             }
         }
     }
@@ -398,6 +526,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                     license_type: None,
                     license_key: None,
                     expires_at: None,
+                    verification_state: None,
+                    verification_expires_at: None,
                 };
 
                 // Don't cache expired status - always check
@@ -414,6 +544,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                     license_type: None,
                     license_key: None,
                     expires_at: None,
+                    verification_state: None,
+                    verification_expires_at: None,
                 };
 
                 // Set last successful trial validation timestamp for grace period tracking
@@ -511,6 +643,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                                 license_type: None,
                                 license_key: None,
                                 expires_at: None,
+                                verification_state: None,
+                                verification_expires_at: None,
                             });
                         }
 
@@ -542,6 +676,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                                     "Offline grace: {} day remaining",
                                     grace_days_remaining
                                 )),
+                                verification_state: None,
+                                verification_expires_at: None,
                             };
 
                             return Ok(status);
@@ -605,6 +741,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
                 license_type: None,
                 license_key: None,
                 expires_at: None,
+                verification_state: None,
+                verification_expires_at: None,
             };
 
             // Don't cache None status - always check
@@ -617,6 +755,8 @@ async fn check_license_status_impl(app: AppHandle) -> Result<LicenseStatus, Stri
 #[tauri::command]
 pub async fn restore_license(app: AppHandle) -> Result<LicenseStatus, String> {
     log::info!("Attempting to restore license");
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
 
     // Check if we have a stored license
     let license_key =
@@ -636,21 +776,9 @@ pub async fn restore_license(app: AppHandle) -> Result<LicenseStatus, String> {
                 log::info!("License restored successfully");
 
                 // Clear cache when license is restored
-                let _ = invalidate_license_cache(app.clone()).await;
+                clear_license_status_cache(&app).await;
 
-                // Set last validation timestamp for grace period tracking
-                let validation_time = Utc::now();
-                if let Err(e) = scache::set(
-                    &app,
-                    LAST_VALIDATION_KEY,
-                    serde_json::to_value(validation_time).unwrap_or_default(),
-                    None, // No TTL for validation timestamp
-                ) {
-                    log::warn!(
-                        "Failed to set last validation timestamp during restore: {}",
-                        e
-                    );
-                }
+                let verification_expires_at = record_successful_validation(&app);
 
                 // Reset recording state when license is restored
                 let app_state = app.state::<AppState>();
@@ -663,24 +791,50 @@ pub async fn restore_license(app: AppHandle) -> Result<LicenseStatus, String> {
                     log::info!("Reset recording state to Idle during license restore");
                 }
 
-                let status = LicenseStatus {
-                    status: LicenseState::Licensed,
-                    trial_days_left: None,
-                    license_type: Some("pro".to_string()),
-                    license_key: Some(license_key),
-                    expires_at: None,
-                };
+                let status = licensed_status(
+                    license_key,
+                    LicenseVerificationState::Verified,
+                    None,
+                    Some(verification_expires_at),
+                );
                 seed_runtime_license_cache(&app, &status).await;
                 Ok(status)
             } else {
-                // License is not valid for this device, try to activate it
-                log::info!("License not valid for this device, attempting activation");
-                activate_license_internal(license_key, app).await
+                let message = response.message.as_deref().unwrap_or_default();
+                if should_delete_invalid_license(message) {
+                    revoke_paid_entitlement(&app).await;
+                    Err(
+                        "The stored license is no longer valid. Enter a valid license key to continue."
+                            .to_string(),
+                    )
+                } else {
+                    log::info!("License not valid for this device, attempting activation");
+                    activate_license_internal(license_key, app).await
+                }
             }
         }
-        Err(e) => {
-            log::error!("Failed to validate license: {}", e);
-            Err(format!("Failed to restore license: {}", e))
+        Err(error)
+            if error.kind == LicenseValidationFailureKind::Rejected
+                && should_delete_invalid_license(&error.message) =>
+        {
+            revoke_paid_entitlement(&app).await;
+            Err(
+                "The stored license is no longer valid. Enter a valid license key to continue."
+                    .to_string(),
+            )
+        }
+        Err(_) => {
+            log::warn!("License restore verification unavailable; preserving offline access");
+            let status = preserve_paid_entitlement(&app, license_key)?;
+            seed_runtime_license_cache(&app, &status).await;
+            let app_state = app.state::<AppState>();
+            if let Err(error) = app_state.recording_state.reset() {
+                log::warn!(
+                    "Failed to reset recording state after offline license restore: {}",
+                    error
+                );
+            }
+            Ok(status)
         }
     }
 }
@@ -716,6 +870,9 @@ pub async fn activate_license(
     {
         return Err("License key contains invalid characters".to_string());
     }
+
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
 
     // Reset recording state to Idle when activating license
     // This ensures we're not stuck in Error state from previous license issues
@@ -763,18 +920,9 @@ async fn activate_license_internal(
                 log::info!("License activated successfully");
 
                 // Clear cache when license is activated
-                let _ = invalidate_license_cache(app.clone()).await;
+                clear_license_status_cache(&app).await;
 
-                // Set last validation timestamp for grace period tracking
-                let validation_time = Utc::now();
-                if let Err(e) = scache::set(
-                    &app,
-                    LAST_VALIDATION_KEY,
-                    serde_json::to_value(validation_time).unwrap_or_default(),
-                    None, // No TTL for validation timestamp
-                ) {
-                    log::warn!("Failed to set last validation timestamp: {}", e);
-                }
+                let verification_expires_at = record_successful_validation(&app);
 
                 // Reset recording state when license is successfully activated
                 let app_state = app.state::<AppState>();
@@ -787,13 +935,12 @@ async fn activate_license_internal(
                     log::info!("Reset recording state to Idle after successful activation");
                 }
 
-                let status = LicenseStatus {
-                    status: LicenseState::Licensed,
-                    trial_days_left: None,
-                    license_type: Some("pro".to_string()),
-                    license_key: Some(license_key),
-                    expires_at: None,
-                };
+                let status = licensed_status(
+                    license_key,
+                    LicenseVerificationState::Verified,
+                    None,
+                    Some(verification_expires_at),
+                );
                 seed_runtime_license_cache(&app, &status).await;
                 Ok(status)
             } else {
@@ -815,6 +962,8 @@ async fn activate_license_internal(
 #[tauri::command]
 pub async fn deactivate_license(app: AppHandle) -> Result<(), String> {
     log::info!("Deactivating license");
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
 
     // Get the stored license
     let license_key =
@@ -842,7 +991,8 @@ pub async fn deactivate_license(app: AppHandle) -> Result<(), String> {
                 let _ = scache::remove(&app, LAST_VALIDATION_KEY);
 
                 // Clear our performance cache too
-                let _ = invalidate_license_cache(app.clone()).await;
+                clear_license_status_cache(&app).await;
+                reset_validation_failures(&app);
 
                 log::info!("License deactivated successfully");
 
@@ -932,26 +1082,111 @@ pub async fn open_purchase_page() -> Result<(), String> {
     Ok(())
 }
 
+async fn clear_license_status_cache(app: &AppHandle) {
+    match scache::remove(app, LICENSE_CACHE_KEY) {
+        Ok(_) => log::debug!("Cleared cached license status"),
+        Err(error) => log::warn!("Failed to clear cached license status: {}", error),
+    }
+
+    let app_state = app.state::<AppState>();
+    let mut runtime_cache = app_state.license_cache.write().await;
+    *runtime_cache = None;
+}
+
+#[tauri::command]
+pub async fn revalidate_license(app: AppHandle) -> Result<LicenseStatus, String> {
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
+    clear_license_status_cache(&app).await;
+    perform_license_status_check(&app).await
+}
+
 pub async fn check_license_status_internal(app: &AppHandle) -> Result<LicenseStatus, String> {
-    let status = check_license_status(app.clone()).await?;
-    seed_runtime_license_cache(app, &status).await;
-    Ok(status)
+    check_license_status(app.clone()).await
 }
 
 /// Invalidate cached license status when license state changes
 #[tauri::command]
 pub async fn invalidate_license_cache(app: AppHandle) -> Result<(), String> {
-    // Clear both the old cache and the new performance cache
-    match scache::remove(&app, LICENSE_CACHE_KEY) {
-        Ok(_) => log::debug!("Cleared old license cache"),
-        Err(e) => log::warn!("Failed to clear old license cache: {}", e),
-    }
-    let _ = scache::remove(&app, LAST_VALIDATION_KEY);
-
-    // Clear the new performance cache
-    let app_state = app.state::<AppState>();
-    let mut perf_cache = app_state.license_cache.write().await;
-    *perf_cache = None;
-    log::debug!("License cache invalidated due to license state change");
+    let validation_lock = app.state::<AppState>().license_validation_lock.clone();
+    let _validation_guard = validation_lock.lock().await;
+    clear_license_status_cache(&app).await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_verification_failures_escalate_without_expiring_entitlement() {
+        assert_eq!(
+            verification_state_for_failures(1),
+            LicenseVerificationState::OfflineGrace
+        );
+        assert_eq!(
+            verification_state_for_failures(2),
+            LicenseVerificationState::OfflineGrace
+        );
+        assert_eq!(
+            verification_state_for_failures(3),
+            LicenseVerificationState::NeedsRevalidation
+        );
+
+        let deadline = Utc::now() + Duration::days(90);
+        let status = licensed_status(
+            "VT-TEST-LICENSE".to_string(),
+            verification_state_for_failures(3),
+            Some("90 days offline remaining".to_string()),
+            Some(deadline),
+        );
+        assert_eq!(status.status, LicenseState::Licensed);
+        assert_eq!(
+            status.verification_state,
+            Some(LicenseVerificationState::NeedsRevalidation)
+        );
+        assert!(!status.verification_window_expired(Utc::now()));
+        assert!(status.verification_window_expired(deadline));
+    }
+
+    #[test]
+    fn verified_license_requires_revalidation_at_exact_deadline() {
+        let deadline = Utc::now() + Duration::days(90);
+        let status = licensed_status(
+            "VT-TEST-LICENSE".to_string(),
+            LicenseVerificationState::Verified,
+            None,
+            Some(deadline),
+        );
+
+        assert!(!status.verification_window_expired(deadline - Duration::milliseconds(1)));
+        assert!(status.verification_window_expired(deadline));
+    }
+
+    #[test]
+    fn only_definitive_entitlement_messages_delete_a_stored_license() {
+        assert!(should_delete_invalid_license("License revoked"));
+        assert!(should_delete_invalid_license("License not found"));
+        assert!(!should_delete_invalid_license(
+            "This license is registered to a different device."
+        ));
+        assert!(!should_delete_invalid_license(
+            "License service temporarily unavailable"
+        ));
+    }
+
+    #[test]
+    fn old_cached_license_status_deserializes_without_verification_metadata() {
+        let status: LicenseStatus = serde_json::from_value(serde_json::json!({
+            "status": "licensed",
+            "trial_days_left": null,
+            "license_type": "pro",
+            "license_key": "VT-TEST-LICENSE",
+            "expires_at": null
+        }))
+        .expect("legacy cached status should remain readable");
+
+        assert_eq!(status.status, LicenseState::Licensed);
+        assert_eq!(status.verification_state, None);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -676,11 +676,11 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             }
 
-            // Clear license cache on app start to ensure fresh checks
+            // Force a fresh online check while preserving the last successful
+            // validation timestamp that anchors paid offline grace.
             {
                 use crate::simple_cache;
                 let _ = simple_cache::remove(app.app_handle(), "license_status");
-                let _ = simple_cache::remove(app.app_handle(), "last_license_validation");
             }
 
             // Initialize whisper manager
@@ -1528,6 +1528,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             request_microphone_permission,
             test_automation_permission,
             check_license_status,
+            revalidate_license,
             restore_license,
             activate_license,
             deactivate_license,

--- a/src-tauri/src/license/api_client.rs
+++ b/src-tauri/src/license/api_client.rs
@@ -3,14 +3,11 @@ use reqwest;
 use serde_json::json;
 use std::time::Duration;
 use sysinfo::System;
-// use tokio::time::sleep; // TODO: Implement retry logic
+use tokio::time::sleep;
 
 const API_TIMEOUT: Duration = Duration::from_secs(30);
-
-// TODO: Implement retry logic
-#[allow(dead_code)]
+const VALIDATION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_RETRIES: u32 = 3;
-#[allow(dead_code)]
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Base URL for the Voicetypr backend API.
@@ -30,8 +27,37 @@ fn get_api_base_url() -> String {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LicenseValidationFailureKind {
+    Unavailable,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LicenseValidationError {
+    pub kind: LicenseValidationFailureKind,
+    pub message: String,
+}
+
+impl LicenseValidationError {
+    fn unavailable(message: String) -> Self {
+        Self {
+            kind: LicenseValidationFailureKind::Unavailable,
+            message,
+        }
+    }
+
+    fn rejected(message: String) -> Self {
+        Self {
+            kind: LicenseValidationFailureKind::Rejected,
+            message,
+        }
+    }
+}
+
 pub struct LicenseApiClient {
     client: reqwest::Client,
+    base_url: String,
 }
 
 impl LicenseApiClient {
@@ -41,12 +67,15 @@ impl LicenseApiClient {
             .build()
             .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            base_url: get_api_base_url(),
+        })
     }
 
     /// Check trial status for a device
     pub async fn check_trial(&self, device_hash: &str) -> Result<TrialCheckResponse, String> {
-        let url = format!("{}/trial/check", get_api_base_url());
+        let url = format!("{}/trial/check", self.base_url);
 
         // Trial check doesn't need OS info, keeping it simple
         let response = self
@@ -80,20 +109,18 @@ impl LicenseApiClient {
         license_key: &str,
         device_hash: &str,
         app_version: Option<&str>,
-    ) -> Result<LicenseValidateResponse, String> {
-        let url = format!("{}/license/validate", get_api_base_url());
+    ) -> Result<LicenseValidateResponse, LicenseValidationError> {
+        let url = format!("{}/license/validate", self.base_url);
 
         let mut body = json!({
             "licenseKey": license_key,
             "deviceHash": device_hash
         });
 
-        // Add app version (required for validate)
         if let Some(version) = app_version {
             body["appVersion"] = json!(version);
         }
 
-        // Add OS type based on compile target
         #[cfg(target_os = "macos")]
         {
             body["osType"] = json!("macos");
@@ -107,32 +134,88 @@ impl LicenseApiClient {
             body["osType"] = json!("linux");
         }
 
-        // Add OS version using sysinfo
         if let Some(os_version) = System::os_version() {
             body["osVersion"] = json!(os_version);
         }
 
-        let response = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| format!("Network error: {}", e))?;
-
-        if response.status().is_success() {
-            response
-                .json::<LicenseValidateResponse>()
+        let mut last_error =
+            LicenseValidationError::unavailable("License validation failed".to_string());
+        for attempt in 1..=MAX_RETRIES {
+            let response = match self
+                .client
+                .post(&url)
+                .timeout(VALIDATION_ATTEMPT_TIMEOUT)
+                .json(&body)
+                .send()
                 .await
-                .map_err(|e| format!("Failed to parse response: {}", e))
-        } else {
-            let error: ApiError = response.json().await.unwrap_or(ApiError {
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    last_error =
+                        LicenseValidationError::unavailable(format!("Network error: {}", error));
+                    if attempt < MAX_RETRIES {
+                        log::warn!(
+                            "License validation transport failure (attempt {}/{}); retrying",
+                            attempt,
+                            MAX_RETRIES
+                        );
+                        sleep(INITIAL_RETRY_DELAY * attempt).await;
+                        continue;
+                    }
+                    break;
+                }
+            };
+
+            let status = response.status();
+            if status.is_success() {
+                match response.json::<LicenseValidateResponse>().await {
+                    Ok(parsed) => return Ok(parsed),
+                    Err(error) => {
+                        last_error = LicenseValidationError::unavailable(format!(
+                            "Failed to parse response: {}",
+                            error
+                        ));
+                        if attempt < MAX_RETRIES {
+                            log::warn!(
+                                "License validation response was malformed (attempt {}/{}); retrying",
+                                attempt,
+                                MAX_RETRIES
+                            );
+                            sleep(INITIAL_RETRY_DELAY * attempt).await;
+                            continue;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            let retryable = status.is_server_error()
+                || status == reqwest::StatusCode::REQUEST_TIMEOUT
+                || status == reqwest::StatusCode::TOO_MANY_REQUESTS;
+            let error = response.json::<ApiError>().await.unwrap_or(ApiError {
                 success: false,
                 error: Some("unknown_error".to_string()),
                 message: "Failed to validate license".to_string(),
             });
-            Err(error.message)
+
+            if !retryable {
+                return Err(LicenseValidationError::rejected(error.message));
+            }
+
+            last_error = LicenseValidationError::unavailable(error.message);
+            if attempt < MAX_RETRIES {
+                log::warn!(
+                    "License validation service unavailable (attempt {}/{}); retrying",
+                    attempt,
+                    MAX_RETRIES
+                );
+                sleep(INITIAL_RETRY_DELAY * attempt).await;
+                continue;
+            }
+            break;
         }
+
+        Err(last_error)
     }
 
     /// Activate a license key on a device
@@ -142,7 +225,7 @@ impl LicenseApiClient {
         device_hash: &str,
         app_version: Option<&str>,
     ) -> Result<LicenseActivateResponse, String> {
-        let url = format!("{}/license/activate", get_api_base_url());
+        let url = format!("{}/license/activate", self.base_url);
 
         let mut body = json!({
             "licenseKey": license_key,
@@ -171,11 +254,6 @@ impl LicenseApiClient {
         // Add OS version using sysinfo
         if let Some(os_version) = System::os_version() {
             body["osVersion"] = json!(os_version);
-        }
-
-        // Add device name (hostname)
-        if let Some(device_name) = System::host_name() {
-            body["deviceName"] = json!(device_name);
         }
 
         let response = self
@@ -220,7 +298,7 @@ impl LicenseApiClient {
         license_key: &str,
         device_hash: &str,
     ) -> Result<LicenseDeactivateResponse, String> {
-        let url = format!("{}/license/deactivate", get_api_base_url());
+        let url = format!("{}/license/deactivate", self.base_url);
 
         let response = self
             .client
@@ -255,9 +333,10 @@ impl Default for LicenseApiClient {
             Ok(client) => client,
             Err(e) => {
                 log::error!("Failed to create default API client: {}", e);
-                // Create a client with minimal configuration as fallback
-                let client = reqwest::Client::new();
-                Self { client }
+                Self {
+                    client: reqwest::Client::new(),
+                    base_url: get_api_base_url(),
+                }
             }
         }
     }
@@ -266,10 +345,102 @@ impl Default for LicenseApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use warp::Filter;
+
+    fn test_client(base_url: String) -> LicenseApiClient {
+        LicenseApiClient {
+            client: reqwest::Client::new(),
+            base_url,
+        }
+    }
 
     #[test]
     fn test_api_client_creation() {
         let client = LicenseApiClient::new();
         assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn validation_retries_service_failures_then_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_route = Arc::clone(&attempts);
+        let route = warp::path!("license" / "validate")
+            .and(warp::post())
+            .map(move || {
+                let attempt = attempts_for_route.fetch_add(1, Ordering::SeqCst) + 1;
+                let (body, status) = if attempt < MAX_RETRIES as usize {
+                    (
+                        json!({
+                            "success": false,
+                            "error": "service_unavailable",
+                            "message": "License service unavailable"
+                        }),
+                        warp::http::StatusCode::SERVICE_UNAVAILABLE,
+                    )
+                } else {
+                    (
+                        json!({
+                            "success": true,
+                            "data": { "valid": true },
+                            "message": null
+                        }),
+                        warp::http::StatusCode::OK,
+                    )
+                };
+                warp::reply::with_status(warp::reply::json(&body), status)
+            });
+        let (address, server) = warp::serve(route).bind_ephemeral(([127, 0, 0, 1], 0));
+        let server_task = tokio::spawn(server);
+        let client = test_client(format!("http://{}", address));
+
+        let result = client
+            .validate_license(
+                "VT-TEST-LICENSE",
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                Some("2.0.4"),
+            )
+            .await;
+
+        server_task.abort();
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_RETRIES as usize);
+    }
+
+    #[tokio::test]
+    async fn validation_classifies_client_rejection_without_retrying() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_route = Arc::clone(&attempts);
+        let route = warp::path!("license" / "validate")
+            .and(warp::post())
+            .map(move || {
+                attempts_for_route.fetch_add(1, Ordering::SeqCst);
+                warp::reply::with_status(
+                    warp::reply::json(&json!({
+                        "success": false,
+                        "error": "license_revoked",
+                        "message": "License revoked"
+                    })),
+                    warp::http::StatusCode::NOT_FOUND,
+                )
+            });
+        let (address, server) = warp::serve(route).bind_ephemeral(([127, 0, 0, 1], 0));
+        let server_task = tokio::spawn(server);
+        let client = test_client(format!("http://{}", address));
+
+        let result = client
+            .validate_license(
+                "VT-TEST-LICENSE",
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                Some("2.0.4"),
+            )
+            .await;
+
+        server_task.abort();
+        let error = result.unwrap_err();
+        assert_eq!(error.kind, LicenseValidationFailureKind::Rejected);
+        assert_eq!(error.message, "License revoked");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 }

--- a/src-tauri/src/license/types.rs
+++ b/src-tauri/src/license/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -7,6 +8,19 @@ pub struct LicenseStatus {
     pub license_type: Option<String>,
     pub license_key: Option<String>,
     pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_state: Option<LicenseVerificationState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_expires_at: Option<DateTime<Utc>>,
+}
+
+impl LicenseStatus {
+    pub fn verification_window_expired(&self, now: DateTime<Utc>) -> bool {
+        matches!(self.status, LicenseState::Licensed)
+            && self
+                .verification_expires_at
+                .is_some_and(|deadline| now >= deadline)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -16,6 +30,14 @@ pub enum LicenseState {
     Trial,
     Expired,
     None,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum LicenseVerificationState {
+    Verified,
+    OfflineGrace,
+    NeedsRevalidation,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -56,6 +56,7 @@ pub struct AppState {
     pub recording_config_cache:
         Arc<tokio::sync::RwLock<Option<crate::commands::audio::RecordingConfig>>>,
     pub license_cache: Arc<tokio::sync::RwLock<Option<crate::commands::license::CachedLicense>>>,
+    pub license_validation_lock: Arc<tokio::sync::Mutex<()>>,
     pub pill_event_queue: Arc<Mutex<Vec<QueuedPillEvent>>>,
     pub last_toggle_press: Arc<Mutex<Option<Instant>>>,
 }
@@ -87,6 +88,7 @@ impl AppState {
             window_manager: Arc::new(Mutex::new(None)),
             recording_config_cache: Arc::new(tokio::sync::RwLock::new(None)),
             license_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            license_validation_lock: Arc::new(tokio::sync::Mutex::new(())),
             pill_event_queue: Arc::new(Mutex::new(Vec::new())),
             last_toggle_press: Arc::new(Mutex::new(None)),
         }

--- a/src/components/sections/AccountSection.tsx
+++ b/src/components/sections/AccountSection.tsx
@@ -19,11 +19,13 @@ import { useLicense } from "@/contexts/LicenseContext";
 import { open } from '@tauri-apps/plugin-shell';
 import { ask } from '@tauri-apps/plugin-dialog';
 import {
+  AlertTriangle,
   Check,
   Clock,
   Crown,
   HelpCircle,
-  Shield
+  Shield,
+  RefreshCw,
 } from "lucide-react";
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -32,7 +34,15 @@ import { createLogger } from "@/lib/logger";
 const log = createLogger("account");
 
 export function AccountSection() {
-  const { status, isLoading, checkStatus, activateLicense, deactivateLicense, openPurchasePage } = useLicense();
+  const {
+    status,
+    isLoading,
+    checkStatus,
+    revalidateLicense,
+    activateLicense,
+    deactivateLicense,
+    openPurchasePage,
+  } = useLicense();
   const [licenseKey, setLicenseKey] = useState('');
   const [isActivating, setIsActivating] = useState(false);
 
@@ -179,6 +189,39 @@ export function AccountSection() {
           />
         )}
 
+        {status?.status === 'licensed' &&
+          status.verification_state &&
+          status.verification_state !== 'verified' && (
+            <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                    {status.verification_state === 'needs_revalidation'
+                      ? 'License verification still unavailable'
+                      : 'Couldn’t verify license'}
+                  </p>
+                  <p className="text-xs text-amber-800 dark:text-amber-300">
+                    Offline access remains available. Your paid license has not expired.
+                  </p>
+                  {status.expires_at && (
+                    <p className="text-xs text-muted-foreground">{status.expires_at}</p>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={revalidateLicense}
+                  disabled={isLoading}
+                >
+                  <RefreshCw className={isLoading ? 'animate-spin' : undefined} />
+                  Revalidate now
+                </Button>
+              </div>
+            </div>
+          )}
+
         {/* Licensed user info */}
         {status && status.status === 'licensed' && (
           <div className="mt-4 space-y-4">
@@ -204,6 +247,18 @@ export function AccountSection() {
             </div>
 
             <div className="flex gap-2">
+              {status.verification_state === 'verified' && (
+                <Button
+                  onClick={revalidateLicense}
+                  disabled={isLoading}
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                >
+                  <RefreshCw className={isLoading ? 'animate-spin' : undefined} />
+                  Revalidate License
+                </Button>
+              )}
               <Button
                 onClick={() => openExternalLink("https://polar.sh/ideaplexa/portal")}
                 variant="outline"

--- a/src/components/sections/__tests__/AccountSection.test.tsx
+++ b/src/components/sections/__tests__/AccountSection.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccountSection } from '../AccountSection';
+
+const mockUseLicense = vi.fn();
+const revalidateLicense = vi.fn();
+
+vi.mock('@/contexts/LicenseContext', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  ask: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe('AccountSection license verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLicense.mockReturnValue({
+      status: {
+        status: 'licensed',
+        license_type: 'pro',
+        license_key: 'VT-TEST-LICENSE-1234',
+        expires_at: '89 days offline remaining',
+        verification_state: 'needs_revalidation',
+      },
+      isLoading: false,
+      checkStatus: vi.fn(),
+      revalidateLicense,
+      activateLicense: vi.fn(),
+      deactivateLicense: vi.fn(),
+      openPurchasePage: vi.fn(),
+    });
+  });
+
+  it('keeps Pro active and offers revalidation instead of showing Trial Expired', () => {
+    render(<AccountSection />);
+
+    expect(screen.getByText('Pro Licensed')).toBeInTheDocument();
+    expect(screen.getByText('License verification still unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText('Offline access remains available. Your paid license has not expired.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Trial Expired')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revalidate now' }));
+    expect(revalidateLicense).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps revalidation reachable after a verified runtime status reaches its deadline', () => {
+    mockUseLicense.mockReturnValue({
+      status: {
+        status: 'licensed',
+        license_type: 'pro',
+        license_key: 'VT-TEST-LICENSE-1234',
+        verification_state: 'verified',
+        verification_expires_at: '2026-07-24T00:00:00Z',
+      },
+      isLoading: false,
+      checkStatus: vi.fn(),
+      revalidateLicense,
+      activateLicense: vi.fn(),
+      deactivateLicense: vi.fn(),
+      openPurchasePage: vi.fn(),
+    });
+
+    render(<AccountSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revalidate License' }));
+    expect(revalidateLicense).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/contexts/LicenseContext.test.tsx
+++ b/src/contexts/LicenseContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LicenseStatus } from '@/types';
 
@@ -26,6 +26,18 @@ const licensedStatus: LicenseStatus = {
 function Probe() {
   useLicense();
   return null;
+}
+
+function RevalidationProbe() {
+  const { status, revalidateLicense } = useLicense();
+  return (
+    <>
+      <span>{status?.verification_state ?? 'none'}</span>
+      <button type="button" onClick={revalidateLicense}>
+        Revalidate
+      </button>
+    </>
+  );
 }
 
 describe('LicenseContext', () => {
@@ -70,5 +82,26 @@ describe('LicenseContext', () => {
     const serialized = JSON.stringify(receivedLog);
     expect(serialized).toContain('"status":"licensed"');
     expect(serialized).toContain('"license_type":"lifetime"');
+  });
+
+  it('revalidates explicitly and replaces offline-grace metadata', async () => {
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'revalidate_license') {
+        return { ...licensedStatus, verification_state: 'verified' };
+      }
+      return { ...licensedStatus, verification_state: 'offline_grace' };
+    });
+
+    render(
+      <LicenseProvider>
+        <RevalidationProbe />
+      </LicenseProvider>,
+    );
+
+    expect(await screen.findByText('offline_grace')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Revalidate' }));
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('revalidate_license'));
+    expect(await screen.findByText('verified')).toBeInTheDocument();
   });
 });

--- a/src/contexts/LicenseContext.tsx
+++ b/src/contexts/LicenseContext.tsx
@@ -6,11 +6,13 @@ import { getErrorMessage } from '@/utils/error';
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("license");
+const LICENSE_COMMAND_TIMEOUT_MS = 60_000;
 
 interface LicenseContextValue {
   status: LicenseStatus | null;
   isLoading: boolean;
   checkStatus: () => Promise<void>;
+  revalidateLicense: () => Promise<void>;
   restoreLicense: () => Promise<void>;
   activateLicense: (key: string) => Promise<void>;
   deactivateLicense: () => Promise<void>;
@@ -78,7 +80,7 @@ export function LicenseProvider({ children }: { children: ReactNode }) {
         // Prevent unhandled rejections if we time out and ignore the result.
       });
 
-      const licenseStatus = await withTimeout(invokePromise, 10_000);
+      const licenseStatus = await withTimeout(invokePromise, LICENSE_COMMAND_TIMEOUT_MS);
 
       if (checkId !== latestCheckStatusId.current) return;
       log.debug('License status received:', {
@@ -86,6 +88,7 @@ export function LicenseProvider({ children }: { children: ReactNode }) {
         trial_days_left: licenseStatus.trial_days_left,
         license_type: licenseStatus.license_type,
         expires_at: licenseStatus.expires_at,
+        verification_state: licenseStatus.verification_state,
       });
       setStatus(licenseStatus);
     } catch (error) {
@@ -98,6 +101,35 @@ export function LicenseProvider({ children }: { children: ReactNode }) {
 
       const message = getErrorMessage(error, 'Failed to check license status');
       log.error('Failed to check license status:', error);
+      toast.error(message);
+    } finally {
+      if (checkId === latestCheckStatusId.current) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  const revalidateLicense = async () => {
+    const checkId = ++latestCheckStatusId.current;
+    try {
+      setIsLoading(true);
+      const invokePromise = invoke<LicenseStatus>('revalidate_license');
+      invokePromise.catch(() => {
+        // Prevent unhandled rejections if the UI timeout wins the race.
+      });
+      const licenseStatus = await withTimeout(invokePromise, LICENSE_COMMAND_TIMEOUT_MS);
+      if (checkId !== latestCheckStatusId.current) return;
+      setStatus(licenseStatus);
+
+      if (licenseStatus.verification_state === 'verified') {
+        toast.success('License verified');
+      } else {
+        toast.info('Couldn’t verify the license yet. Offline access remains available.');
+      }
+    } catch (error: unknown) {
+      if (checkId !== latestCheckStatusId.current) return;
+      const message = getErrorMessage(error, 'Failed to revalidate license');
+      log.error('Failed to revalidate license:', error);
       toast.error(message);
     } finally {
       if (checkId === latestCheckStatusId.current) {
@@ -163,6 +195,7 @@ export function LicenseProvider({ children }: { children: ReactNode }) {
     status,
     isLoading,
     checkStatus,
+    revalidateLicense,
     restoreLicense,
     activateLicense,
     deactivateLicense,

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,4 +147,6 @@ export interface LicenseStatus {
   license_type?: string;
   license_key?: string;
   expires_at?: string;
+  verification_state?: 'verified' | 'offline_grace' | 'needs_revalidation';
+  verification_expires_at?: string;
 }


### PR DESCRIPTION
## Summary
- keep last verified paid entitlement through bounded transient validation failures and the exact persisted 90-day grace boundary
- distinguish retryable outages from definitive invalid/expired/revoked responses
- serialize license lifecycle/cache mutations, bound stale-device repair, and refresh the runtime recording gate
- keep Pro status visible with truthful revalidation controls and remove hostname from activation payloads

## Review and validation
- final independent current-source peer review: PASS, no P0-P2 findings
- `cargo test`: 1,240 passed, 7 ignored
- license-focused Rust tests: 9 passed; exact deadline test: 1 passed
- `cargo clippy --lib -- -D warnings`, `cargo check --lib`, `pnpm typecheck`, and `pnpm lint` passed
- `pnpm test`: 584 passed, 1 skipped
- local Account UI smoke covered verified and needs-revalidation transitions

## Runtime smoke
Exercise paid activation/restart and transient outage behavior on the signed v2.0.5-beta.7 candidate.