### PR TITLE
fix: align dialog plugin protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.0",
-    "@tauri-apps/plugin-dialog": "^2.3.0",
+    "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-os": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^2.7.2
+        version: 2.7.2
       '@tauri-apps/plugin-log':
         specifier: ^2.8.0
         version: 2.8.0
@@ -1805,6 +1805,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/api@2.6.0':
     resolution: {integrity: sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg==}
 
@@ -1890,8 +1893,8 @@ packages:
   '@tauri-apps/plugin-autostart@2.5.0':
     resolution: {integrity: sha512-smSt0vydfVB950AeYRbO2S/c01SZrgMVg4FOrFLQLom0R0amsu/8zYaxgttriBdxcofjBZuHv4hmROBQIBVXmA==}
 
-  '@tauri-apps/plugin-dialog@2.3.0':
-    resolution: {integrity: sha512-ylSBvYYShpGlKKh732ZuaHyJ5Ie1JR71QCXewCtsRLqGdc8Is4xWdz6t43rzXyvkItM9syNPMvFVcvjgEy+/GA==}
+  '@tauri-apps/plugin-dialog@2.7.2':
+    resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
@@ -6349,6 +6352,8 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/api@2.6.0': {}
 
   '@tauri-apps/api@2.9.1': {}
@@ -6404,9 +6409,9 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.6.0
 
-  '@tauri-apps/plugin-dialog@2.3.0':
+  '@tauri-apps/plugin-dialog@2.7.2':
     dependencies:
-      '@tauri-apps/api': 2.6.0
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-log@2.8.0':
     dependencies:

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,7 +23,6 @@
     "opener:default",
     "store:default",
     "dialog:default",
-    "dialog:allow-ask",
     "fs:scope-appdata",
     "shell:allow-open",
     "autostart:allow-enable",


### PR DESCRIPTION
## Problem
Signed `v2.0.6-beta.3` fails every frontend `ask()` call with `Command plugin:dialog|ask not allowed by ACL`. The frontend dialog package was 2.3.0 and invoked the removed `plugin:dialog|ask` command; Rust uses `tauri-plugin-dialog` 2.7.2 and registers only `plugin:dialog|message`.

## Fix
- Upgrade `@tauri-apps/plugin-dialog` to 2.7.2, whose `ask()` wrapper invokes the message command with Yes/No buttons.
- Remove the redundant `dialog:allow-ask` capability added in #134; `dialog:default` already grants `allow-message`.

## Verification
- Inspected installed 2.7.2 bundle: `ask()` calls `messageCommand()` → `plugin:dialog|message`.
- `pnpm quality-gate`
- 629 frontend tests passed
- 1,355 backend tests passed; 13 ignored
- Clippy passed
- `git diff --check`

A newly signed beta will verify the real updater prompt and install path.