### PR TITLE
fix: check release tags exactly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG"; then
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "::error::Tag $TAG already exists. Delete it first or use a different release type."
             exit 1
           fi
@@ -702,7 +702,7 @@ jobs:
       - name: Ensure tag doesn't already exist
         run: |
           TAG="${{ needs.prepare.outputs.tag }}"
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG"; then
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "::error::Tag $TAG already exists. Re-run with a different release type."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- make both release tag-existence checks query the exact ref
- prevent `v2.0.5-beta.7` from being mistaken for stable `v2.0.5`

## Reproduction
Stable release run [30758918499](https://github.com/moinulmoin/voicetypr/actions/runs/30758918499) failed in `prepare` because the substring grep matched the existing Beta 7 tag.

## Verification
- exact lookup for `refs/tags/v2.0.5` exits 2 (absent)
- exact lookup for `refs/tags/v2.0.5-beta.7` exits 0 (present)
