### PR TITLE
fix: allow updater confirmation dialogs

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "opener:default",
     "store:default",
     "dialog:default",
+    "dialog:allow-ask",
     "fs:scope-appdata",
     "shell:allow-open",
     "autostart:allow-enable",


### PR DESCRIPTION
## Problem
Signed `v2.0.6-beta.3` reproduces `Command plugin:dialog|ask not allowed by ACL` when checking for updates, so the update prompt never opens.

## Fix
Grant the explicit `dialog:allow-ask` capability. `dialog:default` includes `allow-message`, but the installed `tauri-plugin-dialog` runtime still authorizes the invoked `ask` command separately.

## Verification
- `pnpm quality-gate`
- 629 frontend tests passed
- 1,355 backend tests passed; 13 ignored
- Clippy passed
- `git diff --check`

A newly signed beta will be used for the runtime updater smoke.