### PR TITLE
fix: preserve Polish failure attribution

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -1145,14 +1145,36 @@ fn executor_for_provider(
     ))
 }
 
+#[derive(Debug)]
+pub(crate) struct AiPolishAttemptError {
+    pub error: AiProviderError,
+    pub provider_id: String,
+    pub model_id: String,
+}
+
+impl AiPolishAttemptError {
+    fn unattributed(error: AiProviderError) -> Self {
+        Self {
+            error,
+            provider_id: String::new(),
+            model_id: String::new(),
+        }
+    }
+}
+
 async fn polish_text_with_prompt_result_typed(
     app: &tauri::AppHandle,
     text: &str,
     model: String,
     provider: String,
     prompt: String,
-) -> Result<crate::ai::contract::AiPolishResult, AiProviderError> {
-    let (executor, runtime_provider) = executor_for_provider(app, &provider)?;
+) -> Result<crate::ai::contract::AiPolishResult, AiPolishAttemptError> {
+    let (executor, runtime_provider) =
+        executor_for_provider(app, &provider).map_err(|error| AiPolishAttemptError {
+            error,
+            provider_id: provider,
+            model_id: model.clone(),
+        })?;
     // CLI providers are cold-spawned with their own hard kill-timeout
     // (AgentCliRuntime::COLD_SPAWN_TIMEOUT); cap the executor budget to ~9s so
     // a wedged CLI surfaces promptly. HTTP providers keep the 30s budget.
@@ -1163,14 +1185,19 @@ async fn polish_text_with_prompt_result_typed(
     };
     let request = AiPolishRequest {
         provider_id: runtime_provider.clone(),
-        model_id: model,
+        model_id: model.clone(),
         input_text: text.to_string(),
         prompt,
         timeout_ms,
     };
     let result = executor
         .polish(request, tokio_util::sync::CancellationToken::new())
-        .await?;
+        .await
+        .map_err(|error| AiPolishAttemptError {
+            error,
+            provider_id: runtime_provider,
+            model_id: model,
+        })?;
     log::info!(
         "Text enhanced successfully via {} (original: {}, enhanced: {}, duration_ms: {})",
         result.provider_id,
@@ -1189,8 +1216,9 @@ pub async fn polish_text_typed(
     transcript_language: Option<&str>,
     context: Option<&str>,
     app_category_hint: Option<&str>,
-) -> Result<crate::ai::contract::AiPolishResult, crate::ai::error::AiProviderError> {
-    let (provider, model) = selected_ai_provider_and_model(app)?;
+) -> Result<crate::ai::contract::AiPolishResult, AiPolishAttemptError> {
+    let (provider, model) =
+        selected_ai_provider_and_model(app).map_err(AiPolishAttemptError::unattributed)?;
     let prompt = crate::ai::prompts::build_enhancement_prompt_for_transcript_language(
         context,
         options,

--- a/src-tauri/src/writing/pipeline.rs
+++ b/src-tauri/src/writing/pipeline.rs
@@ -364,7 +364,7 @@ struct SmartFormattingOutcome {
 
 async fn run_smart_formatting(
     request: SmartFormattingRequest<'_>,
-) -> Result<(String, u64, AiExecutionMetadata), AiProviderError> {
+) -> Result<(String, u64, AiExecutionMetadata), crate::commands::ai::AiPolishAttemptError> {
     let options = crate::ai::EnhancementOptions {
         preset: request.config.preset,
     };
@@ -402,7 +402,11 @@ async fn run_smart_formatting(
                 duration_ms,
             } = result;
             if enhanced.trim().is_empty() {
-                return Err(AiProviderError::BadResponse);
+                return Err(crate::commands::ai::AiPolishAttemptError {
+                    error: AiProviderError::BadResponse,
+                    provider_id,
+                    model_id,
+                });
             }
 
             if enhanced != request.text {
@@ -451,7 +455,7 @@ async fn run_smart_formatting(
 }
 
 fn resolve_smart_formatting_outcome(
-    result: Result<(String, u64, AiExecutionMetadata), AiProviderError>,
+    result: Result<(String, u64, AiExecutionMetadata), crate::commands::ai::AiPolishAttemptError>,
     library_text: &str,
     needs_output_language_transform: bool,
     _transcript_language: Option<&str>,
@@ -467,22 +471,26 @@ fn resolve_smart_formatting_outcome(
         }),
         Err(error) if needs_output_language_transform => Err(WritingError::TranslationFailed {
             target_language: output_language.to_string(),
-            detail: user_facing_message(&error).to_string(),
+            detail: user_facing_message(&error.error).to_string(),
         }),
         Err(error) => {
             warnings.push(WritingWarning {
                 code: "ai_formatting_failed".to_string(),
                 message: format!(
                     "AI formatting failed ({}); used deterministic text instead",
-                    user_facing_message(&error)
+                    user_facing_message(&error.error)
                 ),
+            });
+            let execution = (!error.provider_id.is_empty()).then_some(AiExecutionMetadata {
+                provider_id: error.provider_id,
+                model_id: error.model_id,
             });
 
             Ok(SmartFormattingOutcome {
                 text: library_text.to_string(),
-                error: Some(error),
+                error: Some(error.error),
                 duration_ms: None,
-                execution: None,
+                execution,
             })
         }
     }
@@ -727,6 +735,13 @@ mod tests {
         TranscriptionResult::new(&job, raw_text.to_string())
             .with_transcript_language(transcript_language.map(str::to_string))
     }
+    fn attempt_error(error: AiProviderError) -> crate::commands::ai::AiPolishAttemptError {
+        crate::commands::ai::AiPolishAttemptError {
+            error,
+            provider_id: "openai".to_string(),
+            model_id: "gpt-4.1-mini".to_string(),
+        }
+    }
 
     #[test]
     fn test_resolve_smart_formatting_outcome_preserves_success() {
@@ -758,7 +773,7 @@ mod tests {
         let mut warnings = Vec::new();
         let output_language = "fr".to_string();
         let error = resolve_smart_formatting_outcome(
-            Err(AiProviderError::Network),
+            Err(attempt_error(AiProviderError::Network)),
             "library",
             true,
             Some("en"),
@@ -788,7 +803,7 @@ mod tests {
         let mut warnings = Vec::new();
         let output_language = "en".to_string();
         let outcome = resolve_smart_formatting_outcome(
-            Err(AiProviderError::Timeout),
+            Err(attempt_error(AiProviderError::Timeout)),
             "library text",
             false,
             None,
@@ -800,7 +815,13 @@ mod tests {
         assert_eq!(outcome.text, "library text");
         assert_eq!(outcome.error, Some(AiProviderError::Timeout));
         assert_eq!(outcome.duration_ms, None);
-        assert_eq!(outcome.execution, None);
+        assert_eq!(
+            outcome.execution,
+            Some(AiExecutionMetadata {
+                provider_id: "openai".to_string(),
+                model_id: "gpt-4.1-mini".to_string(),
+            })
+        );
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].code, "ai_formatting_failed");
         assert!(warnings[0].message.contains("timed out"));


### PR DESCRIPTION
## Problem
Failed Polish attempts fell back correctly, but dropped the resolved provider/model before emitting `PolishFinished`. Analytics then misattributed real failures as `provider=none` and `model=automatic`.

## Fix
- carry provider/model metadata alongside typed AI failures
- preserve that metadata on non-translation fallback paths
- cover fallback attribution with a focused unit test

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml test_resolve_smart_formatting_outcome`
- `pnpm quality-gate`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`