### PR TITLE
fix: explain punctuation and formatting outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Improvements
+
+* **formatting:** explain that speech models infer punctuation, document Clean Dictation's AI correction role, and add privacy-safe decision diagnostics showing whether AI formatting ran or was skipped
+
 ### Bug Fixes
 
 * **tray:** recover from transient system-tray startup failures, keep the dashboard reachable, expose retry help, and attach tray diagnostics to support reports

--- a/plans/040-punctuation-consistency-diagnostics.md
+++ b/plans/040-punctuation-consistency-diagnostics.md
@@ -1,0 +1,34 @@
+# 040 — Punctuation consistency and AI-formatting diagnostics
+
+**Status: DONE — reviewer pass; focused checks and local UI smoke passed 2026-07-24**
+
+## Problem
+
+A Windows 2.0.4 report says Russian punctuation and grammar correction work intermittently. The submitted INFO log proves Whisper Large v3 completed, but does not explicitly record why AI Formatting was skipped. Raw Whisper punctuation and optional AI correction are therefore easy to confuse.
+
+## Scope
+
+1. Audit CPU and GPU Whisper decoding parameters that can affect ordinary punctuation, including language and token-suppression parity.
+2. Change punctuation-related inference settings only if upstream and local evidence prove the current configuration is wrong.
+3. Emit one privacy-safe INFO decision/outcome record for each desktop transcription: applied, disabled, mode-skipped, literal-locked, unchanged, or fallback. Do not log dictated text, prompts, keys, or target applications.
+4. Clarify in the existing Formatting UI that speech models infer punctuation, while AI Formatting provides explicit grammar and punctuation correction.
+5. Add focused behavioral tests for the diagnostic contract and guidance.
+
+## Acceptance
+
+- CPU and GPU-sidecar punctuation settings are intentionally aligned or their differences are documented by code/tests.
+- A submitted INFO log identifies whether AI Formatting ran and why it did not run.
+- Formatting settings tell users to select Clean Dictation when they want grammar and punctuation correction.
+- Existing privacy constraints remain intact.
+- Focused Rust and frontend tests, formatting, typecheck, lint, and a local UI smoke pass succeed.
+
+## Validation
+
+- `cargo test ai_formatting_outcome_explains_each_decision_path`
+- `cargo clippy --lib -- -D warnings`
+- `rustfmt --edition 2021 --check src-tauri/src/whisper/transcriber.rs src-tauri/src/writing.rs`
+- `pnpm exec vitest run src/components/sections/__tests__/EnhancementsSection.test.tsx`
+- `pnpm typecheck`
+- `pnpm lint`
+- Browser smoke rendered the real Formatting section with mocked Tauri IPC, confirmed the punctuation guidance, opened the Formatting guide, and visually verified the dialog.
+- Independent reviewer pass after correcting the language-transform fallback classification.

--- a/plans/README.md
+++ b/plans/README.md
@@ -39,6 +39,7 @@ Verification commands used across all plans: `pnpm typecheck`, `pnpm lint`,
 | 027  | Formatting & recording-pill UI/UX pass (naming, guidance, pill state legibility, app-category UI) | P2 | M | 016, 017 | TODO — captured 2026-06-19; backlog for post-2.0.0-smoke UAUX phase (notes only, not yet claimed) |
 | 028  | Transcription latency + streaming ("fast af" dictation) — investigation + phased design | P2 | XL | 015/020 smoke | TODO — drafted 2026-06-20; design/index only, not claimed. Phase 0 (insert-path plumbing tail + ffmpeg normalize) is S/LOW-risk and shippable alone; Phases 1–5 (decode-ahead, Parakeet/Whisper/cloud streaming, partial UX) graduate to 029+ |
 | 031  | GlitchTip observability — errors, symbols, curated logs, sampled traces | P0 | M | — | IN PROGRESS — claimed Main 2026-07-14; user approved stages 1–4 for next Beta |
+| 040  | Punctuation consistency + AI-formatting decision diagnostics | P1 | S | 027 | DONE — reviewer pass; focused checks + local UI smoke passed 2026-07-24 |
 | 041  | Paid-license validation resilience | P0 | M | — | DONE — reviewer PASS; focused/full gates + local Account UI smoke passed 2026-07-24 |
 
 ## Code-done, awaiting batched manual smoke (`plans/SMOKE.md`)

--- a/sidecar/whisper-vulkan/src/main.rs
+++ b/sidecar/whisper-vulkan/src/main.rs
@@ -408,6 +408,7 @@ fn transcribe_with_context(
     params.set_print_realtime(false);
     params.set_print_timestamps(false);
     params.set_suppress_blank(true);
+    // Suppress annotation-like tokens while keeping commas and sentence-ending punctuation.
     params.set_suppress_nst(true);
     params.set_no_speech_thold(0.6);
     params.set_entropy_thold(2.4);

--- a/src-tauri/src/whisper/transcriber.rs
+++ b/src-tauri/src/whisper/transcriber.rs
@@ -557,7 +557,7 @@ impl Transcriber {
         // Suppress blank outputs to avoid empty transcriptions
         params.set_suppress_blank(true);
 
-        // Don't suppress non-speech tokens - they help with timing and context
+        // Suppress annotation-like tokens while keeping commas and sentence-ending punctuation.
         params.set_suppress_nst(true);
 
         // Adjust speech detection threshold

--- a/src-tauri/src/writing.rs
+++ b/src-tauri/src/writing.rs
@@ -46,6 +46,78 @@ impl WritingMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AiFormattingOutcome {
+    Disabled,
+    ModeSkipped,
+    LiteralPreserved,
+    Applied,
+    Unchanged,
+    Fallback,
+}
+
+impl AiFormattingOutcome {
+    fn as_log_value(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::ModeSkipped => "mode_skipped",
+            Self::LiteralPreserved => "literal_preserved",
+            Self::Applied => "applied",
+            Self::Unchanged => "unchanged",
+            Self::Fallback => "fallback",
+        }
+    }
+}
+
+fn writing_mode_log_value(mode: WritingMode) -> &'static str {
+    match mode {
+        WritingMode::PersonalDictation => "personal_dictation",
+        WritingMode::CleanDictation => "clean_dictation",
+        WritingMode::Writing => "writing",
+        WritingMode::Notes => "notes",
+        WritingMode::Message => "message",
+        WritingMode::Code => "code",
+    }
+}
+
+fn classify_ai_formatting_outcome(
+    ai_enabled: bool,
+    mode: WritingMode,
+    literal_locked: bool,
+    ai_applied: bool,
+    needs_output_language_transform: bool,
+    ai_failed: bool,
+) -> AiFormattingOutcome {
+    if !ai_enabled {
+        AiFormattingOutcome::Disabled
+    } else if mode == WritingMode::PersonalDictation {
+        AiFormattingOutcome::ModeSkipped
+    } else if literal_locked {
+        AiFormattingOutcome::LiteralPreserved
+    } else if ai_failed || (needs_output_language_transform && !ai_applied) {
+        AiFormattingOutcome::Fallback
+    } else if ai_applied {
+        AiFormattingOutcome::Applied
+    } else {
+        AiFormattingOutcome::Unchanged
+    }
+}
+
+fn log_ai_formatting_decision(
+    ai_enabled: bool,
+    mode: WritingMode,
+    attempted: bool,
+    outcome: AiFormattingOutcome,
+) {
+    log::info!(
+        "AI_FORMATTING_DECISION | enabled={}, mode={}, attempted={}, outcome={}",
+        ai_enabled,
+        writing_mode_log_value(mode),
+        attempted,
+        outcome.as_log_value()
+    );
+}
+
 impl From<EnhancementPreset> for WritingMode {
     fn from(value: EnhancementPreset) -> Self {
         match value {
@@ -1995,10 +2067,36 @@ pub async fn process_transcription(
     let can_run_ai_formatting = ai_enabled && profile.mode != WritingMode::PersonalDictation;
 
     if needs_output_language_transform && !can_run_ai_formatting && !library_result.literal_locked {
+        log_ai_formatting_decision(
+            ai_enabled,
+            profile.mode,
+            false,
+            classify_ai_formatting_outcome(
+                ai_enabled,
+                profile.mode,
+                library_result.literal_locked,
+                false,
+                needs_output_language_transform,
+                false,
+            ),
+        );
         return Err(WritingError::OutputLanguageRequiresAi);
     }
 
     if profile.mode.requires_ai_formatting() && !ai_enabled && !library_result.literal_locked {
+        log_ai_formatting_decision(
+            ai_enabled,
+            profile.mode,
+            false,
+            classify_ai_formatting_outcome(
+                ai_enabled,
+                profile.mode,
+                library_result.literal_locked,
+                false,
+                needs_output_language_transform,
+                false,
+            ),
+        );
         return Err(WritingError::Config(
             "This writing mode requires AI formatting. Enable AI formatting in settings or switch to Personal Dictation.".into(),
         ));
@@ -2019,25 +2117,37 @@ pub async fn process_transcription(
         }
         library_result.text.clone()
     } else if should_run_ai {
-        let (text, error) = resolve_smart_formatting_outcome(
-            run_smart_formatting(SmartFormattingRequest {
-                app,
-                text: &library_result.text,
-                transcript_language: transcript_language.clone(),
-                output_language: &mut output_language,
-                profile: &profile,
-                settings: &settings,
-                needs_output_language_transform,
-                applied_operations: &mut applied_operations,
-                warnings: &mut warnings,
-            })
-            .await,
+        let smart_formatting = run_smart_formatting(SmartFormattingRequest {
+            app,
+            text: &library_result.text,
+            transcript_language: transcript_language.clone(),
+            output_language: &mut output_language,
+            profile: &profile,
+            settings: &settings,
+            needs_output_language_transform,
+            applied_operations: &mut applied_operations,
+            warnings: &mut warnings,
+        })
+        .await;
+        let (text, error) = match resolve_smart_formatting_outcome(
+            smart_formatting,
             &library_result.text,
             needs_output_language_transform,
             transcript_language.as_deref(),
             &output_language,
             &mut warnings,
-        )?;
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                log_ai_formatting_decision(
+                    ai_enabled,
+                    profile.mode,
+                    true,
+                    AiFormattingOutcome::Fallback,
+                );
+                return Err(error);
+            }
+        };
         ai_error = error;
         text
     } else {
@@ -2053,9 +2163,20 @@ pub async fn process_transcription(
     final_text = guarded_text;
     applied_operations.extend(guard_operations);
 
+    let ai_applied = should_run_ai && ai_error.is_none() && final_text != library_result.text;
+    let ai_outcome = classify_ai_formatting_outcome(
+        ai_enabled,
+        profile.mode,
+        library_result.literal_locked,
+        ai_applied,
+        needs_output_language_transform,
+        ai_error.is_some(),
+    );
+    log_ai_formatting_decision(ai_enabled, profile.mode, should_run_ai, ai_outcome);
+
     Ok(WritingResult {
         raw_text: transcription.raw_text.clone(),
-        ai_applied: should_run_ai && ai_error.is_none() && final_text != library_result.text,
+        ai_applied,
         final_text,
         output_language,
         mode: profile.mode,
@@ -2360,6 +2481,87 @@ mod tests {
         assert!(!WritingMode::PersonalDictation.requires_ai_formatting());
         assert!(WritingMode::CleanDictation.requires_ai_formatting());
         assert!(WritingMode::Code.requires_ai_formatting());
+    }
+
+    #[test]
+    fn ai_formatting_outcome_explains_each_decision_path() {
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                false,
+                WritingMode::PersonalDictation,
+                false,
+                false,
+                false,
+                false,
+            ),
+            AiFormattingOutcome::Disabled
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::PersonalDictation,
+                false,
+                false,
+                false,
+                false,
+            ),
+            AiFormattingOutcome::ModeSkipped
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::CleanDictation,
+                true,
+                false,
+                false,
+                false,
+            ),
+            AiFormattingOutcome::LiteralPreserved
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::CleanDictation,
+                false,
+                true,
+                false,
+                false,
+            ),
+            AiFormattingOutcome::Applied
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::CleanDictation,
+                false,
+                false,
+                false,
+                false,
+            ),
+            AiFormattingOutcome::Unchanged
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::CleanDictation,
+                false,
+                false,
+                false,
+                true,
+            ),
+            AiFormattingOutcome::Fallback
+        );
+        assert_eq!(
+            classify_ai_formatting_outcome(
+                true,
+                WritingMode::CleanDictation,
+                false,
+                false,
+                true,
+                false,
+            ),
+            AiFormattingOutcome::Fallback
+        );
     }
 
     #[test]

--- a/src/components/sections/EnhancementsSection.tsx
+++ b/src/components/sections/EnhancementsSection.tsx
@@ -696,7 +696,7 @@ export function EnhancementsSection({ view = "all" }: { view?: EnhancementsView 
           <header>
             <h2 className="text-base font-semibold">AI polish (optional)</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Rewrites your words for meaning and format. Needs a provider. Off by default.
+              Speech models infer punctuation. Clean Dictation uses AI to correct grammar and punctuation. Needs a provider and is off by default.
             </p>
           </header>
           <FieldSet className="rounded-xl border border-border/60 bg-card p-4">

--- a/src/components/sections/__tests__/EnhancementsSection.test.tsx
+++ b/src/components/sections/__tests__/EnhancementsSection.test.tsx
@@ -277,7 +277,9 @@ describe('EnhancementsSection', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Rewrites your words for meaning and format. Needs a provider. Off by default.'),
+        screen.getByText(
+          'Speech models infer punctuation. Clean Dictation uses AI to correct grammar and punctuation. Needs a provider and is off by default.',
+        ),
       ).toBeInTheDocument()
       expect(
         screen.getByText('Add an API key and choose a model below to turn on AI formatting.'),
@@ -564,7 +566,7 @@ describe('EnhancementsSection', () => {
       expect(screen.getByText('AI polish (optional)')).toBeInTheDocument()
       expect(
         screen.getByText(
-          'Rewrites your words for meaning and format. Needs a provider. Off by default.',
+          'Speech models infer punctuation. Clean Dictation uses AI to correct grammar and punctuation. Needs a provider and is off by default.',
         ),
       ).toBeInTheDocument()
       expect(screen.getByText('Your text rules (always on)')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- retain the evidence-backed CPU/GPU Whisper configuration without speculative inference changes
- emit one privacy-safe AI formatting decision for applied, disabled, mode-skipped, literal-preserved, unchanged, and fallback paths
- clarify that speech models infer punctuation while Clean Dictation performs explicit grammar/punctuation correction

## Review and validation
- final independent current-source peer review: PASS, no P0-P2 findings
- focused Rust outcome-path test and frontend Formatting test passed
- release clippy, rustfmt check, typecheck, lint, and local Formatting UI smoke passed
- no transcript, prompt, key, audio, clipboard, application, or path content enters the diagnostic record

## Runtime smoke
Collect the new decision record from affected Windows/Russian scenarios on signed v2.0.5-beta.7; this patch diagnoses rather than claiming an unproven recognizer fix.